### PR TITLE
Restore host with port when temp finishes

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -18,7 +18,7 @@ module ShopifyAPI
       def temp(domain, token, &block)
         session = new(domain, token)
         begin
-          original_domain  = URI.parse(ShopifyAPI::Base.site.to_s).host
+          original_domain = host_with_port(ShopifyAPI::Base.site.to_s)
         rescue URI::InvalidURIError
         end
         original_token   = ShopifyAPI::Base.headers['X-Shopify-Access-Token']
@@ -43,6 +43,17 @@ module ShopifyAPI
 
         sorted_params = params.except(:signature, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join
         Digest::MD5.hexdigest(secret + sorted_params) == signature
+      end
+
+      def host_with_port(site)
+        parsed_site = URI.parse(site)
+        host = parsed_site.host or return
+        port = parsed_site.port
+        if (protocol == 'http' && port == 80) || (protocol == 'https' && port == 443)
+          host
+        else
+          "#{host}:#{port}"
+        end
       end
 
     end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -53,6 +53,18 @@ class SessionTest < Test::Unit::TestCase
       assert_equal 'https://fakeshop.myshopify.com/admin', ShopifyAPI::Base.site.to_s
     end
 
+    should "#temp reset ShopifyAPI::Base.site to original value when using a non-standard port" do
+      ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
+      session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com:3000', 'token1')
+      ShopifyAPI::Base.activate_session(session1)
+
+      ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token") {
+        @assigned_site = ShopifyAPI::Base.site
+      }
+      assert_equal 'https://testshop.myshopify.com/admin', @assigned_site.to_s
+      assert_equal 'https://fakeshop.myshopify.com:3000/admin', ShopifyAPI::Base.site.to_s
+    end
+
     should "return site for session" do
       session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
       assert_equal "https://testshop.myshopify.com/admin", session.site


### PR DESCRIPTION
`#temp` was stomping on my port when doing local development. Because it only grabbed the host from the existing URI, nested calls to `temp` would end up with an incorrect `ShopifyAPI::Base.site`
