### PR TITLE
Fix line-item properties not getting through properly

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 3.1.6
+
+* Add LineItem::Property resource
+
 == Version 3.1.5
 
 * Expose `orders` action on Customer

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (3.1.4)
+    shopify_api (3.1.6)
       activeresource (>= 3.0.0)
       thor (>= 0.14.4)
 

--- a/lib/shopify_api/resources/line_item.rb
+++ b/lib/shopify_api/resources/line_item.rb
@@ -1,4 +1,6 @@
 module ShopifyAPI
   class LineItem < Base 
+    class Property < Base
+    end
   end
 end

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "3.1.5"
+  VERSION = "3.1.6"
 end


### PR DESCRIPTION
The custom properties on line-items don't come through properly for api_clients that use ActiveRecord < 4. 

ActiveRecord 4 makes properties on the fly, but 3.x doesn't, meaning we have to explicitly specify the expect object. In this case LineItem::Property.

I've added the object + bumped the version right away because this was a critical bug for an app dev. 
