### PR TITLE
Create CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,4 +5,4 @@ Please open an issue here if you encounter a specific bug with this API client l
 
 General questions about the Shopify API and usage of this package (not neccessarily a bug) should be posted on the [Shopify forums](https://ecommerce.shopify.com/c/shopify-apis-and-technology).
 
-When in doubt post on the forum first as more people are monitoring there and you'll likely get your answer quicker. 
+When in doubt, post on the forum first. You'll likely have your questions answered more quickly if you post there; more people monitor the forum than Github.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,8 @@
+Submitting Issues
+-----------------
+
+Please open an issue here if you encounter a specific bug with this API client library or if something is documented here https://docs.shopify.com/api but is missing from this package.
+
+General questions about the Shopify API and usage of this package (not neccessarily a bug) should be posted on the [Shopify forums](https://ecommerce.shopify.com/c/shopify-apis-and-technology).
+
+When in doubt post on the forum first as more people are monitoring there and you'll likely get your answer quicker. 


### PR DESCRIPTION
I'd like to add this file to help direct more questions to the forums rather than on Github where less people are watching.

This is what it will look like when people are submitting issues after this:
https://github.com/blog/1184-contributing-guidelines

Thoughts? I'd like to do the same for the python lib as well.
@ShayneP @joshubrown @atleeclark 
