### PR TITLE
resources: fix odd require not working on 2.1

### DIFF
--- a/lib/shopify_api/resources.rb
+++ b/lib/shopify_api/resources.rb
@@ -1,2 +1,2 @@
 require 'shopify_api/resources/base'
-Dir.glob "#{File.dirname(__FILE__)}/resources/*", &method(:require)
+Dir.glob("#{File.dirname(__FILE__)}/resources/*").each { |file| require(file) } 


### PR DESCRIPTION
This segfaults on Ruby 2.1 in the context of Shopify (but not standalone). Exactly why is a mystery to me. I'll forward this to a Ruby core dev to see get some more insight. For now, this should definitely work.

@csaunders @maartenvg 
