### PR TITLE
add order to ShopifyAPI::SmartCollection

### DIFF
--- a/lib/shopify_api/resources/smart_collection.rb
+++ b/lib/shopify_api/resources/smart_collection.rb
@@ -7,7 +7,9 @@ module ShopifyAPI
       Product.find(:all, :params => {:collection_id => self.id})
     end
 
-    def order(options={}); load_attributes_from_response(put(:order, options, only_id)); end
+    def order(options={})
+      load_attributes_from_response(put(:order, options, only_id))
+    end
 
   end
 end


### PR DESCRIPTION
@csaunders 

Just exposing `SmartCollection#order` through the gem so people can set the manual ordering of products within a SmartCollection via API.
