### PR TITLE
Add JSON encoder/decoder to fix some issues with roots

### DIFF
--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -6,6 +6,7 @@ require 'digest/md5'
 require 'base64'
 require 'active_resource/connection_ext'
 require 'shopify_api/limits'
+require 'shopify_api/json_format'
 
 module ShopifyAPI
   include Limits

--- a/lib/shopify_api/json_format.rb
+++ b/lib/shopify_api/json_format.rb
@@ -1,0 +1,23 @@
+module ActiveResource
+  class Base
+    def encode(options = {})
+      same = dup
+      same.attributes = {self.class.element_name => same.attributes} if self.class.format.extension == 'json'
+
+      same.send("to_#{self.class.format.extension}", options)
+    end
+  end
+
+  module Formats
+    module JsonFormat
+      def decode(json)
+        data = ActiveSupport::JSON.decode(json)
+        if data.is_a?(Hash) && data.keys.size == 1
+          data.values.first
+        else
+          data
+        end
+      end
+    end
+  end
+end

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -1,5 +1,6 @@
 module ShopifyAPI
   class Base < ActiveResource::Base
     extend Countable
+    self.include_root_in_json = false
   end
 end


### PR DESCRIPTION
Mimic how JSON is being handled on Shopify's end, only including the root in the main object, but not nested ones.

@jamesmacaulay @jaw6
