### PR TITLE
Bugfix/orders api order cancellation

### DIFF
--- a/lib/shopify_api/resources/order.rb
+++ b/lib/shopify_api/resources/order.rb
@@ -7,7 +7,7 @@ module ShopifyAPI
     def open;   load_attributes_from_response(post(:open, {}, only_id)); end
 
     def cancel(options = {})
-      load_attributes_from_response(post(:cancel, options, only_id))
+      load_attributes_from_response(post(:cancel, {}, options.to_json))
     end
 
     def transactions

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.0.3"
+  VERSION = "4.0.4"
 end

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -36,7 +36,7 @@ class LogSubscriberTest < Test::Unit::TestCase
   test "logging on #find with an error" do
     fake "pages/2", :method => :get, :body => nil, :status => 404
 
-    assert_raise ActiveResource::ResourceNotFound do
+    assert_raises ActiveResource::ResourceNotFound do
       ShopifyAPI::Page.find(2)
     end
 

--- a/test/limits_test.rb
+++ b/test/limits_test.rb
@@ -30,7 +30,7 @@ class LimitsTest < Test::Unit::TestCase
     should "raise error when header doesn't exist" do
       @header_hash = {}
       ShopifyAPI::Base.connection.expects(:response).at_least(1).returns(@header_hash)
-      assert_raise ShopifyAPI::Limits::LimitUnavailable do
+      assert_raises ShopifyAPI::Limits::LimitUnavailable do
         ShopifyAPI.credit_left
       end
     end

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -35,5 +35,13 @@ class OrderTest < Test::Unit::TestCase
     order = ShopifyAPI::Order.find(450789469)
     assert order.destroy
   end
+
+  test "cancel an order with params" do
+    fake 'orders/450789469', :method => :get, :status => 200, :body => load_fixture('order')
+    fake 'orders/450789469/cancel', :method => :post, :body => load_fixture('order')
+    order = ShopifyAPI::Order.find(450789469)
+    order.cancel(email: false, restock: true)
+    assert_request_body({'email' => false, 'restock' => true}.to_json)
+  end
 end
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -2,198 +2,205 @@ require 'test_helper'
 
 class SessionTest < Test::Unit::TestCase
 
-  context "Session" do
-    should "not be valid without a url" do
-      session = ShopifyAPI::Session.new(nil, "any-token")
-      assert_not session.valid?
-    end
+  def setup
+    ShopifyAPI::Session.secret = 'secret'
+  end
 
-    should "not be valid without token" do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com")
-      assert_not session.valid?
-    end
+  test "not be valid without a url" do
+    session = ShopifyAPI::Session.new(nil, "any-token")
+    assert_not session.valid?
+  end
 
-    should "be valid with any token and any url" do
+  test "not be valid without token" do
+    session = ShopifyAPI::Session.new("testshop.myshopify.com")
+    assert_not session.valid?
+  end
+
+  test "be valid with any token and any url" do
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
+    assert session.valid?
+  end
+
+  test "not raise error without params" do
+    assert_nothing_raised do
       session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
-      assert session.valid?
     end
+  end
 
-    should "ignore everything but the subdomain in the shop" do
-      assert_equal "https://testshop.myshopify.com/admin", ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token").site
-    end
+  test "ignore everything but the subdomain in the shop" do
+    assert_equal "https://testshop.myshopify.com/admin", ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token").site
+  end
 
-    should "append the myshopify domain if not given" do
-      assert_equal "https://testshop.myshopify.com/admin", ShopifyAPI::Session.new("testshop", "any-token").site
-    end
+  test "append the myshopify domain if not given" do
+    assert_equal "https://testshop.myshopify.com/admin", ShopifyAPI::Session.new("testshop", "any-token").site
+  end
 
