### PR TITLE
Specify minitest 4.2

### DIFF
--- a/Gemfile_ar40threadsafe
+++ b/Gemfile_ar40threadsafe
@@ -3,3 +3,5 @@ source "https://rubygems.org"
 gemspec
 
 gem 'activeresource', :git => 'git://github.com/Shopify/activeresource', :ref => 'e9dc76b4aa'
+
+gem 'minitest', "~> 4.2"


### PR DESCRIPTION
Assuming everything goes green (it _should_) the problem with the test suite for the threadsafe gemfiles was an activeresource dependency on minitest 4.2. 

I don't know a lot about the history of the threadsafe branch and whatnot but this looks like it works

@csaunders @pickle27 
