### PR TITLE
Add support for token revocation

### DIFF
--- a/lib/shopify_api/resources/o_auth.rb
+++ b/lib/shopify_api/resources/o_auth.rb
@@ -1,0 +1,9 @@
+module ShopifyAPI
+  class OAuth < Base
+    self.collection_name = 'oauth'
+
+    def self.revoke
+      delete(:revoke)
+    end
+  end
+end

--- a/test/fixtures/o_auth_revoke.json
+++ b/test/fixtures/o_auth_revoke.json
@@ -1,0 +1,5 @@
+{
+  "permission": {
+    "access_token": "8ccb0232e04c672bf044f71ff0156098"
+  }
+}

--- a/test/o_auth_test.rb
+++ b/test/o_auth_test.rb
@@ -1,0 +1,8 @@
+require 'test_helper'
+
+class OAuthTest < Test::Unit::TestCase
+  def test_revoke_kills_the_token
+    fake 'oauth/revoke', method: :delete, body: load_fixture('o_auth_revoke')
+    assert ShopifyAPI::OAuth.revoke
+  end
+end


### PR DESCRIPTION
## Problem

We don't provide an easy way to revoke an OAuth token.

## Solution

OAuth tokens can be revoked with `ShopifyAPI::OAuth.revoke` .

/related Shopify/facebook-commerce#2765
/review @awd, @ilikeorangutans