### PR TITLE
Add missing order_id prefix_option to Fulfillment resource

### DIFF
--- a/lib/shopify_api/resources/fulfillment.rb
+++ b/lib/shopify_api/resources/fulfillment.rb
@@ -2,6 +2,10 @@ module ShopifyAPI
   class Fulfillment < Base
     init_prefix :order
 
+    def order_id
+      @prefix_options[:order_id]
+    end
+
     def cancel; load_attributes_from_response(post(:cancel, {}, only_id)); end
     def complete; load_attributes_from_response(post(:complete, {}, only_id)); end
   end

--- a/test/fulfillment_test.rb
+++ b/test/fulfillment_test.rb
@@ -33,6 +33,14 @@ class FulFillmentTest < Test::Unit::TestCase
         assert_equal 'cancelled', fulfillment.status
       end
     end
+
+    context "#find" do
+      should "be able to find fulfillment" do
+        fulfillment = ShopifyAPI::Fulfillment.find(255858046, :params => {:order_id => 450789469})
+        assert_equal 255858046, fulfillment.id
+        assert_equal 450789469, fulfillment.order_id
+      end
+    end
   end
 
 end


### PR DESCRIPTION
This pull request resolve #253 issue add missing `order_id` prefix_option.