-    should "not raise error without params" do
-      assert_nothing_raised do
-        session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
-      end
-    end
-
-    should "raise error if params passed but signature omitted" do
-      assert_raises(ShopifyAPI::ValidationException) do
-        session = ShopifyAPI::Session.new("testshop.myshopify.com")
-        session.request_token({'code' => 'any-code'})
-      end
-    end
-
-    should "setup api_key and secret for all sessions" do
-      ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
-      assert_equal "My test key", ShopifyAPI::Session.api_key
-      assert_equal "My test secret", ShopifyAPI::Session.secret
-    end
-
-    should "use 'https' protocol by default for all sessions" do
-      assert_equal 'https', ShopifyAPI::Session.protocol
-    end
-
-    should "#temp reset ShopifyAPI::Base.site to original value" do
-
-      ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
-      session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com', 'token1')
-      ShopifyAPI::Base.activate_session(session1)
-
-      ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token") {
-        @assigned_site = ShopifyAPI::Base.site
-      }
-      assert_equal 'https://testshop.myshopify.com/admin', @assigned_site.to_s
-      assert_equal 'https://fakeshop.myshopify.com/admin', ShopifyAPI::Base.site.to_s
-    end
-
-    should "create_permission_url returns correct url with single scope no redirect uri" do
-      ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-      session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
-      scope = ["write_products"]
-      permission_url = session.create_permission_url(scope)
-      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
-    end
-
-    should "create_permission_url returns correct url with single scope and redirect uri" do
-      ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-      session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
-      scope = ["write_products"]
-      permission_url = session.create_permission_url(scope, "http://my_redirect_uri.com")
-      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com", permission_url
-    end
-
-    should "create_permission_url returns correct url with dual scope no redirect uri" do
-      ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-      session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
-      scope = ["write_products","write_customers"]
-      permission_url = session.create_permission_url(scope)
-      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
-    end
-
-    should "create_permission_url returns correct url with no scope no redirect uri" do
-      ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-      session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
-      scope = []
-      permission_url = session.create_permission_url(scope)
-      assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=", permission_url
-    end
-
-    should "raise exception if code invalid in request token" do
-      ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
-      session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
-      fake nil, :url => 'https://localhost.myshopify.com/admin/oauth/access_token',:method => :post, :status => 404, :body => '{"error" : "invalid_request"}'
-      assert_raises(ShopifyAPI::ValidationException) do
-        session.request_token(params={:code => "bad-code"})
-      end
-      assert_equal false, session.valid?
-    end
-
-    should "myshopify_domain supports non-standard ports" do
-      begin
-        ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret", :myshopify_domain => 'localhost', port: '3000')
-
-        session = ShopifyAPI::Session.new('fakeshop.localhost:3000', 'token1')
-        ShopifyAPI::Base.activate_session(session)
-        assert_equal 'https://fakeshop.localhost:3000/admin', ShopifyAPI::Base.site.to_s
-
-        session = ShopifyAPI::Session.new('fakeshop', 'token1')
-        ShopifyAPI::Base.activate_session(session)
-        assert_equal 'https://fakeshop.localhost:3000/admin', ShopifyAPI::Base.site.to_s
-      ensure
-        ShopifyAPI::Session.myshopify_domain = "myshopify.com"
-        ShopifyAPI::Session.port = nil
-      end
-    end
-
-    should "return site for session" do
+  test "not raise error without params" do
+    assert_nothing_raised do
       session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
-      assert_equal "https://testshop.myshopify.com/admin", session.site
     end
+  end
 
-    should "return_token_if_signature_is_valid" do
-      ShopifyAPI::Session.secret = 'secret'
-      params = {:code => 'any-code', :timestamp => Time.now}
-      sorted_params = make_sorted_params(params)
-      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
-      fake nil, :url => 'https://testshop.myshopify.com/admin/oauth/access_token',:method => :post, :body => '{"access_token" : "any-token"}'
+  test "raise error if params passed but signature omitted" do
+    assert_raises(ShopifyAPI::ValidationException) do
       session = ShopifyAPI::Session.new("testshop.myshopify.com")
-      token = session.request_token(params.merge(:hmac => signature))
-      assert_equal "any-token", token
+      session.request_token({'code' => 'any-code'})
     end
+  end
 
