### PR TITLE
allow scope to be string in ShopifyApi::Session::create_permission_url

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -73,7 +73,8 @@ module ShopifyAPI
     end
 
     def create_permission_url(scope, redirect_uri = nil)
-      params = {:client_id => api_key, :scope => scope.join(',')}
+      params = {:client_id => api_key}
+      params[:scope] = scope.kind_of?(Array) ? scope.join(',') : scope
       params[:redirect_uri] = redirect_uri if redirect_uri
       "#{site}/oauth/authorize?#{parameterize(params)}"
     end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -95,6 +95,22 @@ class SessionTest < Test::Unit::TestCase
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
   end
 
+  test "create_permission_url returns correct url with dual string scope no redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = "write_products","write_customers"
+    permission_url = session.create_permission_url(scope)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
+  end
+
+  test "create_permission_url returns correct url with string scope no redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = "write_products"
+    permission_url = session.create_permission_url(scope)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
+  end
+
   test "create_permission_url returns correct url with no scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
     session = ShopifyAPI::Session.new('http://localhost.myshopify.com')


### PR DESCRIPTION
Hey!
I'm using the embedded SDK and would like to do something like : 
```ruby
session_shopify.create_permission_url(ShopifyApp.configuration.scope)
```
I could have processed `ShopifyApp.configuration.scope` to an array before passing it to create_permission_url but it seems useless as you are processing it back to a string in this method.


