### PR TITLE
Revert has_many due to ActiveResource version

### DIFF
--- a/lib/shopify_api/resources/customer_saved_search.rb
+++ b/lib/shopify_api/resources/customer_saved_search.rb
@@ -2,6 +2,8 @@ require 'shopify_api/resources/customer'
 
 module ShopifyAPI
   class CustomerSavedSearch < Base
-    has_many :customers, :class_name => ShopifyAPI::Customer
+    def customers(params = {})
+      Customer.find(:all, :params => params.merge({ :customer_saved_search_id => self.id }))
+    end
   end
 end

--- a/test/customer_saved_search_test.rb
+++ b/test/customer_saved_search_test.rb
@@ -12,6 +12,13 @@ class CustomerSavedSearchTest < Test::Unit::TestCase
     assert_equal 112223902, @customer_saved_search.customers.first.id
   end
 
+  def test_get_customers_from_customer_saved_search_with_params
+    fake 'customers.json?customer_saved_search_id=8899730&limit=1', :body => load_fixture('customer_saved_search_customers'), :extension => false
+    customers = @customer_saved_search.customers(:limit => 1)
+    assert_equal 1, customers.length
+    assert_equal 112223902, customers.first.id
+  end
+
   private
   def load_customer_saved_search
     fake 'customer_saved_searches/8899730', :body => load_fixture('customer_saved_search')


### PR DESCRIPTION
It turns out the version of `ActiveResource` bundled with `Rails 3.2` is missing `Associations`.

https://github.com/rails/rails/blob/3-2-stable/activeresource/lib/active_resource.rb vs https://github.com/rails/activeresource/blame/master/lib/active_resource/base.rb#L19

This PR reverts the `has_many` and puts a method called `customers` which you can pass it params (if needed.)
### Review

@dylanahsmith @alexcoco 
