### PR TITLE
use a custom subclass of ActiveResource::Connection if possible

### DIFF
--- a/lib/active_resource/connection_ext.rb
+++ b/lib/active_resource/connection_ext.rb
@@ -1,32 +1,10 @@
+require 'shopify_api/connection'
+
 module ActiveResource
   class Connection
     attr_reader :response
 
-    module ResponseCapture
-      def handle_response(response)
-        @response = super
-      end
-    end
-
-    module RequestNotification
-      def request(method, path, *arguments)
-        super.tap do |response|
-          notify_about_request(response, arguments)
-        end
-      rescue => e
-        notify_about_request(e.response, arguments) if e.respond_to?(:response)
-        raise
-      end
-
-      def notify_about_request(response, arguments)
-        ActiveSupport::Notifications.instrument("request.active_resource_detailed") do |payload|
-          payload[:response] = response
-          payload[:data]     = arguments
-        end
-      end
-    end
-
-    prepend ResponseCapture
-    prepend RequestNotification
+    prepend ShopifyAPI::Connection::ResponseCapture
+    prepend ShopifyAPI::Connection::RequestNotification
   end
 end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -4,7 +4,6 @@ require 'active_resource'
 require 'active_support/core_ext/class/attribute_accessors'
 require 'digest/md5'
 require 'base64'
-require 'active_resource/connection_ext'
 require 'active_resource/detailed_log_subscriber'
 require 'shopify_api/limits'
 require 'shopify_api/json_format'
@@ -22,3 +21,11 @@ require 'shopify_api/metafields'
 require 'shopify_api/countable'
 require 'shopify_api/resources'
 require 'shopify_api/session'
+require 'shopify_api/connection'
+
+# ActiveResource::Base.connection_class was introduced in https://github.com/rails/activeresource/pull/222
+if ShopifyAPI::Base.respond_to?(:connection_class)
+  ShopifyAPI::Base.connection_class = ShopifyAPI::Connection
+else
+  require 'active_resource/connection_ext'
+end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -23,7 +23,6 @@ require 'shopify_api/resources'
 require 'shopify_api/session'
 require 'shopify_api/connection'
 
-# ActiveResource::Base.connection_class was introduced in https://github.com/rails/activeresource/pull/222
 if ShopifyAPI::Base.respond_to?(:connection_class)
   ShopifyAPI::Base.connection_class = ShopifyAPI::Connection
 else

--- a/lib/shopify_api/connection.rb
+++ b/lib/shopify_api/connection.rb
@@ -1,0 +1,33 @@
+module ShopifyAPI
+  class Connection < ActiveResource::Connection
+    attr_reader :response
+
+    module ResponseCapture
+      def handle_response(response)
+        @response = super
+      end
+    end
+
+    include ResponseCapture
+
+    module RequestNotification
+      def request(method, path, *arguments)
+        super.tap do |response|
+          notify_about_request(response, arguments)
+        end
+      rescue => e
+        notify_about_request(e.response, arguments) if e.respond_to?(:response)
+        raise
+      end
+
+      def notify_about_request(response, arguments)
+        ActiveSupport::Notifications.instrument("request.active_resource_detailed") do |payload|
+          payload[:response] = response
+          payload[:data]     = arguments
+        end
+      end
+    end
+
+    include RequestNotification
+  end
+end


### PR DESCRIPTION
This PR attempts to improve on #286 by only setting `ActiveResource::Base.connection_class` if it is available, and falls back to monkeypatching `ActiveResource::Connection` for older versions of `activeresource` that do not have that feature.