### PR TITLE
Update link to API docs

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -145,7 +145,7 @@ Download the source code and run:
 
 == Additional Resources
 
-http://api.shopify.com <= Read the tech docs!
+http://docs.shopify.com/api <= Read the tech docs!
 
 http://ecommerce.shopify.com/c/shopify-apis-and-technology <= Ask questions on the forums!
 


### PR DESCRIPTION
Shopify redirects api.shopify.com to docs.shopify.com/api
