### PR TITLE
Bump to version 4.3.5 for draft orders support

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 4.3.5
+
+* Added `ShopifyAPI::DraftOrder`
+
 == Version 4.3.4
 
 * Added `ShopifyAPI::ProductListing`

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.3.4"
+  VERSION = "4.3.5"
 end


### PR DESCRIPTION
Bumping gem version to 4.3.5 for releasing support for draft orders