### PR TITLE
bump version, including gemfile.lock

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-== Version 3.1.4
+== Version 3.1.5
 
 * Expose `orders` action on Customer
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (3.1.3)
+    shopify_api (3.1.4)
       activeresource (>= 3.0.0)
       thor (>= 0.14.4)
 

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "3.1.4"
+  VERSION = "3.1.5"
 end


### PR DESCRIPTION
For some reason Gemfile.lock didn't come along for the ride, so now I have to bump versions again. >:(
