### PR TITLE
Refactor prefix setting duplication

### DIFF
--- a/lib/active_resource/disable_prefix_check.rb
+++ b/lib/active_resource/disable_prefix_check.rb
@@ -4,5 +4,19 @@ module DisablePrefixCheck
   module ClassMethods
     def check_prefix_options(options)
     end
+
+    # `flexible = true` is hack to allow multiple things through the same AR class
+    def conditional_prefix(resource, flexible = false)
+      resource_id = "#{resource}_id".to_sym
+      resource_type = flexible ? ":#{resource}" : resource.to_s.pluralize
+
+      init_prefix_explicit resource_type, resource_id
+
+      define_singleton_method :prefix do |options|
+        resource_type =  options[resource] if flexible
+
+        options[resource_id].nil? ? "/admin/" : "/admin/#{resource_type}/#{options[resource_id]}/"
+      end
+    end
   end
 end

--- a/lib/shopify_api/resources/article.rb
+++ b/lib/shopify_api/resources/article.rb
@@ -4,11 +4,7 @@ module ShopifyAPI
     include Metafields
     include DisablePrefixCheck
 
-    self.prefix = "/admin/blogs/:blog_id/"
-     
-    def self.prefix(options={})
-      options[:blog_id].nil? ? "/admin/" : "/admin/blogs/#{options[:blog_id]}/"
-    end
+    conditional_prefix :blog
 
     def comments
       Comment.find(:all, :params => { :article_id => id })

--- a/lib/shopify_api/resources/asset.rb
+++ b/lib/shopify_api/resources/asset.rb
@@ -35,12 +35,9 @@ module ShopifyAPI
     include DisablePrefixCheck
 
     self.primary_key = 'key'
-    self.prefix = "/admin/themes/:theme_id/"
-    
-    def self.prefix(options={})
-      options[:theme_id].nil? ? "/admin/" : "/admin/themes/#{options[:theme_id]}/"
-    end
-    
+
+    conditional_prefix :theme
+
     def self.element_path(id, prefix_options = {}, query_options = nil) #:nodoc:
       prefix_options, query_options = split_options(prefix_options) if query_options.nil?
       "#{prefix(prefix_options)}#{collection_name}.#{format.extension}#{query_string(query_options)}"

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -45,6 +45,14 @@ module ShopifyAPI
         self.site = nil
         self.headers.delete('X-Shopify-Access-Token')
       end
+
+      def init_prefix(resource)
+        init_prefix_explicit(resource.to_s.pluralize, "#{resource}_id")
+      end
+
+      def init_prefix_explicit(resource_type, resource_id)
+        self.prefix = "/admin/#{resource_type}/:#{resource_id}/"
+      end
     end
 
     def persisted?

--- a/lib/shopify_api/resources/event.rb
+++ b/lib/shopify_api/resources/event.rb
@@ -2,11 +2,6 @@ module ShopifyAPI
   class Event < Base
     include DisablePrefixCheck
 
-    self.prefix = "/admin/:resource/:resource_id/"
-    
-    # Hack to allow both Shop and other Events in through the same AR class
-    def self.prefix(options={})
-      options[:resource].nil? ? "/admin/" : "/admin/#{options[:resource]}/#{options[:resource_id]}/"
-    end
+    conditional_prefix :resource, true
   end
 end

--- a/lib/shopify_api/resources/fulfillment.rb
+++ b/lib/shopify_api/resources/fulfillment.rb
@@ -1,6 +1,6 @@
 module ShopifyAPI
   class Fulfillment < Base
-    self.prefix = "/admin/orders/:order_id/"
+    init_prefix :order
 
     def cancel; load_attributes_from_response(post(:cancel, {}, only_id)); end
     def complete; load_attributes_from_response(post(:complete, {}, only_id)); end

--- a/lib/shopify_api/resources/image.rb
+++ b/lib/shopify_api/resources/image.rb
@@ -1,6 +1,6 @@
 module ShopifyAPI
   class Image < Base
