### PR TITLE
Better detection of threadsafe ActiveResource

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ gemfile:
   - Gemfile_ar32
   - Gemfile_ar40threadsafe
   - Gemfile_ar42threadsafe
-  - Gemfile_ar50
 
 sudo: false
 
@@ -19,6 +18,8 @@ before_script: echo $OLD_RAKE
 
 matrix:
   include:
+    - rvm: 2.2.1
+      gemfile: Gemfile_ar50
     - rvm: 1.9.2
       gemfile: Gemfile_ar30
       env: OLD_RAKE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ gemfile:
   - Gemfile_ar31
   - Gemfile_ar32
   - Gemfile_ar40threadsafe
+  - Gemfile_ar42threadsafe
+  - Gemfile_ar50
 
 sudo: false
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 4.2.0
+
+* Threadsafety is now compatible with the latest ActiveResource master
+
 == Version 4.1.1
 
 * Added explicit 90 second timeout to `ShopifyAPI::Base`

--- a/Gemfile_ar50
+++ b/Gemfile_ar50
@@ -1,0 +1,11 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem 'activeresource', git: 'git://github.com/rails/activeresource', ref: 'c3cd2b535b7c5cdc12cc6a3c1e11be6c74ffa179'
+
+gem 'minitest', "~> 5.1"
+gem 'activesupport', github: 'rails/rails'
+gem 'activemodel', github: 'rails/rails'
+gem 'arel', github: 'rails/arel'
+gem 'rails-observers', github: 'rails/rails-observers'

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -28,7 +28,7 @@ module ShopifyAPI
     end
 
     class << self
-      if ActiveResource::VERSION::MAJOR == 4 && ActiveResource::VERSION::PRE == 'threadsafe'
+      if ActiveResource::Base.respond_to?(:_headers) && ActiveResource::Base.respond_to?(:_headers_defined?)
         def headers
           if _headers_defined?
             _headers

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.1.1"
+  VERSION = "4.2.0"
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -88,7 +88,7 @@ class BaseTest < Test::Unit::TestCase
     end
   end
 
-  if ActiveResource::VERSION::MAJOR >= 4 && ActiveResource::VERSION::PRE == "threadsafe"
+  if ActiveResource::VERSION::MAJOR > 5 || (ActiveResource::VERSION::MAJOR >= 4 && ActiveResource::VERSION::PRE == "threadsafe")
     test "#headers set in the main thread affect spawned threads" do
       ShopifyAPI::Base.headers['X-Custom'] = "the value"
       Thread.new do

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -88,7 +88,7 @@ class BaseTest < Test::Unit::TestCase
     end
   end
 
-  if ActiveResource::VERSION::MAJOR > 5 || (ActiveResource::VERSION::MAJOR >= 4 && ActiveResource::VERSION::PRE == "threadsafe")
+  if ActiveResource::VERSION::MAJOR >= 5 || (ActiveResource::VERSION::MAJOR >= 4 && ActiveResource::VERSION::PRE == "threadsafe")
     test "#headers set in the main thread affect spawned threads" do
       ShopifyAPI::Base.headers['X-Custom'] = "the value"
       Thread.new do

--- a/test/recurring_application_charge_test.rb
+++ b/test/recurring_application_charge_test.rb
@@ -137,7 +137,7 @@ class RecurringApplicationChargeTest < Test::Unit::TestCase
     fake "recurring_application_charges", body: '{"errors":"Not Found"}', status: 404
 
     all_application_charges = ShopifyAPI::RecurringApplicationCharge.all
-    if ActiveResource::VERSION::MAJOR >= 4 && ActiveResource::VERSION::MINOR >= 2
+    if ActiveResource::VERSION::MAJOR >= 5 || (ActiveResource::VERSION::MAJOR == 4 && ActiveResource::VERSION::MINOR >= 2)
       assert_equal [], all_application_charges
     else
       assert_equal nil, all_application_charges


### PR DESCRIPTION
@alexaitken @kevinhughes27 @ch33sybr3ad

Fixes https://github.com/Shopify/shopify_api/issues/194

## Problem

`ShopifyAPI::Base.headers` behaves differently, depending on whether we've detected that we're using the threadsafe version of ActiveResource, or the non-threadsafe version of ActiveResource.

Right now, we're detecting that based on the version number of the `activeresource` gem. This isn't a sustainable solution, because:

1. It assumes that the "pre" string is "threadsafe", which is only defined in Shopify's fork of ActiveResource. Now that core ActiveResource contains the threadsafe changes, we should start to work with that instead of just our own fork.

2. It only works with major version 4, and core ActiveResource is now at version 5

## Solution

Instead of detecting the version string, directly check that the methods we want to use are available on `ActiveResource::Base`

## Food for Thought

This is still an unsatisfying solution. The best thing would be to not override the `headers` method at all. Is this change really necessary? If it is necessary, is this something that can be pushed to core ActiveResource?

Compared to the [`ActiveResource::Base.headers`](https://github.com/rails/activeresource/blob/c3cd2b535b7c5cdc12cc6a3c1e11be6c74ffa179/lib/active_resource/base.rb#L652-L659), it seems like the behaviour in ActiveResource is to merge the class's headers with the superclass's headers. The behaviour in ShopifyAPI is to return either the superclass's headers or the class's headers.

This was originally added here: https://github.com/Shopify/shopify_api/pull/19

Looks like it was to support oauth changes