### PR TITLE
Metafield URL Parameters

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== Version 4.7.1
+
+* Added support for URL parameter (e.g. limit & page) to ShopifyAPI::Metafields
+* Added support for URL parameter (e.g. limit & page) to metafield operator in ShopifyAPI::Shop
+
 == Version 4.7.0
 
 * Removed the mandatory `application_id` parameter from `ShopifyAPI::ProductListing` and `ShopifyAPI::CollectionListing`

--- a/lib/shopify_api/metafields.rb
+++ b/lib/shopify_api/metafields.rb
@@ -1,7 +1,9 @@
 module ShopifyAPI
   module Metafields
-    def metafields
-      Metafield.find(:all, :params => {:resource => self.class.collection_name, :resource_id => id})
+    def metafields(**options)
+      options.merge! resource: self.class.collection_name, resource_id: id
+
+      Metafield.find :all, params: options
     end
 
     def add_metafield(metafield)

--- a/lib/shopify_api/resources/shop.rb
+++ b/lib/shopify_api/resources/shop.rb
@@ -6,10 +6,10 @@ module ShopifyAPI
       find(:one, options.merge({from: "/admin/shop.#{format.extension}"}))
     end
 
-    def metafields
-      Metafield.find(:all)
+    def metafields(**options)
+      Metafield.find :all, params: options
     end
-    
+
     def add_metafield(metafield)
       raise ArgumentError, "You can only add metafields to resource that has been saved" if new?      
       metafield.save

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.7.0"
+  VERSION = "4.7.1"
 end

--- a/test/draft_order_test.rb
+++ b/test/draft_order_test.rb
@@ -103,13 +103,25 @@ class DraftOrderTest < Test::Unit::TestCase
     assert_equal '123@example.com', field.value
   end
 
-  def test_get_metafields_for_draft_order
+  def test_get_all_metafields_for_draft_order
     fake 'draft_orders/517119332/metafields', body: load_fixture('metafields')
 
     metafields = @draft_order.metafields
 
-    assert_equal 2, metafields.length
+    assert_equal 3, metafields.length
     assert metafields.all? { |m| m.is_a?(ShopifyAPI::Metafield) }
+  end
+
+  def test_get_2_metafields_for_draft_order
+    body = ActiveSupport::JSON.decode load_fixture 'metafields'
+    body['metafields'].slice! 2, 1
+
+    fake 'draft_orders/517119332/metafields.json?limit=2', body: body.to_json, extension: false
+
+    metafields = @draft_order.metafields limit: 2
+
+    assert_equal 2, metafields.length
+    assert metafields.all?{ |m| m.is_a? ShopifyAPI::Metafield }
   end
 
   def test_complete_draft_order_with_no_params

--- a/test/fixtures/metafields.json
+++ b/test/fixtures/metafields.json
@@ -19,6 +19,16 @@
       "description": null,
       "key": "phone",
       "value_type": "string"
+    },
+    {
+      "created_at": "2017-04-24T20:14:24.031-04:00",
+      "updated_at": "2017-04-24T20:14:24.031-04:00",
+      "namespace": "contact",
+      "id": "72544103001",
+      "value": "Ottawa",
+      "description": null,
+      "key": "City",
+      "value_type": "string"
     }
   ]
 }

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -19,13 +19,25 @@ class ProductTest < Test::Unit::TestCase
     assert_equal "123@example.com", field.value
   end
 
-  def test_get_metafields_for_product
+  def test_get_all_metafields_for_product
     fake "products/632910392/metafields", :body => load_fixture('metafields')
 
     metafields = @product.metafields
 
+    assert_equal 3, metafields.length
+    assert metafields.all?{ |m| m.is_a? ShopifyAPI::Metafield }
+  end
+
+  def test_get_2_metafields_for_product
+    body = ActiveSupport::JSON.decode load_fixture 'metafields'
+    body['metafields'].slice! 2, 1
+
+    fake 'products/632910392/metafields.json?limit=2', body: body.to_json, extension: false
+
+    metafields = @product.metafields limit: 2
+
     assert_equal 2, metafields.length
-    assert metafields.all?{|m| m.is_a?(ShopifyAPI::Metafield)}
+    assert metafields.all?{ |m| m.is_a? ShopifyAPI::Metafield }
   end
 
   def test_update_loaded_variant

--- a/test/shop_test.rb
+++ b/test/shop_test.rb
@@ -25,13 +25,25 @@ class ShopTest < Test::Unit::TestCase
     assert_equal "apple.myshopify.com", @shop.myshopify_domain
   end
 
-  def test_get_metafields_for_shop
+  def test_get_all_metafields_for_shop
     fake "metafields"
 
     metafields = @shop.metafields
 
-    assert_equal 2, metafields.length
+    assert_equal 3, metafields.length
     assert metafields.all?{|m| m.is_a?(ShopifyAPI::Metafield)}
+  end
+
+  def test_get_2_metafields_for_shop
+    body = ActiveSupport::JSON.decode load_fixture 'metafields'
+    body['metafields'].slice! 2, 1
+
+    fake 'metafields.json?limit=2', body: body.to_json, extension: false
+
+    metafields = @shop.metafields limit: 2
+
+    assert_equal 2, metafields.length
+    assert metafields.all?{ |m| m.is_a? ShopifyAPI::Metafield }
   end
 
   def test_add_metafield


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify_api/issues/215.

This allows passing URL parameters to the [Metafields API](https://help.shopify.com/api/reference/metafield#index).

Example Request:
`my-shop.myshopify.com:443/admin/<collection_name>/:collection_id/metafields.json?limit=250&page=1`