### PR TITLE
Add the ability to attach an image to ShopifyAPI::Image from external URL

### DIFF
--- a/lib/shopify_api/resources/image.rb
+++ b/lib/shopify_api/resources/image.rb
@@ -12,5 +12,11 @@ module ShopifyAPI
       attributes['attachment'] = Base64.encode64(data)
       attributes['filename'] = filename unless filename.nil?
     end
+
+    # Specify the +url+ of an image that Shopify will download for the
+    # product image.
+    def attach_image_from_url(url)
+      attributes['src'] = url
+    end
   end
 end


### PR DESCRIPTION
This adds a new method: `ShopifyAPI::Image#attach_image_from_url`.

The new methods allows for attaching an external image via the `src`
attribute. This is useful when adding images that are already available
on the web. It removes the need for downloading the image or opening
it in memory when it is attached with `#attach_image`.

Based on these docs: https://help.shopify.com/api/reference/product_image#create

```
Create a new product image using a source URL that will be downloaded by Shopify

POST /admin/products/#{id}/images.json
{
  "image": {
    "src": "http:\/\/example.com\/rails_logo.gif"
  }
}
```