### PR TITLE
Raise a useful error when trying to activate_session with nil

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -2,6 +2,7 @@ require 'shopify_api/version'
 
 module ShopifyAPI
   class Base < ActiveResource::Base
+    class InvalidSessionError < StandardError; end
     extend Countable
     self.include_root_in_json = false
     self.headers['User-Agent'] = ["ShopifyAPI/#{ShopifyAPI::VERSION}",
@@ -49,6 +50,7 @@ module ShopifyAPI
       end
 
       def activate_session(session)
+        raise InvalidSessionError.new("Session cannot be nil") if session.nil?
         self.site = session.site
         self.headers.merge!('X-Shopify-Access-Token' => session.token)
       end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -51,6 +51,12 @@ class BaseTest < Test::Unit::TestCase
     assert_equal 'token2', ShopifyAPI::Shop.headers['X-Shopify-Access-Token']
   end
 
+  test '#activate_session with nil raises an InvalidSessionError' do
+    assert_raises ShopifyAPI::Base::InvalidSessionError do
+      ShopifyAPI::Base.activate_session nil
+    end
+  end
+
   test "#delete should send custom headers with request" do
     ShopifyAPI::Base.activate_session @session1
     ShopifyAPI::Base.headers['X-Custom'] = 'abc'


### PR DESCRIPTION
When trying to perform `ShopifyAPI::Base.activate_session(nil)` instead of getting a cryptic error you'll get the following:

```
irb(main):002:0> ShopifyAPI::Base.activate_session(nil)
ShopifyAPI::Base::InvalidSessionError: Session cannot be nil
    from /Users/csaunders/development/ruby/shopify_api/lib/shopify_api/resources/base.rb:53:in `activate_session'
    from (irb):2
    from /Users/csaunders/.rbenv/versions/2.0.0-p247/bin/irb:12:in `<main>'
```

Please review @alexcoco @awd 
