### PR TITLE
Add shipping zone resource

### DIFF
--- a/lib/shopify_api/resources/shipping_zone.rb
+++ b/lib/shopify_api/resources/shipping_zone.rb
@@ -1,0 +1,4 @@
+module ShopifyAPI
+  class ShippingZone < Base
+  end
+end

--- a/test/fixtures/shipping_zones.json
+++ b/test/fixtures/shipping_zones.json
@@ -1,0 +1,315 @@
+{
+  "shipping_zones": [
+    {
+      "id": 1,
+      "name": "Canada",
+      "countries": [
+        {
+          "id": 189,
+          "name": "Canada",
+          "tax": 0,
+          "code": "CA",
+          "tax_name": "GST",
+          "provinces": [
+            {
+              "id": 1,
+              "country_id": 189,
+              "name": "Alberta",
+              "code": "AB",
+              "tax": 0,
+              "tax_name": "PST",
+              "tax_type": null,
+              "shipping_zone_id": 1,
+              "tax_percentage": 0
+            },
+            {
+              "id": 2,
+              "country_id": 189,
+              "name": "British Columbia",
+              "code": "BC",
+              "tax": 0,
+              "tax_name": "PST",
+              "tax_type": null,
+              "shipping_zone_id": 1,
+              "tax_percentage": 0
+            },
+            {
+              "id": 9,
+              "country_id": 189,
+              "name": "Ontario",
+              "code": "ON",
+              "tax": 0,
+              "tax_name": "HST",
+              "tax_type": "harmonized",
+              "shipping_zone_id": 1,
+              "tax_percentage": 0
+            },
+            {
+              "id": 11,
+              "country_id": 189,
+              "name": "Quebec",
+              "code": "QC",
+              "tax": 0,
+              "tax_name": "QST",
+              "tax_type": null,
+              "shipping_zone_id": 1,
+              "tax_percentage": 0
+            }
+          ]
+        }
+      ],
+      "weight_based_shipping_rates": [
+        {
+          "id": 1,
+          "weight_low": 0,
+          "weight_high": 55.12,
+          "name": "Lighter items",
+          "price": "10.00",
+          "shipping_zone_id": 1
+        }
+      ],
+      "price_based_shipping_rates": [
+        {
+          "id": 1,
+          "name": "Cheaper items",
+          "min_order_subtotal": "0.00",
+          "price": "100.00",
+          "max_order_subtotal": "50.00",
+          "shipping_zone_id": 1
+        }
+      ],
+      "carrier_shipping_rate_providers": [
+        {
+          "id": 81,
+          "country_id": null,
+          "carrier_service_id": 15,
+          "percent_modifier": 1,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 1
+        },
+        {
+          "id": 454,
+          "country_id": null,
+          "carrier_service_id": 17,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 1
+        },
+        {
+          "id": 457,
+          "country_id": null,
+          "carrier_service_id": 21,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 1
+        },
+        {
+          "id": 460,
+          "country_id": null,
+          "carrier_service_id": 22,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 1
+        }
+      ]
+    },
+    {
+      "id": 2,
+      "name": "US",
+      "countries": [
+        {
+          "id": 190,
+          "name": "United States",
+          "tax": 0,
+          "code": "US",
+          "tax_name": "Federal Tax",
+          "provinces": [
+            {
+              "id": 58,
+              "country_id": 190,
+              "name": "Puerto Rico",
+              "code": "PR",
+              "tax": 0,
+              "tax_name": "State Tax",
+              "tax_type": null,
+              "shipping_zone_id": 2,
+              "tax_percentage": 0
+            },
+            {
+              "id": 67,
+              "country_id": 190,
+              "name": "Washington",
+              "code": "WA",
+              "tax": 0,
+              "tax_name": "State Tax",
+              "tax_type": null,
+              "shipping_zone_id": 2,
+              "tax_percentage": 0
+            },
+            {
+              "id": 70,
+              "country_id": 190,
+              "name": "Wisconsin",
+              "code": "WI",
+              "tax": 0,
+              "tax_name": "State Tax",
+              "tax_type": null,
+              "shipping_zone_id": 2,
+              "tax_percentage": 0
+            },
+            {
+              "id": 71,
+              "country_id": 190,
+              "name": "Wyoming",
+              "code": "WY",
+              "tax": 0,
+              "tax_name": "State Tax",
+              "tax_type": null,
+              "shipping_zone_id": 2,
+              "tax_percentage": 0
+            }
+          ]
+        }
+      ],
+      "weight_based_shipping_rates": [
+        
+      ],
+      "price_based_shipping_rates": [
+        
+      ],
+      "carrier_shipping_rate_providers": [
+        {
+          "id": 455,
+          "country_id": null,
+          "carrier_service_id": 17,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 2
+        },
+        {
+          "id": 458,
+          "country_id": null,
+          "carrier_service_id": 21,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 2
+        },
+        {
+          "id": 461,
+          "country_id": null,
+          "carrier_service_id": 22,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 2
+        },
+        {
+          "id": 475,
+          "country_id": null,
+          "carrier_service_id": 15,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 2
+        }
+      ]
+    },
+    {
+      "id": 7,
+      "name": "UK",
+      "countries": [
+        {
+          "id": 195,
+          "name": "United Kingdom",
+          "tax": 0,
+          "code": "GB",
+          "tax_name": "VAT",
+          "provinces": [
+            
+          ]
+        }
+      ],
+      "weight_based_shipping_rates": [
+        
+      ],
+      "price_based_shipping_rates": [
+        {
+          "id": 2,
+          "name": "Some name",
+          "min_order_subtotal": "0.00",
+          "price": "30.00",
+          "max_order_subtotal": "29.99",
+          "shipping_zone_id": 7
+        }
+      ],
+      "carrier_shipping_rate_providers": [
+        {
+          "id": 456,
+          "country_id": null,
+          "carrier_service_id": 17,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 7
+        },
+        {
+          "id": 459,
+          "country_id": null,
+          "carrier_service_id": 21,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 7
+        },
+        {
+          "id": 462,
+          "country_id": null,
+          "carrier_service_id": 22,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 7
+        },
+        {
+          "id": 476,
+          "country_id": null,
+          "carrier_service_id": 15,
+          "percent_modifier": 0,
+          "service_filter": {
+            "*": "+"
+          },
+          "flat_modifier": "0.00",
+          "shipping_zone_id": 7
+        }
+      ]
+    }
+  ]
+}

--- a/test/shipping_zone_test.rb
+++ b/test/shipping_zone_test.rb
@@ -1,0 +1,10 @@
+require 'test_helper'
+
+class ShippingZoneTest < Test::Unit::TestCase
+  test "get all should get all shipping zones" do
+    fake 'shipping_zones', :method => :get, :status => 200, :body => load_fixture('shipping_zones')
+    checkout = ShopifyAPI::ShippingZone.all
+    assert_equal 1, checkout.first.id
+    assert_equal "Canada", checkout.first.name
+  end
+end


### PR DESCRIPTION
### Problem

We moved everyone over to shipping zones, and it has made all the rates that are showing on the countries resource invalid.

### Solution

I have a PR on shopify's side to add the shipping zone endpoint, this adds the resource.

@shawnfrench @csaunders 