### PR TITLE
Monkey pacthes active resource build and delete to include custom headers

### DIFF
--- a/lib/active_resource/base_ext.rb
+++ b/lib/active_resource/base_ext.rb
@@ -10,5 +10,13 @@ module ActiveResource
         @headers
       end
     end
+    # https://github.com/rails/activeresource/commit/dfef85ce8f653f75673631b2950fcdb0781c313c
+    def self.delete(id, options = {})
+      connection.delete(element_path(id, options), headers)
+    end
+    def self.build(attributes = {})
+      attrs = self.format.decode(connection.get("#{new_element_path}", headers).body).merge(attributes)
+      self.new(attrs)
+    end
   end
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -47,4 +47,18 @@ class BaseTest < Test::Unit::TestCase
     assert_equal 'token2', ShopifyAPI::Shop.headers['X-Shopify-Access-Token']
   end
 
+  test "#delete should send custom headers with request" do
+    ShopifyAPI::Base.activate_session @session1
+    ShopifyAPI::Base.expects(:headers).returns({'X-Custom' => 'abc'})
+    ShopifyAPI::Base.connection.expects(:delete).with('/admin/bases/1.json', {'X-Custom' => 'abc'})
+    ShopifyAPI::Base.delete "1"
+  end
+
+  test "#build should send custom headers with request" do
+    ShopifyAPI::Base.activate_session @session1
+    ShopifyAPI::Base.expects(:headers).returns({'X-Custom' => 'abc'})
+    ShopifyAPI::Base.connection.expects(:delete).with('/admin/bases/1.json', {'X-Custom' => 'abc'})
+    ShopifyAPI::Base.delete "1"
+  end
+
 end


### PR DESCRIPTION
active resource 3.2.8 doesn't include this patch yet, so we need to monkey patch the gem to fix it

https://github.com/rails/activeresource/commit/dfef85ce8f653f75673631b2950fcdb0781c313c

@jduff @odorcicd Please review, thanks!
