### PR TITLE
add api_key_params to ShopifyAPI::Session::create_permission_url

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -72,9 +72,10 @@ module ShopifyAPI
       self.token = token
     end
 
-    def create_permission_url(scope, redirect_uri = nil)
+    def create_permission_url(scope, redirect_uri = nil, api_key_param = nil)
       params = {:client_id => api_key, :scope => scope.join(',')}
       params[:redirect_uri] = redirect_uri if redirect_uri
+      params[:client_id] = api_key_param if api_key_param
       "#{site}/oauth/authorize?#{parameterize(params)}"
     end
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -79,6 +79,13 @@ class SessionTest < Test::Unit::TestCase
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
   end
 
+  test "create_permission_url returns correct url with api_key provided single scope no redirect uri" do
+    session = ShopifyAPI::Session.new("localhost.myshopify.com", "some-token")
+    scope = ["write_products"]
+    permission_url = session.create_permission_url(scope, nil, "My_test_key")
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
+  end
+
   test "create_permission_url returns correct url with single scope and redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
     session = ShopifyAPI::Session.new('http://localhost.myshopify.com')


### PR DESCRIPTION
Add possibility to add app_id manually in case session is initiated with a token.
I'm using the embedded SDK and I need to generate a redirection url but I get :
https://localhost.myshopify.com/admin/oauth/authorize?client_id=&scope=write_products
because I'm using (from Embedded App SDK)
```ruby
@sess = ShopifyApp::SessionRepository.retrieve(session[:shopify])
 ShopifyAPI::Base.activate_session(@sess)
```
to init my session. The session doesn't contain any api_key but just a token.

I'm not sure it is reasonable for security matters to add the possibility for developers to specify the api_key on their own when generating the redirect_url but that would solve my pb :)
Let me know 
