### PR TITLE
Bump version and update changelog

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,9 +1,14 @@
-== Version 3.1.9 (Unreleased)
+== Version 3.2.0
 
 * in Session::request_token params is no longer optional, you must pass all the params and the method will now extract the code
-* Add access to FulfillmentService endpoint
-* Fix JSON errors handling (#103)
-* Add convenience method Customer#search (#45)
+* Fixed JSON errors handling (#103)
+* Fixed compatibility with Ruby 2.1.x (#83)
+* Fixed getting parent ID from nested resources like Variants (#44)
+* Cleaned up compatibility with ActiveResource 4.0.x
+* Added OrderRisk resource
+* Added FulfillmentService resource
+* Removed discontinued ProductSearchEngine resource
+* Added convenience method Customer#search (#45)
 
 == Version 3.1.8
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (3.1.8)
+    shopify_api (3.2.0)
       activeresource (>= 3.0.0)
       thor (>= 0.14.4)
 
@@ -24,7 +24,7 @@ GEM
     atomic (1.1.14)
     builder (3.1.4)
     fakeweb (1.3.0)
-    i18n (0.6.5)
+    i18n (0.6.9)
     metaclass (0.0.1)
     minitest (4.7.5)
     mocha (0.14.0)

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "3.1.8"
+  VERSION = "3.2.0"
 end


### PR DESCRIPTION
Time to release v3.2.0 (minor compatibility breaking change in something added last time).

Updated changelog to match actual changes

review @costford @phoet 
