### PR TITLE
Fix for `TypeError: can't convert Hash into Integer` when calling `Product.count` with latest activeresource

### DIFF
--- a/lib/shopify_api/countable.rb
+++ b/lib/shopify_api/countable.rb
@@ -1,7 +1,14 @@
 module ShopifyAPI
   module Countable
     def count(options = {})
-      Integer(get(:count, options))
+      data = get(:count, options)
+
+      count = case data
+        when Hash then data["count"]
+        else data
+      end
+
+      Integer(count)
     end
   end
 end

--- a/test/countable_test.rb
+++ b/test/countable_test.rb
@@ -1,0 +1,12 @@
+require 'test_helper'
+
+class CountableTest < Test::Unit::TestCase
+  def setup
+    fake "products/count", :body => '{"count": 16}'
+  end
+
+  def test_count_products
+    count = ShopifyAPI::Product.count
+    assert_equal 16, count
+  end
+end


### PR DESCRIPTION
The `Countable` mixin doesn't work with activeresource@master because of this pull request that was merged in January: rails/activeresource#96. This PR adds a test to expose this issue as well as a fix.

In short, the problem is that the call to `get(:count)` now no longer removes the root from the response properly, so the return value is now `{"count" => 16}` instead of `16` (assuming there are 16 of the resource). To fix it, I added some code to check if the value returned from `get(:count)` is a Hash instead of a number, and remove the root manually. I've also posted a comment on the offending PR about the new problem it caused here: https://github.com/rails/activeresource/pull/96#issuecomment-234991786