-    should "raise error if signature does not match expected" do
-      ShopifyAPI::Session.secret = 'secret'
-      params = {:code => "any-code", :timestamp => Time.now}
-      sorted_params = make_sorted_params(params)
-      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
-      params[:foo] = 'world'
-      assert_raises(ShopifyAPI::ValidationException) do
-        session = ShopifyAPI::Session.new("testshop.myshopify.com")
-        session.request_token(params.merge(:hmac => signature))
-      end
+  test "setup api_key and secret for all sessions" do
+    ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
+    assert_equal "My test key", ShopifyAPI::Session.api_key
+    assert_equal "My test secret", ShopifyAPI::Session.secret
+  end
+
+  test "use 'https' protocol by default for all sessions" do
+    assert_equal 'https', ShopifyAPI::Session.protocol
+  end
+
+  test "#temp reset ShopifyAPI::Base.site to original value" do
+
+    ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
+    session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com', 'token1')
+    ShopifyAPI::Base.activate_session(session1)
+
+    ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token") {
+      @assigned_site = ShopifyAPI::Base.site
+    }
+    assert_equal 'https://testshop.myshopify.com/admin', @assigned_site.to_s
+    assert_equal 'https://fakeshop.myshopify.com/admin', ShopifyAPI::Base.site.to_s
+  end
+
+  test "create_permission_url returns correct url with single scope no redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = ["write_products"]
+    permission_url = session.create_permission_url(scope)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
+  end
+
+  test "create_permission_url returns correct url with single scope and redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = ["write_products"]
+    permission_url = session.create_permission_url(scope, "http://my_redirect_uri.com")
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com", permission_url
+  end
+
+  test "create_permission_url returns correct url with dual scope no redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = ["write_products","write_customers"]
+    permission_url = session.create_permission_url(scope)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
+  end
+
+  test "create_permission_url returns correct url with no scope no redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = []
+    permission_url = session.create_permission_url(scope)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=", permission_url
+  end
+
+  test "raise exception if code invalid in request token" do
+    ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    fake nil, :url => 'https://localhost.myshopify.com/admin/oauth/access_token',:method => :post, :status => 404, :body => '{"error" : "invalid_request"}'
+    assert_raises(ShopifyAPI::ValidationException) do
+      session.request_token(params={:code => "bad-code"})
     end
+    assert_equal false, session.valid?
+  end
 
-    should "raise error if timestamp is too old" do
-      ShopifyAPI::Session.secret = 'secret'
-      params = {:code => "any-code", :timestamp => Time.now - 2.days}
-      sorted_params = make_sorted_params(params)
-      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
-      params[:foo] = 'world'
-      assert_raises(ShopifyAPI::ValidationException) do
-        session = ShopifyAPI::Session.new("testshop.myshopify.com")
-        session.request_token(params.merge(:hmac => signature))
-      end
+  test "#temp reset ShopifyAPI::Base.site to original value when using a non-standard port" do
+    ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
+    session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com:3000', 'token1')
+    ShopifyAPI::Base.activate_session(session1)
+  end
+
+  test "myshopify_domain supports non-standard ports" do
+    begin
+      ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret", :myshopify_domain => 'localhost', port: '3000')
+      session = ShopifyAPI::Session.new('fakeshop.localhost:3000', 'token1')
+      ShopifyAPI::Base.activate_session(session)
+      assert_equal 'https://fakeshop.localhost:3000/admin', ShopifyAPI::Base.site.to_s
+
+      session = ShopifyAPI::Session.new('fakeshop', 'token1')
+      ShopifyAPI::Base.activate_session(session)
+      assert_equal 'https://fakeshop.localhost:3000/admin', ShopifyAPI::Base.site.to_s
+    ensure
+      ShopifyAPI::Session.myshopify_domain = "myshopify.com"
+      ShopifyAPI::Session.port = nil
     end
+  end
 
-    should "return true when the signature is valid and the keys of params are strings" do
-      now = Time.now
-      params = {"code" => "any-code", "timestamp" => now}
-      sorted_params = make_sorted_params(params)
-      signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
-      params = {"code" => "any-code", "timestamp" => now, "hmac" => signature}
+  test "return site for session" do
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
+    assert_equal "https://testshop.myshopify.com/admin", session.site
+  end
 
-      assert_equal true, ShopifyAPI::Session.validate_signature(params)
+  test "return_token_if_signature_is_valid" do
+    params = {:code => 'any-code', :timestamp => Time.now}
+    sorted_params = make_sorted_params(params)
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
+    fake nil, :url => 'https://testshop.myshopify.com/admin/oauth/access_token',:method => :post, :body => '{"access_token" : "any-token"}'
+    session = ShopifyAPI::Session.new("testshop.myshopify.com")
+    token = session.request_token(params.merge(:hmac => signature))
+    assert_equal "any-token", token
+  end
+
+  test "raise error if signature does not match expected" do
+    params = {:code => "any-code", :timestamp => Time.now}
+    sorted_params = make_sorted_params(params)
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
+    params[:foo] = 'world'
+    assert_raises(ShopifyAPI::ValidationException) do
+      session = ShopifyAPI::Session.new("testshop.myshopify.com")
+      session.request_token(params.merge(:hmac => signature))
     end
+  end
 
