### PR TITLE
Refactored session code

### DIFF
--- a/lib/shopify_api/session/oauth.rb
+++ b/lib/shopify_api/session/oauth.rb
@@ -1,0 +1,77 @@
+module ShopifyAPI
+  class ValidationException < StandardError; end
+
+  class Session
+    cattr_accessor :api_key
+    cattr_accessor :secret
+
+    attr_accessor :token
+
+    class << self
+      def validate_signature(params)
+        params = params.with_indifferent_access
+        return false unless signature = params[:signature]
+        params[:timestamp].to_i > 24.hours.ago.utc.to_i &&
+        Digest::MD5.hexdigest(secret + sort_params(params)) == signature
+      end
+
+      private
+
+      def sort_params(params)
+        params.except(*ignored_params).collect {|key, value|
+          "#{key}=#{value}"
+        }.sort.join
+      end
+
+      def ignored_params
+        [:signature, :action, :controller]
+      end
+    end
+
+    def create_permission_url(scope, redirect_uri=nil)
+      uri.build(
+        host: url,
+        path: "/admin/oauth/authorize",
+        query: oauth_authorize_params(scope, redirect_uri).to_query
+      ).to_s
+    end
+
+    def request_token(params)
+      return token if token.present?
+      raise_validation_exception unless self.class.validate_signature(params)
+      response = access_token_request(params['code'])
+      raise RuntimeError, response.msg unless response.code == "200"
+      JSON.parse(response.body)['access_token']
+    end
+
+    private
+
+    def raise_validation_exception
+      raise ValidationException,
+        "Invalid Signature: Possible malicious login",
+        caller
+    end
+
+    def oauth_authorize_params(scope, redirect_uri)
+      {}.tap do |params|
+        params[:client_id] = api_key
+        params[:scope] = scope.join(",")
+        params[:redirect_uri] = redirect_uri if redirect_uri.present?
+      end
+    end
+
+    def access_token_request(code)
+      u = uri.build(host: url, path: "/admin/oauth/access_token")
+      https = Net::HTTP.new(u.host, u.port).tap {|h| h.use_ssl = true }
+      request = Net::HTTP::Post.new(u.request_uri)
+      request.set_form_data(access_token_request_params(code))
+      https.request(request)
+    end
+
+    def access_token_request_params(code)
+      { "client_id" => api_key,
+        "client_secret" => secret,
+        "code" => code }
+    end
+  end
+end

--- a/lib/shopify_api/session/temp.rb
+++ b/lib/shopify_api/session/temp.rb
@@ -1,0 +1,34 @@
+module ShopifyAPI
+  class Session
+    class << self
+      def temp(domain, token, &block)
+        store_current_session
+        ShopifyAPI::Base.activate_session new(domain, token)
+        yield if block_given?
+      ensure
+        restore_previous_session
+      end
+
+      private
+
+      def current_domain
+        host_with_port(ShopifyAPI::Base.site.to_s)
+      rescue URI::InvalidURIError
+        nil
+      end
+
+      def current_token
+        ShopifyAPI::Base.headers['X-Shopify-Access-Token']
+      end
+
+      def store_current_session
+        @saved_session = new(current_domain, current_token)
+      end
+
+      def restore_previous_session
+        ShopifyAPI::Base.activate_session(@saved_session)
+        @saved_session = nil
+      end
+    end
+  end
+end

--- a/lib/shopify_api/session/uri.rb
+++ b/lib/shopify_api/session/uri.rb
@@ -1,0 +1,18 @@
+module ShopifyAPI
+  class Session
+    cattr_accessor :protocol
+
+    self.protocol = 'https'
+
+    private
+
+    def https(path)
+      u = uri.build(host: url, path: path)
+      Net::HTTP.new(u.host, u.port).tap {|h| h.use_ssl = true }
+    end
+
+    def uri
+      protocol == 'https' ? URI::HTTPS : URI::HTTP
+    end
+  end
+end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -67,7 +67,7 @@ class SessionTest < Test::Unit::TestCase
       session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
       scope = ["write_products"]
       permission_url = session.create_permission_url(scope, "http://my_redirect_uri.com")
-      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com", permission_url
+      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&redirect_uri=http%3A%2F%2Fmy_redirect_uri.com&scope=write_products", permission_url
     end
 
     should "create_permission_url returns correct url with dual scope no redirect uri" do
@@ -75,7 +75,7 @@ class SessionTest < Test::Unit::TestCase
       session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
       scope = ["write_products","write_customers"]
       permission_url = session.create_permission_url(scope)
-      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
+      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products%2Cwrite_customers", permission_url
     end
 
     should "create_permission_url returns correct url with no scope no redirect uri" do


### PR DESCRIPTION
The session code was getting somewhat unwieldy so I refactored it into smaller chunks of more manageable code.

I fixed a small concern with Session#setup. It was using `send` instead of `public_send`. Using `send` in a public method could potentially allow private methods to be called without raising an exception.

Session#validate_signature now checks the timestamp. Previously it was ignoring it. #request_token was raising a ValidationException even when #validate_signature returned true.

The Session#temp method I originally introduced has since become rather large and confusing, so I broke it up into smaller, easier to understand methods and moved it into its own file, `session/temp.rb`.

I also moved all the OAuth specific code into `session/oauth.rb` for easier management.

Instead of using strings to build URIs, URI::HTTP or URI::HTTPS are now used whenever possible.

I removed Session#parameterize in favor of ActiveSupport's #to_query extension. No reason to duplicate a helper method that already exists in one of the library's dependencies.

I moved some Hashes and Arrays into their own private methods to simplify some confusing methods.
