### PR TITLE
Set errors on Bad Requests

### DIFF
--- a/lib/active_resource/json_errors.rb
+++ b/lib/active_resource/json_errors.rb
@@ -16,7 +16,7 @@ module ActiveResource
       clear unless save_cache
 
       messages.each do |key,errors|
-        errors.each do |error|
+        [errors].flatten.each do |error|
           add(key, error)
         end
       end

--- a/lib/active_resource/validations_ext.rb
+++ b/lib/active_resource/validations_ext.rb
@@ -1,0 +1,18 @@
+module ActiveResource
+  module Validations
+    def self.included(base)
+      base.class_eval do
+        alias_method_chain :save, :bad_request_handling
+      end
+    end
+
+    def save_with_bad_request_handling(options={})
+      save_without_bad_request_handling
+    rescue BadRequest => error
+      @remote_errors = error
+      load_remote_errors(@remote_errors, true)
+
+      raise
+    end
+  end
+end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -2,12 +2,14 @@ $:.unshift File.dirname(__FILE__)
 
 require 'active_resource'
 require 'active_support/core_ext/class/attribute_accessors'
+require 'active_resource/exceptions' # for ActiveResource =< 3.1
 require 'digest/md5'
 require 'base64'
 require 'active_resource/connection_ext'
 require 'active_resource/detailed_log_subscriber'
 require 'shopify_api/limits'
 require 'shopify_api/json_format'
+require 'active_resource/validations_ext'
 require 'active_resource/json_errors'
 require 'active_resource/disable_prefix_check'
 require 'active_resource/base_ext'

--- a/test/active_resource/json_errors_test.rb
+++ b/test/active_resource/json_errors_test.rb
@@ -13,6 +13,11 @@ module ActiveResource
       assert_equal(["some generic error"], errors)
     end
 
+    def test_parsing_of_error_json_hash_with_plain_strings
+      errors = some_error.from_json({errors: {name: 'missing'}}.to_json)
+      assert_equal({"name"=>"missing"}, errors)
+    end
+
     private
 
     def some_error

--- a/test/error_test.rb
+++ b/test/error_test.rb
@@ -1,0 +1,45 @@
+require 'test_helper'
+
+class ErrorTest < Test::Unit::TestCase
+  def test_bad_request_with_error
+    fake "blogs/1008414260/articles", :method => :post, :body => load_fixture('errors'), :status => 400
+    article = ShopifyAPI::Article.new(:blog_id => 1008414260)
+    assert_raises ActiveResource::BadRequest do
+      article.save
+    end
+
+    assert_equal ["can't be blank"], article.errors[:title]
+    assert_equal ["expected String to be a Money"], article.errors[:price]
+  end
+
+  def test_bad_request_without_error
+    fake "blogs/1008414260/articles", :method => :post, :body => nil, :status => 400
+    article = ShopifyAPI::Article.new(:blog_id => 1008414260)
+
+    assert_raises ActiveResource::BadRequest do
+      article.save
+    end
+
+    assert_equal 0, article.errors.count
+  end
+
+  def test_unprocessable_entity_with_error
+    fake "blogs/1008414260/articles", :method => :post, :body => load_fixture('errors'), :status => 422
+    article = ShopifyAPI::Article.new(:blog_id => 1008414260)
+    assert_equal false, article.save
+
+    assert_equal ["can't be blank"], article.errors[:title]
+    assert_equal ["expected String to be a Money"], article.errors[:price]
+  end
+
+  def test_unprocessable_entity_without_error
+    fake "blogs/1008414260/articles", :method => :post, :body => nil, :status => 422
+    article = ShopifyAPI::Article.new(:blog_id => 1008414260)
+
+    assert_equal false, article.save
+
+
+    assert_equal 0, article.errors.count
+  end
+
+end

--- a/test/fixtures/errors.json
+++ b/test/fixtures/errors.json
@@ -1,0 +1,6 @@
+{
+  "errors": {
+    "title": ["can't be blank"],
+    "price": ["expected String to be a Money"]
+  }
+}


### PR DESCRIPTION
### Problem
With the introduction of stronger parameters, requests that send bad data (HTTP 400 Bad Request) will often still result a great error description on why the request was rejected. For example, when you send an non-money-formatted string when setting the variant price, the result is:
```
HTTP 400 Bad Request
{
 "errors": {
    "price": "expected String to be a Money"
  }
}
```
Unfortunately, ActiveResource only checks for the presence of the error data in the response body for HTTP codes >= 401, so it is impossible to see these errors via the ShopifyAPI gem.

### Solution
Money patch ActiveResource to look for errors on BadRequests.

@jamesmacaulay @awd 
/cc @EiNSTeiN- 