### PR TITLE
bump gem to 4.1.0

### DIFF
--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.0.7"
+  VERSION = "4.1.0"
 end


### PR DESCRIPTION
## Description
- bump gem to 4.1.0, can't deploy without changing version number

@Shopify/finance @dominiquesr 