### PR TITLE
Updating the reference to the threadsafe branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ We have a forked version of ActiveResource that stores these class variables in 
 To enable threadsafety with ShopifyAPI, add the following to your Gemfile:
 
 ```
-gem 'activeresource', git: 'git://github.com/Shopify/activeresource', branch: 'threadsafe'
+gem 'activeresource', git: 'git://github.com/Shopify/activeresource', branch: 'threadsafe_2015_01'
 gem 'shopify_api', '>= 3.2.1'
 ```
 


### PR DESCRIPTION
@jamesmacaulay @csaunders 

I've rebased our `activeresource` fork to be on the latest version of `rails/activeresource`.

I've also rebased our threadsafe branch on top of the updated master, and called the branch `threadsafe_2015_01`

This updates the reference to the threadsafe branch in our README to the new version, which is pretty harmless.

The real question, is how do we make this sustainable. We can't delete the original "threadsafe" branch, since we've stated in this README that people should use that branch. We could update the "threadsafe" branch to be on the latest code, and if people update their gem, they'll get the latest code, but that could potentially upgrade people without knowing.

Maybe we can just put a disclaimer in this README recommending that people reference the commit, rather than the branch, so they don't get unexpectedly upgraded?

WDYT?