### PR TITLE
Add Customer#account_activation_url method

### DIFF
--- a/lib/shopify_api/resources/customer.rb
+++ b/lib/shopify_api/resources/customer.rb
@@ -9,5 +9,16 @@ module ShopifyAPI
     def self.search(params)
       find(:all, from: :search, params: params)
     end
+
+    def account_activation_url
+      resource = post(:account_activation_url, {}, only_id)
+      data = ActiveSupport::JSON.decode(resource.body.to_s)
+      result = nil
+
+      if data.key?('account_activation_url')
+        result = data['account_activation_url']
+      end
+      result
+    end
   end
 end

--- a/test/customer_test.rb
+++ b/test/customer_test.rb
@@ -1,10 +1,20 @@
 require 'test_helper'
 
 class CustomerTest < Test::Unit::TestCase
-  def test_search
-    fake "customers/search.json?query=Bob+country%3AUnited+States", extension: false, body: load_fixture('customers_search')
+
+  test "search should get a customers collection" do
+    fake "customers/search.json?query=Bob+country%3AUnited+States", :extension => false, :body => load_fixture('customers_search')
 
     results = ShopifyAPI::Customer.search(query: 'Bob country:United States')
     assert_equal 'Bob', results.first.first_name
+  end
+
+  test "account_activation_url should create an account activation url" do
+    fake "customers/207119551", :body => load_fixture('customers')
+    fake "customers/207119551/account_activation_url", :method => :post, :body => load_fixture('customers_account_activation_url')
+
+    customer = ShopifyAPI::Customer.find(207119551)
+    activation_url = "http://apple.myshopify.com/account/activate/207119551/86688abf23572680740b1c062fa37111-1458248616"
+    assert_equal activation_url, customer.account_activation_url
   end
 end

--- a/test/fixtures/customers.json
+++ b/test/fixtures/customers.json
@@ -1,0 +1,59 @@
+{
+  "customer": {
+    "id": 207119551,
+    "email": "bob.norman@hostmail.com",
+    "accepts_marketing": false,
+    "created_at": "2016-03-17T17:04:13-04:00",
+    "updated_at": "2016-03-17T17:04:13-04:00",
+    "first_name": "Bob",
+    "last_name": "Norman",
+    "orders_count": 1,
+    "state": "disabled",
+    "total_spent": "41.94",
+    "last_order_id": 450789469,
+    "note": null,
+    "verified_email": true,
+    "multipass_identifier": null,
+    "tax_exempt": false,
+    "tags": "",
+    "last_order_name": "#1001",
+    "default_address": {
+      "id": 207119551,
+      "first_name": null,
+      "last_name": null,
+      "company": null,
+      "address1": "Chestnut Street 92",
+      "address2": "",
+      "city": "Louisville",
+      "province": "Kentucky",
+      "country": "United States",
+      "zip": "40202",
+      "phone": "555-625-1199",
+      "name": "",
+      "province_code": "KY",
+      "country_code": "US",
+      "country_name": "United States",
+      "default": true
+    },
+    "addresses": [
+      {
+        "id": 207119551,
+        "first_name": null,
+        "last_name": null,
+        "company": null,
+        "address1": "Chestnut Street 92",
+        "address2": "",
+        "city": "Louisville",
+        "province": "Kentucky",
+        "country": "United States",
+        "zip": "40202",
+        "phone": "555-625-1199",
+        "name": "",
+        "province_code": "KY",
+        "country_code": "US",
+        "country_name": "United States",
+        "default": true
+      }
+    ]
+  }
+}

--- a/test/fixtures/customers_account_activation_url.json
+++ b/test/fixtures/customers_account_activation_url.json
@@ -1,0 +1,3 @@
+{
+  "account_activation_url": "http:\/\/apple.myshopify.com\/account\/activate\/207119551\/86688abf23572680740b1c062fa37111-1458248616"
+}


### PR DESCRIPTION
According to the [API Announcements](https://ecommerce.shopify.com/c/api-announcements/t/new-api-to-retrieve-customer-account-activation-urls-305726) post.
I updated the gem with the new `account_activation_url` method for Customers resource.

/cc @kevinhughes27