### PR TITLE
Remove the ActiveResource::Base.build method override

### DIFF
--- a/lib/active_resource/base_ext.rb
+++ b/lib/active_resource/base_ext.rb
@@ -17,10 +17,5 @@ module ActiveResource
         connection.delete(element_path(id, options), headers)
       end
     end
-
-    def self.build(attributes = {})
-      attrs = self.format.decode(connection.get("#{new_element_path}", headers).body).merge(attributes)
-      self.new(attrs)
-    end
   end
 end


### PR DESCRIPTION
@pickle27 @maartenvg 

Related to #89 

Remove the `ActiveResource::Base.build` method override. It's not used for ShopifyAPI, and as found in #89, it ends up requiring a bunch of different versions to support it across various versions of ActiveResource.
