### PR TITLE
Add ability to delegate an access token

### DIFF
--- a/lib/shopify_api/resources/access_token.rb
+++ b/lib/shopify_api/resources/access_token.rb
@@ -1,0 +1,8 @@
+module ShopifyAPI
+  class AccessToken < Base
+    def self.delegate(access_scope, expires_in = nil)
+      resource = post(:delegate, delegate_access_scope: access_scope, expires_in: expires_in)
+      instantiate_record(format.decode(resource.body), {})
+    end
+  end
+end

--- a/test/access_token_test.rb
+++ b/test/access_token_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+class AccessTokenTest < Test::Unit::TestCase
+
+  def test_delegate_access_token
+    fake "access_tokens/delegate.json?delegate_access_scope%5B%5D=write_orders&" \
+      "delegate_access_scope%5B%5D=read_products&expires_in=",
+      method: :post,
+      status: 201,
+      body: load_fixture('access_token_delegate'),
+      extension: false
+
+    delegate_scope = ['write_orders', 'read_products']
+    token = ShopifyAPI::AccessToken.delegate(delegate_scope)
+
+    assert_equal 'abracadabra', token.access_token
+    assert_equal 'write_orders,read_products', token.scope
+  end
+end

--- a/test/fixtures/access_token_delegate.json
+++ b/test/fixtures/access_token_delegate.json
@@ -1,0 +1,4 @@
+{
+  "access_token": "abracadabra",
+  "scope": "write_orders,read_products"
+}


### PR DESCRIPTION
Adds the `/admin/access_tokens/delegate` endpoint. The endpoint is documented here: https://help.shopify.com/api/guides/authentication/oauth (or will be after the documentation is deployed next).

@garethson @kevinhughes27 for review