### PR TITLE
String errors should be added to :base

### DIFF
--- a/lib/active_resource/json_errors.rb
+++ b/lib/active_resource/json_errors.rb
@@ -25,7 +25,7 @@ module ActiveResource
     def from_string(error, save_cache = false)
       clear unless save_cache
 
-      add("message", error)
+      add(:base, error)
     end
   end
 end

--- a/test/active_resource/json_errors_test.rb
+++ b/test/active_resource/json_errors_test.rb
@@ -4,19 +4,16 @@ module ActiveResource
   class JsonErrorsTest < Test::Unit::TestCase
 
     def test_parsing_of_error_json_hash
-      errors = some_error.from_json({errors: {name: ['missing']}}.to_json)
-      assert_equal({"name"=>["missing"]}, errors)
+      @model = ShopifyAPI::Order.new
+      @model.errors.from_json({errors: {name: ['missing']}}.to_json)
+      assert_equal ['missing'], @model.errors[:name]
     end
 
     def test_parsing_of_error_json_plain_string
-      errors = some_error.from_json({errors: 'some generic error'}.to_json)
-      assert_equal(["some generic error"], errors)
-    end
-
-    private
-
-    def some_error
-      ActiveResource::Errors.new(ShopifyAPI::Order.new)
+      @model = ShopifyAPI::Order.new
+      @model.errors.from_json({errors: 'some generic error'}.to_json)
+      assert_equal ['some generic error'], @model.errors[:base]
+      assert_equal 'some generic error', @model.errors.full_messages.to_sentence
     end
   end
 end


### PR DESCRIPTION
The fix in https://github.com/Shopify/shopify_api/pull/107 was wrong IMO. As the documentation states, `attribute should be set to :base if the error is not directly associated with a single attribute.`

@kevinhughes27 @maartenvg  