### PR TITLE
Calculate credit_limit per shop

### DIFF
--- a/lib/shopify_api/limits.rb
+++ b/lib/shopify_api/limits.rb
@@ -39,8 +39,7 @@ module ShopifyAPI
       # @return {Integer}
       #
       def credit_limit(scope=:shop)
-        @api_credit_limit ||= {}
-        @api_credit_limit[scope] ||= api_credit_limit_param(scope).pop.to_i - 1
+        api_credit_limit_param(scope).pop.to_i - 1
       end
       alias_method :call_limit, :credit_limit
 


### PR DESCRIPTION
Shopify Plus plans have double the API request limit of non-plus plans (bursts of 80 requests as opposed to 40 with the regular plans).

Prior to the changes made below, if `@api_credit_limit[:shop]` was initialized with the response from a Shopify Plus shop, then subsequent calls to `credit_limit` would always return 79 regardless of whether or not the shop had the higher request limit. Since `credit_left` uses `credit_limit`, requests made to non-Plus shops could be made under the pretense that they had more requests remaining than they actually did, triggering 429 errors in the process. 

The changes in this pull request prevent setting a global request limit by calculating the credit limit for each shop as part of each request/response cycle. 
