### PR TITLE
Allow options to be passed to shop fetching

### DIFF
--- a/lib/shopify_api/resources/shop.rb
+++ b/lib/shopify_api/resources/shop.rb
@@ -2,8 +2,8 @@ module ShopifyAPI
   # Shop object. Use Shop.current to receive 
   # the shop.
   class Shop < Base
-    def self.current
-      find(:one, from: "/admin/shop.#{format.extension}")
+    def self.current(options={})
+      find(:one, options.merge({from: "/admin/shop.#{format.extension}"}))
     end
 
     def metafields

--- a/test/shop_test.rb
+++ b/test/shop_test.rb
@@ -8,8 +8,6 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_current_should_return_current_shop
-    fake "shop"
-    @shop = ShopifyAPI::Shop.current
     assert @shop.is_a?(ShopifyAPI::Shop)
     assert_equal "Apple Computers", @shop.name
     assert_equal "apple.myshopify.com", @shop.myshopify_domain
@@ -28,9 +26,6 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_get_metafields_for_shop
-    fake "shop"
-    @shop = ShopifyAPI::Shop.current
-
     fake "metafields"
 
     metafields = @shop.metafields
@@ -40,9 +35,6 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_add_metafield
-    fake "shop"
-    @shop = ShopifyAPI::Shop.current
-
     fake "metafields", :method => :post, :status => 201, :body =>load_fixture('metafield')
 
     field = @shop.add_metafield(ShopifyAPI::Metafield.new(:namespace => "contact", :key => "email", :value => "123@example.com", :value_type => "string"))
@@ -54,9 +46,6 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_events
-    fake "shop"
-    @shop = ShopifyAPI::Shop.current
-
     fake "events"
 
     events = @shop.events

--- a/test/shop_test.rb
+++ b/test/shop_test.rb
@@ -8,6 +8,8 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_current_should_return_current_shop
+    fake "shop"
+    @shop = ShopifyAPI::Shop.current
     assert @shop.is_a?(ShopifyAPI::Shop)
     assert_equal "Apple Computers", @shop.name
     assert_equal "apple.myshopify.com", @shop.myshopify_domain
@@ -16,7 +18,19 @@ class ShopTest < Test::Unit::TestCase
     assert_nil @shop.tax_shipping
   end
 
+  def test_current_with_options_should_return_current_shop
+    fake "shop.json?fields%5B%5D=name&fields%5B%5D=myshopify_domain", :extension => false, :method => :get, :status => 201, :body => load_fixture('shop')
+
+    @shop = ShopifyAPI::Shop.current(params: { fields: [:name, :myshopify_domain]})
+    assert @shop.is_a?(ShopifyAPI::Shop)
+    assert_equal "Apple Computers", @shop.name
+    assert_equal "apple.myshopify.com", @shop.myshopify_domain
+  end
+
   def test_get_metafields_for_shop
+    fake "shop"
+    @shop = ShopifyAPI::Shop.current
+
     fake "metafields"
 
     metafields = @shop.metafields
@@ -26,6 +40,9 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_add_metafield
+    fake "shop"
+    @shop = ShopifyAPI::Shop.current
+
     fake "metafields", :method => :post, :status => 201, :body =>load_fixture('metafield')
 
     field = @shop.add_metafield(ShopifyAPI::Metafield.new(:namespace => "contact", :key => "email", :value => "123@example.com", :value_type => "string"))
@@ -37,6 +54,9 @@ class ShopTest < Test::Unit::TestCase
   end
 
   def test_events
+    fake "shop"
+    @shop = ShopifyAPI::Shop.current
+
     fake "events"
 
     events = @shop.events


### PR DESCRIPTION
This allows options to be passed when fetching the current shop.  For example

    ShopifyAPI::Shop.current(params: { fields: ['name', 'email'] })