### PR TITLE
Remove required argument on prefix in disable_prefix_check

### DIFF
--- a/lib/active_resource/disable_prefix_check.rb
+++ b/lib/active_resource/disable_prefix_check.rb
@@ -12,7 +12,7 @@ module DisablePrefixCheck
 
       init_prefix_explicit resource_type, resource_id
 
-      define_singleton_method :prefix do |options|
+      define_singleton_method :prefix do |options = {}|
         resource_type =  options[resource] if flexible
 
         options[resource_id].nil? ? "/admin/" : "/admin/#{resource_type}/#{options[resource_id]}/"


### PR DESCRIPTION
For some reason we are patching this module in ActiveResource and in the actual gem the prefix args are optional (https://github.com/rails/activeresource/blob/f8abaf13174e94d179227f352c9dd6fb8b03e0da/lib/active_resource/base.rb#L1575), but in our version they are required.  This fix makes them optional so this error doesn't happen:

```ruby
ShopifyAPI::ProductListing.find(:first, params: {application_id: KEYS[:shopify_provider_id]})
ArgumentError: wrong number of arguments (given 0, expected 1)
           from /Users/matt/.gem/ruby/2.3.1/gems/shopify_api-4.3.0/lib/active_resource/disable_prefix_check.rb:15:in `block in conditional_prefix'
           from /Users/matt/.gem/ruby/2.3.1/bundler/gems/activeresource-f8abaf13174e/lib/active_resource/base.rb:1575:in `create_resource_for'
```

/review @swalkinshaw @lreeves @minasmart 