### PR TITLE
Revert "bump gem to 4.1.0"

### DIFF
--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.1.0"
+  VERSION = "4.0.7"
 end


### PR DESCRIPTION
Reverts Shopify/shopify_api#242