### PR TITLE
validate_signature error

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -39,6 +39,7 @@ module ShopifyAPI
       end
 
       def validate_signature(params)
+        params = params.with_indifferent_access
         return false unless signature = params[:signature]
 
         sorted_params = params.except(:signature, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -148,10 +148,20 @@ class SessionTest < Test::Unit::TestCase
       end
     end
 
+    should "return true when the signature is valid and the keys of params are strings" do
+      now = Time.now
+      params = {"code" => "any-code", "timestamp" => now}
+      sorted_params = make_sorted_params(params)
+      signature = Digest::MD5.hexdigest(ShopifyAPI::Session.secret + sorted_params)
+      params = {"code" => "any-code", "timestamp" => now, "signature" => signature}
+
+      assert_equal true, ShopifyAPI::Session.validate_signature(params)
+    end
+
     private
 
     def make_sorted_params(params)
-      sorted_params = params.except(:signature, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join
+      sorted_params = params.with_indifferent_access.except(:signature, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join
     end
 
   end


### PR DESCRIPTION
I'm using sinatra, and I've found out that when I use token = session.request_token(params) after the first redirect the params variable is a hash with strings as keys and validation_signature expects a symbol.
