### PR TITLE
Make sending options #authors  possible

### DIFF
--- a/lib/shopify_api/resources/article.rb
+++ b/lib/shopify_api/resources/article.rb
@@ -14,8 +14,8 @@ module ShopifyAPI
       Comment.find(:all, :params => { :article_id => id })
     end
 
-    def self.authors
-      get(:authors)
+    def self.authors(options = {})
+      get(:authors, options)
     end
 
     def self.tags(options={})

--- a/test/article_test.rb
+++ b/test/article_test.rb
@@ -33,6 +33,12 @@ class ArticleTest < Test::Unit::TestCase
     assert_equal "development shop", authors.last
   end
 
+  def test_get_authors_for_blog_id
+    fake "blogs/1008414260/articles/authors", :method => :get, :body => load_fixture('authors')
+    authors = ShopifyAPI::Article.authors(:blog_id => 1008414260)
+    assert_equal 3, authors.length
+  end
+
   def test_get_tags
     fake "articles/tags", :method => :get, :body => load_fixture('tags')
     tags = ShopifyAPI::Article.tags
@@ -50,7 +56,7 @@ class ArticleTest < Test::Unit::TestCase
   def test_get_popular_tags
     fake "articles/tags.json?limit=1&popular=1", :extension => false, :method => :get, :body => load_fixture('tags')
     tags = ShopifyAPI::Article.tags(:popular => 1, :limit => 1)
-    puts tags
+    assert_equal 3, tags.length
   end
 
 end


### PR DESCRIPTION
I want to be able to send `:blog_id` to authors to retrieve only the authors on a specific blog. 

This will make it possible to send parameters to `#authors`

It also removes a left-over `puts` from one of the tests.

@pickle27 @costford 
