### PR TITLE
Escape ampersand in params or equal in keys before signing with hmac.

### DIFF
--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -25,6 +25,7 @@ Gem::Specification.new do |s|
   s.license = 'MIT'
 
   s.add_dependency("activeresource")
+  s.add_dependency("rack")
 
   dev_dependencies = [['mocha', '>= 0.9.8'],
                       ['fakeweb'], 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -171,6 +171,15 @@ class SessionTest < Test::Unit::TestCase
       assert_equal true, ShopifyAPI::Session.validate_signature(params)
     end
 
+    should "return true when validating signature of params with ampersand and equal sign characters" do
+      ShopifyAPI::Session.secret = 'secret'
+      params = {'a' => '1&b=2', 'c=3&d' => '4'}
+      to_sign = "a=1%26b=2&c%3D3%26d=4"
+      params['hmac'] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyAPI::Session.secret, to_sign)
+
+      assert_equal true, ShopifyAPI::Session.validate_signature(params)
+    end
+
     private
 
     def make_sorted_params(params)

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -180,6 +180,15 @@ class SessionTest < Test::Unit::TestCase
       assert_equal true, ShopifyAPI::Session.validate_signature(params)
     end
 
+    test "return true when validating signature of params with percent sign characters" do
+      ShopifyAPI::Session.secret = 'secret'
+      params = {'a%3D1%26b' => '2%26c%3D3'}
+      to_sign = "a%253D1%2526b=2%2526c%253D3"
+      params['hmac'] = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha256'), ShopifyAPI::Session.secret, to_sign)
+
+      assert_equal true, ShopifyAPI::Session.validate_signature(params)
+    end
+
     private
 
     def make_sorted_params(params)


### PR DESCRIPTION
@csaunders & @clayton-shopify for review

This implements the same escaping that we added in Shopify for generating the signature to prevent delimiters from being added to tamper with params without changing the signature.  In the uncommon cases where these delimiters do appear in the keys or values, this pull request will make sure the signature is properly validated.