### PR TITLE
Workaround ActiveResource 3.1+ bug for saving nested resources.

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -28,7 +28,11 @@ module ShopifyAPI
         self.site = nil
         self.headers.delete('X-Shopify-Access-Token')
       end
-    end                  
+    end
+
+    def persisted?
+      !id.nil?
+    end
 
     private
     def only_id

--- a/test/fixtures/product.json
+++ b/test/fixtures/product.json
@@ -23,6 +23,7 @@
       {
         "position": 1,
         "price": "199.00",
+        "product_id": 632910392,
         "created_at": "2011-10-20T14:05:13-04:00",
         "requires_shipping": true,
         "title": "Pink",
@@ -43,6 +44,7 @@
       {
         "position": 2,
         "price": "199.00",
+        "product_id": 632910392,
         "created_at": "2011-10-20T14:05:13-04:00",
         "requires_shipping": true,
         "title": "Red",
@@ -63,6 +65,7 @@
       {
         "position": 3,
         "price": "199.00",
+        "product_id": 632910392,
         "created_at": "2011-10-20T14:05:13-04:00",
         "requires_shipping": true,
         "title": "Green",
@@ -83,6 +86,7 @@
       {
         "position": 4,
         "price": "199.00",
+        "product_id": 632910392,
         "created_at": "2011-10-20T14:05:13-04:00",
         "requires_shipping": true,
         "title": "Black",

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -27,4 +27,12 @@ class ProductTest < Test::Unit::TestCase
     assert_equal 2, metafields.length
     assert metafields.all?{|m| m.is_a?(ShopifyAPI::Metafield)}
   end
+
+  def test_update_loaded_variant
+    fake "products/632910392/variants/808950810", :method => :put, :status => 200, :body => load_fixture('variant')
+
+    variant = @product.variants.first
+    variant.price = "0.50"
+    variant.save
+  end
 end


### PR DESCRIPTION
For issue #28.

@jduff and @odorcicd for review

I have also submitted a [pull request to fix this upstream](https://github.com/rails/activeresource/pull/30).

The workaround depends on the presence of primary key value to know whether the resource has been persisted, which this bug has shown to be a better indicator than the @persisted instance variable.

Let me know if you think we shouldn't fix this in the shopify_api gem, in which case we should close the issue as being an upstream bug.
