### PR TITLE
Added search interface to Customer class

### DIFF
--- a/lib/shopify_api/resources/customer.rb
+++ b/lib/shopify_api/resources/customer.rb
@@ -2,8 +2,8 @@ module ShopifyAPI
   class Customer < Base
     include Metafields
 
-    def self.search(query_string)
-      self.find(:all, from: '/admin/customers/search.json',params: {query: query_string})
+    def self.search(params)
+      self.find(:all, from: '/admin/customers/search.json',params: params)
     end
   end
 end


### PR DESCRIPTION
This pull request allows users to do the following:

``` ruby
ShopifyAPI::Customer.search(query: 'Bob country:United States')
```

to execute the search example in the API documentation here:

http://docs.shopify.com/api/customer#search

Let me know if there's a smarter way to do this.

Thanks!
