### PR TITLE
Travis++, Flowdock notifications & ActiveSupport fix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ coverage
 rdoc
 doc
 pkg
+.ruby-version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: ruby
+
+rvm:
+  - 2.0.0
+  - 1.9.3
+
+gemfile:
+  - Gemfile
+  - Gemfile_ar30
+  - Gemfile_ar31
+  - Gemfile_ar32
+
+install: bundle install
+
+before_script: echo $OLD_RAKE
+
+matrix:
+  include:
+    - rvm: 1.9.2
+      gemfile: Gemfile_ar30
+      env: OLD_RAKE=1
+    - rvm: 1.9.2
+      gemfile: Gemfile_ar31
+      env: OLD_RAKE=1
+    - rvm: 1.9.2
+      gemfile: Gemfile_ar32
+      env: OLD_RAKE=1
+
+
+notifications:
+  flowdock: 
+    secure: "RCgSxzMScnqK6bOwkv9sWSdieLBeJla8NcDtM/QmuFW8soTgV6qCTAPAGd4lpjg4vGTaM3DsdHU5GMDbgdWN5dE2Rf09ayFqiZg8OloPMQ63KIwLJyVcw3cVJO5i7smjIpsSjPjBkvAXHIOFcKdsnuYGS4YD8hjl+QrZ3ghi440="

--- a/Gemfile_ar30
+++ b/Gemfile_ar30
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "activeresource", "~> 3.0.0"
+
+if ENV['OLD_RAKE'] == '1'
+  gem "rake", "~> 0.9.2"
+end

--- a/Gemfile_ar31
+++ b/Gemfile_ar31
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "activeresource", "~> 3.1.0"
+
+if ENV['OLD_RAKE'] == '1'
+  gem "rake", "~> 0.9.2"
+end

--- a/Gemfile_ar32
+++ b/Gemfile_ar32
@@ -1,0 +1,9 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "activeresource", "~> 3.2.0"
+
+if ENV['OLD_RAKE'] == '1'
+  gem "rake", "~> 0.9.2"
+end

--- a/lib/active_resource/to_query.rb
+++ b/lib/active_resource/to_query.rb
@@ -1,0 +1,10 @@
+# ActiveSupport 3.0 doesn't URL-encode paths with arrays as params properly.
+# Backported from ActiveSupport > 3.0
+if ActiveSupport::VERSION::MAJOR == 3 && ActiveSupport::VERSION::MINOR == 0
+  class Object
+    def to_query(key)
+      require 'cgi' unless defined?(CGI) && defined?(CGI::escape)
+      "#{CGI.escape(key.to_param)}=#{CGI.escape(to_param.to_s)}"
+    end
+  end
+end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -11,6 +11,7 @@ require 'shopify_api/json_format'
 require 'active_resource/json_errors'
 require 'active_resource/disable_prefix_check'
 require 'active_resource/base_ext'
+require 'active_resource/to_query'
 
 module ShopifyAPI
   include Limits


### PR DESCRIPTION
This PR adds a Travis testing matrix for ruby versions 1.9.2, 1.9.3, and 2.0.0, with ActiveResource 3.0, 3.1, 3.2 and 4.0. Resulting in 11 supported combinations, because AR 4.0 doesn't support 1.9.2. 

To accomplish this, I've added ActiveResource specific `Gemfiles` (without lock files) and a `.travis.yml` file. I've included an encrypted Flowdock token to report back to the API flow. 

This PR also fixes unit tests for ActiveResource 3.0.x. The issue was that `to_query` didn't encode square brackets in URL parameters, but in later versions it does. I've backported that encoding to fix support for AR 3.0.

@costford @pickle27 @csaunders 
