### PR TITLE
Fix customer saved search method

### DIFF
--- a/lib/shopify_api/resources/customer_saved_search.rb
+++ b/lib/shopify_api/resources/customer_saved_search.rb
@@ -3,7 +3,7 @@ require 'shopify_api/resources/customer'
 module ShopifyAPI
   class CustomerSavedSearch < Base
     def customers(params = {})
-      Customer.find(:all, :params => params.merge({ :customer_saved_search_id => self.id }))
+      Customer.search(params.merge({:saved_search_id => self.id}))
     end
   end
 end

--- a/test/customer_saved_search_test.rb
+++ b/test/customer_saved_search_test.rb
@@ -7,13 +7,13 @@ class CustomerSavedSearchTest < Test::Unit::TestCase
   end
 
   def test_get_customers_from_customer_saved_search
-    fake 'customers.json?customer_saved_search_id=8899730', :body => load_fixture('customer_saved_search_customers'), :extension => false
+    fake 'customers/search.json?saved_search_id=8899730', :body => load_fixture('customer_saved_search_customers'), :extension => false
     assert_equal 1, @customer_saved_search.customers.length
     assert_equal 112223902, @customer_saved_search.customers.first.id
   end
 
   def test_get_customers_from_customer_saved_search_with_params
-    fake 'customers.json?customer_saved_search_id=8899730&limit=1', :body => load_fixture('customer_saved_search_customers'), :extension => false
+    fake 'customers/search.json?saved_search_id=8899730&limit=1', :body => load_fixture('customer_saved_search_customers'), :extension => false
     customers = @customer_saved_search.customers(:limit => 1)
     assert_equal 1, customers.length
     assert_equal 112223902, customers.first.id


### PR DESCRIPTION
Fixes #146

Changes to the customer search on Shopify's side never made their way to the gem. This PR cahnes the `customers` method on `CustomerSavedSearch` to use the customer search endpoint to return the customers a specific saved search

@csaunders @pickle27 
