### PR TITLE
Relax ruby version requirement to 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: false
 
 rvm:
+  - '2.0'
   - 2.3.1
   - 2.4.0-preview1
 
@@ -14,6 +15,9 @@ gemfile:
   - Gemfile_ar_master
 
 matrix:
+  exclude:
+    - rvm: '2.0'
+      gemfile: Gemfile_ar_master
   fast_finish: true
   allow_failures:
     - rvm: 2.4.0-preview1

--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "activeresource", "~> 4.1"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/Gemfile_ar30
+++ b/Gemfile_ar30
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "activeresource", "~> 3.0.0"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/Gemfile_ar31
+++ b/Gemfile_ar31
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "activeresource", "~> 3.1.0"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/Gemfile_ar32
+++ b/Gemfile_ar32
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "activeresource", "~> 3.2.0"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/Gemfile_ar40
+++ b/Gemfile_ar40
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem "activeresource", "4.0.0"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/Gemfile_ar_master
+++ b/Gemfile_ar_master
@@ -3,3 +3,4 @@ source "https://rubygems.org"
 gemspec
 
 gem 'activeresource', git: 'git://github.com/rails/activeresource'
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.summary = %q{ShopifyAPI is a lightweight gem for accessing the Shopify admin REST web services}
   s.license = "MIT"
 
-  s.required_ruby_version = ">= 2.3"
+  s.required_ruby_version = ">= 2.0"
 
   s.add_runtime_dependency("activeresource", ">= 3.0.0")
   s.add_runtime_dependency("rack")


### PR DESCRIPTION
`shopify_api` doesn't need anything more recent than `MRI 2.0`, so might as well not be too restrictive there.

Feel free to bump that requirement as needed later, but I think it's better that way for now.

@swalkinshaw @camilo  