### PR TITLE
Adds to_f to prices to get correct range.

### DIFF
--- a/lib/shopify_api/resources/product.rb
+++ b/lib/shopify_api/resources/product.rb
@@ -5,7 +5,7 @@ module ShopifyAPI
 
     # compute the price range
     def price_range
-      prices = variants.collect(&:price)
+      prices = variants.collect(&:price).collect(&:to_f)
       format =  "%0.2f"
       if prices.min != prices.max
         "#{format % prices.min} - #{format % prices.max}"


### PR DESCRIPTION
Variant price list was a list of strings, causing min and max to give incorrect results. Added to_f to fix this.

@jduff @gauravmc Can you review please, thanks!
