### PR TITLE
Don't override headers and delete methods in AR4

### DIFF
--- a/lib/active_resource/base_ext.rb
+++ b/lib/active_resource/base_ext.rb
@@ -1,19 +1,23 @@
 module ActiveResource
   class Base
-    # Backported from ActiveResource master branch
-    def self.headers
-      @headers ||= {}
+    if ActiveResource::VERSION::MAJOR < 4
+      # Backported from ActiveResource master branch
+      def self.headers
+        @headers ||= {}
 
-      if superclass != Object && superclass.headers
-        @headers = superclass.headers.merge(@headers)
-      else
-        @headers
+        if superclass != Object && superclass.headers
+          @headers = superclass.headers.merge(@headers)
+        else
+          @headers
+        end
+      end
+
+      # https://github.com/rails/activeresource/commit/dfef85ce8f653f75673631b2950fcdb0781c313c
+      def self.delete(id, options = {})
+        connection.delete(element_path(id, options), headers)
       end
     end
-    # https://github.com/rails/activeresource/commit/dfef85ce8f653f75673631b2950fcdb0781c313c
-    def self.delete(id, options = {})
-      connection.delete(element_path(id, options), headers)
-    end
+
     def self.build(attributes = {})
       attrs = self.format.decode(connection.get("#{new_element_path}", headers).body).merge(attributes)
       self.new(attrs)


### PR DESCRIPTION
@maartenvg @pickle27 

Neither of the overrides in `base_ext` are necessary in AR4.

[AR4's version of `headers`](https://github.com/rails/activeresource/blob/v4.0.0/lib/active_resource/base.rb#L603) is the same as is defined here, as is [the code for `delete`](https://github.com/rails/activeresource/blob/v4.0.0/lib/active_resource/base.rb#L922)
