### PR TITLE
Adds friendlier error message for missing site URI

### DIFF
--- a/lib/active_resource/connection_ext.rb
+++ b/lib/active_resource/connection_ext.rb
@@ -5,6 +5,15 @@ module ActiveResource
 
     attr_reader :response
 
+    alias_method :raw_initialize, :initialize
+
+    def initialize(site, *args)
+      if site.blank?
+        raise ArgumentError, 'Missing site URI. Make sure ShopifyAPI calls are wrapped in a Shopify session'
+      end
+      raw_initialize(site, *args)
+    end
+
     def handle_response_with_response_capture(response)
       @response = handle_response_without_response_capture(response)
     end

--- a/test/active_resource/connection_test.rb
+++ b/test/active_resource/connection_test.rb
@@ -1,0 +1,17 @@
+require 'test_helper'
+
+class ConnectionTest < Test::Unit::TestCase
+  test 'initialize with a nil site should raise an exception' do
+    error = assert_raises ArgumentError do
+      ActiveResource::Connection.new(nil)
+    end
+    assert_equal 'Missing site URI. Make sure ShopifyAPI calls are wrapped in a Shopify session', error.message
+  end
+
+  test 'initialize with a site should not raise an exception' do
+    assert_nothing_raised do
+      connection = ActiveResource::Connection.new('some_site.com')
+      assert_equal 'some_site.com', connection.site.to_s
+    end
+  end
+end


### PR DESCRIPTION
It came up on Slack #developers-talk and on [stack overflow](http://stackoverflow.com/questions/35091476/shopify-gem-create-products-from-database-script) that it is very common to forget to be in a Shopify session when using the Shopify API, and the error message isn't great, just `"Missing site URI"`.

It would help everyone if we make the error message better (the copy can change; IIRC in the context of this gem all that matters is `ShopifyAPI::Base.site` being set, whereas in the `shopify_app` gem you generally would use a `shop.with_shopify_session {}` wrapper)
