### PR TITLE
Fixes ActiveModel json serialization and ActiveResource json decoding post 3.0.17

### DIFF
--- a/lib/shopify_api/json_format.rb
+++ b/lib/shopify_api/json_format.rb
@@ -1,37 +1,14 @@
 module ActiveResource
-  class Base
-    def encode(options = {})
-      same = dup
-      same.attributes = {self.class.element_name => same.attributes} if self.class.format.extension == 'json'
-      
-      same.send("to_#{self.class.format.extension}", options)
-    end
-  end
-
-  module Formats
-    module JsonFormat
-      def decode(json)
-        data = ActiveSupport::JSON.decode(json)
-        if data.is_a?(Hash) && data.keys.size == 1
-          data.values.first
-        else
-          data
-        end
-      end
-    end
-  end
-end
-
-module ActiveModel
-  module Serializers
-    module JSON
-      def as_json(options = nil)
-        root = options[:root] if options.try(:key?, :root)
-        if include_root_in_json
-          root = self.class.model_name.element if root == true
-          { root => serializable_hash(options) }
-        else
-          serializable_hash(options)
+  if ActiveResource::VERSION::STRING =~ /^3\.0\./
+    module Formats
+      module JsonFormat
+        def decode(json)
+          data = ActiveSupport::JSON.decode(json)
+          if data.is_a?(Hash) && data.keys.size == 1
+            data.values.first
+          else
+            data
+          end
         end
       end
     end

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -34,9 +34,23 @@ module ShopifyAPI
       !id.nil?
     end
 
+    def encode(options = {})
+      obj = dup
+
+      if self.class.format.extension == 'json' && !already_has_root_element?(obj.attributes)
+        obj.attributes = {self.class.element_name => obj.attributes}
+      end
+
+      obj.send("to_#{self.class.format.extension}", options)
+    end
     private
     def only_id
       encode(:only => :id, :include => [], :methods => [])
     end
+
+    def already_has_root_element?(attributes)
+      attributes.keys.size == 1 && attributes.values.first.kind_of?(Hash)
+    end
   end
 end
+ 


### PR DESCRIPTION
https://github.com/Shopify/shopify_api/commit/f474f3d7b9059092896b07ef34cdad0c1d062fd0 was overriding the JSON serializer for ActiveModel. This was changing the behaviour of any rails projects using this gem, and trying to use the include_root_in_json globally and properly when rendering json. This PR keeps that logic within our library.

One risk here is that current projects that use this gem may break, so we'll have to make this a major version update (4.0). 

Also, our module patch for ActiveResource::Formats::JsonFormat decode is only required for rails pre-3.1. This has been fixed in rails 3.1 an forward. See https://github.com/rails/rails/blob/v3.1.0/activeresource/lib/active_resource/formats/json_format.rb vs https://github.com/rails/rails/blob/v3.0.17/activeresource/lib/active_resource/formats/json_format.rb