-    self.prefix = "/admin/products/:product_id/"
+    init_prefix :product
     
     # generate a method for each possible image variant
     [:pico, :icon, :thumb, :small, :compact, :medium, :large, :grande, :original].each do |m|

--- a/lib/shopify_api/resources/metafield.rb
+++ b/lib/shopify_api/resources/metafield.rb
@@ -2,13 +2,8 @@ module ShopifyAPI
   class Metafield < Base
     include DisablePrefixCheck
 
-    self.prefix = "/admin/:resource/:resource_id/"
-    
-    # Hack to allow both Shop and other Metafields in through the same AR class
-    def self.prefix(options={})
-      options[:resource].nil? ? "/admin/" : "/admin/#{options[:resource]}/#{options[:resource_id]}/"
-    end
-            
+    conditional_prefix :resource, true
+
     def value
       return if attributes["value"].nil?
       attributes["value_type"] == "integer" ? attributes["value"].to_i : attributes["value"]

--- a/lib/shopify_api/resources/province.rb
+++ b/lib/shopify_api/resources/province.rb
@@ -1,5 +1,5 @@
 module ShopifyAPI
   class Province < Base
-    self.prefix = "/admin/countries/:country_id/"
+    init_prefix :country
   end
 end

--- a/lib/shopify_api/resources/transaction.rb
+++ b/lib/shopify_api/resources/transaction.rb
@@ -1,5 +1,5 @@
 module ShopifyAPI
   class Transaction < Base
-    self.prefix = "/admin/orders/:order_id/"
+    init_prefix :order
   end
 end

--- a/lib/shopify_api/resources/variant.rb
+++ b/lib/shopify_api/resources/variant.rb
@@ -3,10 +3,6 @@ module ShopifyAPI
     include Metafields
     include DisablePrefixCheck
 
-    self.prefix = "/admin/products/:product_id/"
-    
-    def self.prefix(options={})
-      options[:product_id].nil? ? "/admin/" : "/admin/products/#{options[:product_id]}/"
-    end
+    conditional_prefix :product
   end
 end

--- a/test/fixtures/transaction.json
+++ b/test/fixtures/transaction.json
@@ -1,0 +1,29 @@
+{
+  "transaction": {
+    "amount": "409.94",
+    "authorization": "authorization-key",
+    "created_at": "2005-08-01T11:57:11-04:00",
+    "gateway": "bogus",
+    "id": 389404469,
+    "kind": "authorization",
+    "location_id": null,
+    "message": null,
+    "order_id": 450789469,
+    "parent_id": null,
+    "status": "success",
+    "test": false,
+    "user_id": null,
+    "device_id": null,
+    "receipt": {
+      "testcase": true,
+      "authorization": "123456"
+    },
+    "payment_details": {
+      "avs_result_code": null,
+      "credit_card_bin": null,
+      "cvv_result_code": null,
+      "credit_card_number": "XXXX-XXXX-XXXX-4242",
+      "credit_card_company": "Visa"
+    }
+  }
+}

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+class TransactionTest < Test::Unit::TestCase
+  def setup
+    fake "orders/450789469/transactions/389404469", :method => :get, :body => load_fixture('transaction')
+  end
+
+  context "Transaction" do
+    context "#find" do
+      should "find a specific transaction" do
+        transaction = ShopifyAPI::Transaction.find(389404469, :params => {:order_id => 450789469})
+        assert_equal "409.94", transaction.amount
+      end
+    end
+  end
+end


### PR DESCRIPTION
I DRYed the way we set the prefixes for the specific resources. 
- `init_prefix :order` does the normal `self.prefix = '/admin/orders/:order_id/'`
- `conditional_prefix :order` does creates a `self.prefix` method which checks if `params[:order_id]` exists. Based on that it chooses either `/admin/` or `/admin/orders/:order_id/`.
- `conditional_prefix :resource, true` does the same, but retrieves the resource from the `params` provided. This requires a prefix that looks like `self.prefix = '/admin/:resource/:resource_id'`

No change of logic, only reduced the number of repeating code. Also added test for Transactions.

@csaunders @costford @pickle27 
