### PR TITLE
packaging for release 3.1.7

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 3.1.7
+
+* Expose `authors` and `tags` action on Article
+
 == Version 3.1.6
 
 * Add LineItem::Property resource

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (3.1.6)
+    shopify_api (3.1.7)
       activeresource (>= 3.0.0)
       thor (>= 0.14.4)
 

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "3.1.6"
+  VERSION = "3.1.7"
 end


### PR DESCRIPTION
@costford @maartenvg 

bumps version to 3.1.7 

changelog 
Expose `authors` and `tags` action on Article
