### PR TITLE
Add default timeout to ShopifyAPI::Base

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 4.1.1
+
+* Added explicit 90 second timeout to `ShopifyAPI::Base`
+
 == Version 4.0.7
 
 * Added `ShippingAPI::ShippingZone`

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -4,6 +4,7 @@ module ShopifyAPI
   class Base < ActiveResource::Base
     class InvalidSessionError < StandardError; end
     extend Countable
+    self.timeout = 90
     self.include_root_in_json = false
     self.headers['User-Agent'] = ["ShopifyAPI/#{ShopifyAPI::VERSION}",
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.1.0"
+  VERSION = "4.1.1"
 end


### PR DESCRIPTION
@maartenvg @celsodantas @peterjm 

Closes #225

There is not default timeout on `ShopifyAPI::Base` (it's `nil` 😔). This introduces a ~~25~~ 90 second default timeout for API requests.