### PR TITLE
Add support to fulfillment events

### DIFF
--- a/lib/shopify_api/resources/fulfillment_event.rb
+++ b/lib/shopify_api/resources/fulfillment_event.rb
@@ -1,0 +1,15 @@
+module ShopifyAPI
+  class FulfillmentEvent < Base
+    self.prefix = '/admin/orders/:order_id/fulfillments/:fulfillment_id/'
+    self.collection_name = 'events'
+    self.element_name = 'event'
+
+    def order_id
+      @prefix_options[:order_id]
+    end
+
+    def fulfillment_id
+      @prefix_options[:fulfillment_id]
+    end
+  end
+end

--- a/test/fixtures/fulfillment_event.json
+++ b/test/fixtures/fulfillment_event.json
@@ -1,0 +1,12 @@
+{
+  "event": {
+    "created_at": "2013-11-01T16:06:08-04:00",
+    "updated_at": "2013-11-01T16:06:08-04:00",
+    "id": 334455,
+    "fulfillment_id": 255858046,
+    "order_id": 450789469,
+    "status": "in_transit",
+    "happened_at": "2013-11-01T16:06:08-04:00",
+    "estimated_delivery_date": "2013-11-15T18:00:00-04:00"
+  }
+}

--- a/test/fulfillment_event_test.rb
+++ b/test/fulfillment_event_test.rb
@@ -1,0 +1,69 @@
+require 'test_helper'
+
+class FulFillmentEventTest < Test::Unit::TestCase
+  def test_find_all_resources
+    fake 'orders/450789469/fulfillments/255858046/events',
+         method: :get,
+         body: "[#{load_fixture('fulfillment_event')}]"
+
+    events = ShopifyAPI::FulfillmentEvent.all(
+      params: { fulfillment_id: 255858046, order_id: 450789469 }
+    )
+
+    assert_equal 1, events.count
+  end
+
+  def test_find_a_resource
+    fake 'orders/450789469/fulfillments/255858046/events/334455',
+         method: :get,
+         body: load_fixture('fulfillment_event')
+
+    event = ShopifyAPI::FulfillmentEvent.find(
+      334455, params: { fulfillment_id: 255858046, order_id: 450789469 }
+    )
+
+    assert_equal 'in_transit', event.status
+    assert_equal 255858046, event.fulfillment_id
+    assert_equal 450789469, event.order_id
+  end
+
+  def test_create_a_resource
+    fake 'orders/450789469/fulfillments/255858046/events', method: :post, body: ''
+
+    event = ShopifyAPI::FulfillmentEvent.new(
+      fulfillment_id: 255858046,
+      order_id: 450789469,
+      status: 'in_transit'
+    )
+
+    assert event.save
+  end
+
+  def test_update_a_resource
+    fake 'orders/450789469/fulfillments/255858046/events/334455',
+         method: :get,
+         body: load_fixture('fulfillment_event')
+
+    event = ShopifyAPI::FulfillmentEvent.find(
+      334455, params: { fulfillment_id: 255858046, order_id: 450789469 }
+    )
+
+    fake 'orders/450789469/fulfillments/255858046/events/334455', method: :put, body: ''
+
+    assert event.save
+  end
+
+  def test_destroy_a_resource
+    fake 'orders/450789469/fulfillments/255858046/events/334455',
+         method: :get,
+         body: load_fixture('fulfillment_event')
+
+    event = ShopifyAPI::FulfillmentEvent.find(
+      334455, params: { fulfillment_id: 255858046, order_id: 450789469 }
+    )
+
+    fake 'orders/450789469/fulfillments/255858046/events/334455', method: :delete, body: ''
+
+    assert event.destroy
+  end
+end


### PR DESCRIPTION
This PR adds support to fulfillment events. Fulfillment events are simple resources that can be CRUDed under `/admin/orders/:order_id/fulfillments/:fulfillment_id/events`.

Please review @christianblais @csaunders 