### PR TITLE
Remove product search engine

### DIFF
--- a/lib/shopify_api/resources/product_search_engine.rb
+++ b/lib/shopify_api/resources/product_search_engine.rb
@@ -1,4 +1,0 @@
-module ShopifyAPI
-  class ProductSearchEngine < Base
-  end
-end


### PR DESCRIPTION
We've discontinued the (unused) ProductSearchEngine endpoint. No need for this file anymore.

@pickle27  @phoet 