-    should "return true when validating signature of params with ampersand and equal sign characters" do
-      ShopifyAPI::Session.secret = 'secret'
-      params = {'a' => '1&b=2', 'c=3&d' => '4'}
-      to_sign = "a=1%26b=2&c%3D3%26d=4"
-      params['hmac'] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyAPI::Session.secret, to_sign)
-
-      assert_equal true, ShopifyAPI::Session.validate_signature(params)
+  test "raise error if timestamp is too old" do
+    params = {:code => "any-code", :timestamp => Time.now - 2.days}
+    sorted_params = make_sorted_params(params)
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
+    params[:foo] = 'world'
+    assert_raises(ShopifyAPI::ValidationException) do
+      session = ShopifyAPI::Session.new("testshop.myshopify.com")
+      session.request_token(params.merge(:hmac => signature))
     end
+  end
 
-    test "return true when validating signature of params with percent sign characters" do
-      ShopifyAPI::Session.secret = 'secret'
-      params = {'a%3D1%26b' => '2%26c%3D3'}
-      to_sign = "a%253D1%2526b=2%2526c%253D3"
-      params['hmac'] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyAPI::Session.secret, to_sign)
+  test "return true when the signature is valid and the keys of params are strings" do
+    now = Time.now
+    params = {"code" => "any-code", "timestamp" => now}
+    sorted_params = make_sorted_params(params)
+    signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), ShopifyAPI::Session.secret, sorted_params)
+    params = {"code" => "any-code", "timestamp" => now, "hmac" => signature}
+  end
 
-      assert_equal true, ShopifyAPI::Session.validate_signature(params)
-    end
+  test "return true when validating signature of params with ampersand and equal sign characters" do
+    ShopifyAPI::Session.secret = 'secret'
+    params = {'a' => '1&b=2', 'c=3&d' => '4'}
+    to_sign = "a=1%26b=2&c%3D3%26d=4"
+    params['hmac'] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyAPI::Session.secret, to_sign)
 
-    private
+    assert_equal true, ShopifyAPI::Session.validate_signature(params)
+  end
 
-    def make_sorted_params(params)
-      sorted_params = params.with_indifferent_access.except(:signature, :hmac, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join('&')
-    end
+  test "return true when validating signature of params with percent sign characters" do
+    ShopifyAPI::Session.secret = 'secret'
+    params = {'a%3D1%26b' => '2%26c%3D3'}
+    to_sign = "a%253D1%2526b=2%2526c%253D3"
+    params['hmac'] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyAPI::Session.secret, to_sign)
 
+    assert_equal true, ShopifyAPI::Session.validate_signature(params)
+  end
+
+  private
+
+  def make_sorted_params(params)
+    sorted_params = params.with_indifferent_access.except(:signature, :hmac, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join('&')
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'rubygems'
-require 'test/unit'
+require 'minitest/autorun'
 require 'fakeweb'
 require 'mocha/setup'
 
@@ -10,8 +10,12 @@ require 'shopify_api'
 FakeWeb.allow_net_connect = false
 
 # setup ShopifyAPI with fake api_key and secret
+module Test
+  module Unit
+  end
+end
 
-class Test::Unit::TestCase
+class Test::Unit::TestCase < Minitest::Unit::TestCase
   def self.test(string, &block)
     define_method("test:#{string}", &block)
   end
@@ -46,11 +50,27 @@ class Test::Unit::TestCase
 
   # Custom Assertions
   def assert_not(expression)
-    assert_block("Expected <#{expression}> to be false!") { not expression }
+    refute expression, "Expected <#{expression}> to be false!"
+  end
+
+  def assert_nothing_raised
+    yield
+  end
+
+  def assert_not_includes(array, value)
+    refute array.include?(value)
+  end
+
+  def assert_includes(array, value)
+    assert array.include?(value)
   end
 
   def load_fixture(name, format=:json)
     File.read(File.dirname(__FILE__) + "/fixtures/#{name}.#{format}")
+  end
+
+  def assert_request_body(expected)
+    assert_equal expected, FakeWeb.last_request.body
   end
 
   def fake(endpoint, options={})


### PR DESCRIPTION
Parameters being sent to the orders API were being
attached to the query string instead of added to the body.

As a result their truthiness was being lost and all calls to
cancel an order would result in an email being delivered to
the customer.

----

There is still an underlying issue with the API in that URL Encoded forms with values like `email=false` result in stringy values instead of boolean ones. We should probably patch Shopify anyway, and as a result _could_ throw out this PR. I'd like some thoughts on that as well.

for review @maartenvg @edward 

for context take a look at: https://github.com/Shopify/shopify/issues/38454