### PR TITLE
Bump to version 4.3.1

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 4.3.1
+
+* Support for ShopifyAPI::ApplicationCredit
+
 == Version 4.3.0
 
 * Require Ruby >= `2.3.0`

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.3.0"
+  VERSION = "4.3.1"
 end


### PR DESCRIPTION
## Description
- bumping gem version to 4.3.1 for releasing support for application credits

@Shopify/finance @kevinhughes27 @peterjm 