### PR TITLE
Move pry and thor to dev dependencies

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,8 +3,6 @@ PATH
   specs:
     shopify_api (3.2.7)
       activeresource
-      pry (>= 0.9.12.6)
-      thor (~> 0.18.1)
 
 GEM
   remote: https://rubygems.org/
@@ -52,5 +50,7 @@ DEPENDENCIES
   fakeweb
   minitest (~> 4.0)
   mocha (>= 0.9.8)
+  pry (>= 0.9.12.6)
   rake
   shopify_api!
+  thor (~> 0.18.1)

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -25,18 +25,18 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency("activeresource")
-  s.add_dependency("thor", ["~> 0.18.1"])
-  s.add_dependency("pry", [">= 0.9.12.6"])
+
+  dev_dependencies = [['mocha', '>= 0.9.8'],
+                      ['fakeweb'], 
+                      ['minitest', '~> 4.0'],
+                      ['rake'],
+                      ['thor', '~> 0.18.1'],
+                      ['pry', ">= 0.9.12.6"]
+  ]
 
   if s.respond_to?(:add_development_dependency)
-    s.add_development_dependency("mocha", ">= 0.9.8")
-    s.add_development_dependency("fakeweb")
-    s.add_development_dependency("minitest", "~> 4.0")
-    s.add_development_dependency("rake")
+    dev_dependencies.each { |dep| s.add_development_dependency(*dep) }
   else
-    s.add_dependency("mocha", ">= 0.9.8")
-    s.add_dependency("fakeweb")
-    s.add_dependency("minitest", "~> 4.0")
-    s.add_dependency("rake")
+    dev_dependencies.each { |dep| s.add_dependency(*dep) }
   end
 end


### PR DESCRIPTION
Pry and thor bring along a bunch of "friends"  if they slip into a production
bundle it seems  unlikely that either is needed in production, moving them here
to be a dev dependency.

@kevinhughes27 @jamesmacaulay @ibawt makes sense?