### PR TITLE
Add a myshopify_domain class variable to use for building the site url.

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -6,10 +6,9 @@ module ShopifyAPI
   end
 
   class Session
-    cattr_accessor :api_key
-    cattr_accessor :secret
-    cattr_accessor :protocol
+    cattr_accessor :api_key, :secret, :protocol, :myshopify_domain, :port
     self.protocol = 'https'
+    self.myshopify_domain = 'myshopify.com'
 
     attr_accessor :url, :token, :name
 
@@ -21,12 +20,9 @@ module ShopifyAPI
 
       def temp(domain, token, &block)
         session = new(domain, token)
-        begin
-          original_domain = host_with_port(ShopifyAPI::Base.site.to_s)
-        rescue URI::InvalidURIError
-        end
-        original_token   = ShopifyAPI::Base.headers['X-Shopify-Access-Token']
-        original_session = new(original_domain, original_token)
+        original_site = ShopifyAPI::Base.site.to_s
+        original_token = ShopifyAPI::Base.headers['X-Shopify-Access-Token']
+        original_session = new(original_site, original_token)
 
         begin
           ShopifyAPI::Base.activate_session(session)
@@ -38,8 +34,19 @@ module ShopifyAPI
 
       def prepare_url(url)
         return nil if url.blank?
-        url.gsub!(/https?:\/\//, '')                            # remove http:// or https://
-        url.concat(".myshopify.com") unless url.include?('.')   # extend url to myshopify.com if no host is given
+        # remove http:// or https://
+        url = url.strip.gsub(/\Ahttps?:\/\//, '')
+        # extract host, removing any username, password or path
+        shop = URI.parse("https://#{url}").host
+        # extract subdomain of .myshopify.com
+        if idx = shop.index(".")
+          shop = shop.slice(0, idx)
+        end
+        return nil if shop.empty?
+        shop = "#{shop}.#{myshopify_domain}"
+        port ? "#{shop}:#{port}" : shop
+      rescue URI::InvalidURIError
+        nil
       end
 
       def validate_signature(params)
@@ -49,29 +56,17 @@ module ShopifyAPI
         sorted_params = params.except(:signature, :hmac, :action, :controller).collect{|k,v|"#{k}=#{v}"}.sort.join('&')
         OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), secret, sorted_params) == signature
       end
-
-      def host_with_port(site)
-        parsed_site = URI.parse(site)
-        host = parsed_site.host or return
-        port = parsed_site.port
-        if (protocol == 'http' && port == 80) || (protocol == 'https' && port == 443)
-          host
-        else
-          "#{host}:#{port}"
-        end
-      end
-
     end
 
     def initialize(url, token = nil)
-      self.url, self.token = url, token
-      self.class.prepare_url(self.url)
+      self.url = self.class.prepare_url(url)
+      self.token = token
     end
 
     def create_permission_url(scope, redirect_uri = nil)
       params = {:client_id => api_key, :scope => scope.join(',')}
       params[:redirect_uri] = redirect_uri if redirect_uri
-      "#{protocol}://#{url}/admin/oauth/authorize?#{parameterize(params)}"
+      "#{site}/oauth/authorize?#{parameterize(params)}"
     end
 
     def request_token(params)


### PR DESCRIPTION
@clayton-shopify & @kevinhughes27 

This is an extra precaution to make sure requests always go to a .myshopify.com domain.

For development, there is still a ShopifyAPI::Session.myshopify_domain class variable that can be modified outside of the production environment.