### PR TITLE
Protect from incidental mutation of URL

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -64,7 +64,7 @@ module ShopifyAPI
 
     def initialize(url, token = nil)
       self.url, self.token = url, token
-      self.class.prepare_url(self.url)
+      self.class.prepare_url(self.url.dup)
     end
 
     def create_permission_url(scope, redirect_uri = nil)


### PR DESCRIPTION
Session.prepare_url is mutating and that makes Session.temp(domain, token) mutate domain without communicating that to the user in any way.
