### PR TITLE
Bump to version 4.3.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== Version 4.3.0
+
+* Require Ruby >= `2.3.0`
+* Use inheritance instead of the deprecated Rails `Module#alias_method_chain`
+
 == Version 4.2.2
 
 * Support for AccessToken#delegate endpoint

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.2.2"
+  VERSION = "4.3.0"
 end

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -23,8 +23,10 @@ Gem::Specification.new do |s|
   s.summary = %q{ShopifyAPI is a lightweight gem for accessing the Shopify admin REST web services}
   s.license = "MIT"
 
-  s.add_dependency("activeresource", ">= 3.0.0")
-  s.add_dependency("rack")
+  s.required_ruby_version = ">= 2.3"
+
+  s.add_runtime_dependency("activeresource", ">= 3.0.0")
+  s.add_runtime_dependency("rack")
 
   s.add_development_dependency("mocha", ">= 0.9.8")
   s.add_development_dependency("fakeweb")


### PR DESCRIPTION
Does `4.3.0` make sense for the version bump?

@peterjm  @kevinhughes27 