### PR TITLE
[amends https://github.com/Shopify/shopify_api/issues/138]

### DIFF
--- a/test/image_test.rb
+++ b/test/image_test.rb
@@ -36,4 +36,10 @@ class ImageTest < Test::Unit::TestCase
     image = ShopifyAPI::Image.new(product_id: 632910392, id: 850703190)
     assert image.destroy
   end
+
+  def test_delete_image_with_one_call
+    fake "products/632910392/images/850703190", :method => :delete, :body => "destroyed"
+    response = ShopifyAPI::Image.delete(850703190, product_id: 632910392)
+    assert_equal '200', response.code
+  end
 end


### PR DESCRIPTION
Document alternate syntax for deleting an image with one api call.

I added a test for deleting an image using the syntax mentioned by:
@Hammadk 

In this comment: https://github.com/Shopify/shopify_api/issues/138#issuecomment-50498732

In my use case I wanted to delete an image with one API call, not fetch the image and then delete it using a subsequent call. The gem already supports this syntax, it's just buried in this github issue: https://github.com/Shopify/shopify_api/issues/138

With it added to the tests it should be easier for people to discover in the future.
