### PR TITLE
Remove automatic encoding of the root key on ::Base

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -9,7 +9,7 @@ module ShopifyAPI
     self.headers['User-Agent'] = ["ShopifyAPI/#{ShopifyAPI::VERSION}",
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",
                                   "Ruby/#{RUBY_VERSION}"].join(' ')
-    self.site = "https://maxime-bedard.myshopify.com"
+    # self.site = "https://maxime-bedard.myshopify.com"
 
     def encode(options = {})
       options = { root: self.class.element_name }.merge(options) if self.class.format.extension == "json"

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -5,22 +5,18 @@ module ShopifyAPI
     class InvalidSessionError < StandardError; end
     extend Countable
     self.timeout = 90
-    self.include_root_in_json = false
+    self.include_root_in_json = true
     self.headers['User-Agent'] = ["ShopifyAPI/#{ShopifyAPI::VERSION}",
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",
                                   "Ruby/#{RUBY_VERSION}"].join(' ')
 
-    def encode(options = {})
-      same = dup
-      same.attributes = {self.class.element_name => same.attributes} if self.class.format.extension == 'json'
-
-      same.send("to_#{self.class.format.extension}", options)
-    end
-
     def as_json(options = nil)
-      root = options[:root] if options.try(:key?, :root)
-      if include_root_in_json
-        root = self.class.model_name.element if root == true
+      opts = options || {}
+
+      root = opts.fetch(:root, include_root_in_json)
+      root = self.class.model_name.element if root == true
+
+      if root
         { root => serializable_hash(options) }
       else
         serializable_hash(options)

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -10,19 +10,6 @@ module ShopifyAPI
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",
                                   "Ruby/#{RUBY_VERSION}"].join(' ')
 
-    def as_json(options = nil)
-      opts = options || {}
-
-      root = opts.fetch(:root, include_root_in_json)
-      root = self.class.model_name.element if root == true
-
-      if root
-        { root => serializable_hash(options) }
-      else
-        serializable_hash(options)
-      end
-    end
-
     class << self
       if ActiveResource::Base.respond_to?(:_headers) && ActiveResource::Base.respond_to?(:_headers_defined?)
         def headers

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -5,10 +5,16 @@ module ShopifyAPI
     class InvalidSessionError < StandardError; end
     extend Countable
     self.timeout = 90
-    self.include_root_in_json = true
+    self.include_root_in_json = false
     self.headers['User-Agent'] = ["ShopifyAPI/#{ShopifyAPI::VERSION}",
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",
                                   "Ruby/#{RUBY_VERSION}"].join(' ')
+    self.site = "https://maxime-bedard.myshopify.com"
+
+    def encode(options = {})
+      options = { root: self.class.element_name }.merge(options) if self.class.format.extension == "json"
+      super(options)
+    end
 
     class << self
       if ActiveResource::Base.respond_to?(:_headers) && ActiveResource::Base.respond_to?(:_headers_defined?)


### PR DESCRIPTION
Instead of always encoding the root key, we will reuse the `include_root_in_json` parameter and set it to true instead. Because in the end, it's exactly what we are doing, except that this will allow us to customize serializations in some very specific cases during the encoding phase without having to worry if the root key is present or not.


Let me know what you think 👍  @maartenvg @Shopify/api 