### PR TITLE
Bump version of API gem to 3.2.5

### DIFF
--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "3.2.4"
+  VERSION = "3.2.5"
 end


### PR DESCRIPTION
Bump API version from `3.2.4` to `3.2.5`. 

cc: @csaunders @pickle27 
