### PR TITLE
Fix for token auth calls triggered after login/password calls

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -57,7 +57,10 @@ module ShopifyAPI
 
       def clear_session
         self.site = nil
+        self.user = nil
+        self.password = nil
         self.headers.delete('X-Shopify-Access-Token')
+        self.headers.delete('Authorization')
       end
 
       def init_prefix(resource)


### PR DESCRIPTION
Properly reset all the state that affects new requests. 

In a scenario when one Ruby (Rails) instance would first attempt to connect to a store using a login/password and then would try to connect to a different store through OAuth token, second connection would always fail because of the old Authorization header. 

Proposed patch fixes the issue.
