### PR TITLE
Raise explicit error when Shopify call limit header is unavailable

### DIFF
--- a/test/limits_test.rb
+++ b/test/limits_test.rb
@@ -7,25 +7,33 @@ class LimitsTest < Test::Unit::TestCase
     @header_hash = {'http_x_shopify_shop_api_call_limit' => '100/300'}
     ShopifyAPI::Base.connection.expects(:response).at_least(0).returns(@header_hash)
   end
-  
+
   context "Limits" do
     should "fetch limit total" do
       assert_equal(299, ShopifyAPI.credit_limit(:shop))
     end
-    
+
     should "fetch used calls" do
       assert_equal(100, ShopifyAPI.credit_used(:shop))
     end
-    
+
     should "calculate remaining calls" do
       assert_equal(199, ShopifyAPI.credit_left)
     end
-    
+
     should "flag maxed out credits" do
       assert !ShopifyAPI.maxed?
       @header_hash = {'http_x_shopify_shop_api_call_limit' => '299/300'}
       ShopifyAPI::Base.connection.expects(:response).at_least(1).returns(@header_hash)
       assert ShopifyAPI.maxed?
+    end
+
+    should "raise error when header doesn't exist" do
+      @header_hash = {}
+      ShopifyAPI::Base.connection.expects(:response).at_least(1).returns(@header_hash)
+      assert_raise ShopifyAPI::Limits::LimitUnavailable do
+        ShopifyAPI.credit_left
+      end
     end
   end
 end


### PR DESCRIPTION
The `Limit` code crashes with a `NoMethodError` on nil when the call limit header is unavailable. This makes it raise an exception that can be caught.
