### PR TITLE
Fix JSON error handling

### DIFF
--- a/lib/active_resource/json_errors.rb
+++ b/lib/active_resource/json_errors.rb
@@ -1,0 +1,21 @@
+require 'active_resource/base'
+
+module ActiveResource
+  class Errors < ActiveModel::Errors
+    def from_hash(messages, save_cache = false)
+      clear unless save_cache
+
+      messages.each do |key,errors|
+        errors.each do |error|
+          add(key, error)
+        end
+      end
+    end
+
+    # Grabs errors from a json response.
+    def from_json(json, save_cache = false)
+      hash = ActiveSupport::JSON.decode(json)['errors'] || {} rescue {}
+      from_hash hash, save_cache
+    end
+  end
+end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -7,6 +7,7 @@ require 'base64'
 require 'active_resource/connection_ext'
 require 'shopify_api/limits'
 require 'shopify_api/json_format'
+require 'active_resource/json_errors'
 
 module ShopifyAPI
   include Limits


### PR DESCRIPTION
@Soleone @jamesmacaulay

JSON error handling in ActiveResource doesn't work. It tries parsing them in the same way it does XML errors, although XML errors are in string format and JSON is key:value.
See [here](https://github.com/rails/rails/blob/master/activeresource/lib/active_resource/validations.rb) for current implementation.

Everything should be straight-forward besides detecting association attributes. 

```
if k = @base.attributes.keys.detect{ |a| a.gsub(/_id$/, '') == key.gsub(/_id$/, '') }
```

That line is because the JSON will sometimes contain the association name instead of the actual attribute. For example the error hash could contain a key called 'author', while the actual attribute name is 'author_id'.

I've sent a pull request for Rails, but until it is in we'll have to handle it ourselves.
