### PR TITLE
Unexpected Auth headers is so Basic

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -58,6 +58,8 @@ module ShopifyAPI
 
       def clear_session
         self.site = nil
+        self.password = nil
+        self.user = nil
         self.headers.delete('X-Shopify-Access-Token')
       end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -24,6 +24,19 @@ class BaseTest < Test::Unit::TestCase
     assert_equal 'token1', ShopifyAPI::Shop.headers['X-Shopify-Access-Token']
   end
 
+  test '#clear_session should clear base site settings from Base' do
+    ShopifyAPI::Base.site = "https://foo:bar@www.zombo.com"
+
+    assert_equal "foo", ShopifyAPI::Base.user
+    assert_equal "bar", ShopifyAPI::Base.password
+
+    ShopifyAPI::Base.clear_session
+
+    assert_equal nil, ShopifyAPI::Base.user
+    assert_equal nil, ShopifyAPI::Base.password
+    assert_equal nil, ShopifyAPI::Base.site
+  end
+
   test '#clear_session should clear site and headers from Base' do
     ShopifyAPI::Base.activate_session @session1
     ShopifyAPI::Base.clear_session


### PR DESCRIPTION
@kevinhughes27 @maartenvg 

when you set `site=` in `ActiveResource::Base`, it parses out the password and username out of that and sets it internally. so when we clear the session here, we should also clear those flags, otherwise you end up with unexpected authentication headers down the line