### PR TITLE
Fix refund_test create params

### DIFF
--- a/test/refund_test.rb
+++ b/test/refund_test.rb
@@ -9,7 +9,7 @@ class RefundTest < Test::Unit::TestCase
       :restock => true,
       :note => "wrong size",
       :shipping => { :full_refund => true },
-      :refund_line_items => [{ :line_item => 518995019, :quantity => 1 }]
+      :refund_line_items => [{ :line_item_id => 518995019, :quantity => 1 }]
     )
     assert_equal 703073504, refund.refund_line_items.first.line_item_id
   end


### PR DESCRIPTION
Just a tiny little thing

```RUBY
# This doesn't work with the actual API
refund = ShopifyAPI::Refund.create(
      :order_id => 450789469,
      :restock => true,
      :note => "wrong size",
      :shipping => { :full_refund => true },
     :refund_line_items => [{ :line_item => 518995019, :quantity => 1 }] # Here is the culprit
)

# This does
refund = ShopifyAPI::Refund.create(
      :order_id => 450789469,
      :restock => true,
      :note => "wrong size",
      :shipping => { :full_refund => true },
     :refund_line_items => [{ :line_item_id => 518995019, :quantity => 1 }] # Tiny little change
)

```

It doesn't break the test, but it wouldn't work with the shopify API, since the parameter has to be either a line_item json  including the id `{ "id": 123123,  ... }`, or the line_item_id.

Kinda bit me, since I usually use the tests as a kind of documentation ;)