### PR TITLE
Actually run all tests and remove flakiness by doing proper setup and teardown

### DIFF
--- a/lib/shopify_api/resources/fulfillment_request.rb
+++ b/lib/shopify_api/resources/fulfillment_request.rb
@@ -7,9 +7,9 @@ module ShopifyAPI
     end
 
     def mark_as_failed
-      load_attributes_from_response(
-        put(:mark_as_failed, message: failure_message)
-      )
+      options = {}
+      options[:message] = failure_message if failure_message
+      load_attributes_from_response(put(:mark_as_failed, options))
     end
   end
 end

--- a/test/countable_test.rb
+++ b/test/countable_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class CountableTest < Test::Unit::TestCase
   def setup
+    super
     fake "products/count", :body => '{"count": 16}'
   end
 

--- a/test/fulfillment_request_test.rb
+++ b/test/fulfillment_request_test.rb
@@ -2,20 +2,20 @@ require 'test_helper'
 
 class FulFillmentRequestTest < Test::Unit::TestCase
   def setup
-    fake "orders/450789469/fulfillment_requests/255858046", method: :get, body: load_fixture('fulfillment_request')
+    super
+    fake "orders/450789469/fulfillment_requests/695890229", method: :get, body: load_fixture('fulfillment_request')
   end
 
   context "#mark_as_failed" do
     should "be able to mark_as_failed a fulfillment request" do
-      fulfillment_request = ShopifyAPI::FulfillmentRequest.find(255858046, params: { order_id: 450789469 })
+      fulfillment_request = ShopifyAPI::FulfillmentRequest.find(695890229, params: { order_id: 450789469 })
 
       cancelled = ActiveSupport::JSON.decode(load_fixture('fulfillment_request'))
       cancelled['failure_message'] = 'failure reason'
       cancelled['message'] = nil
-      fake "orders/450789469/fulfillment_requests/695890229/mark_as_failed.json?message=",
+      fake "orders/450789469/fulfillment_requests/695890229/mark_as_failed",
         method: :put,
-        body: ActiveSupport::JSON.encode(cancelled),
-        extension: false
+        body: ActiveSupport::JSON.encode(cancelled)
 
       assert fulfillment_request.failure_message.blank?
       assert fulfillment_request.mark_as_failed
@@ -25,7 +25,7 @@ class FulFillmentRequestTest < Test::Unit::TestCase
 
   context "#find" do
     should "be able to find fulfillment request" do
-      fulfillment_request = ShopifyAPI::FulfillmentRequest.find(255858046, params: { order_id: 450789469 })
+      fulfillment_request = ShopifyAPI::FulfillmentRequest.find(695890229, params: { order_id: 450789469 })
       assert_equal 695890229, fulfillment_request.id
       assert_equal 450789469, fulfillment_request.order_id
     end

--- a/test/fulfillment_test.rb
+++ b/test/fulfillment_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class FulFillmentTest < Test::Unit::TestCase
   def setup
+    super
     fake "orders/450789469/fulfillments/255858046", :method => :get, :body => load_fixture('fulfillment')
   end
 

--- a/test/limits_test.rb
+++ b/test/limits_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 class LimitsTest < Test::Unit::TestCase
   def setup
-    ShopifyAPI::Base.site = "test.myshopify.com"
+    super
     @header_hash = {'http_x_shopify_shop_api_call_limit' => '100/300'}
     ShopifyAPI::Base.connection.expects(:response).at_least(0).returns(@header_hash)
   end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -4,6 +4,7 @@ require 'timecop'
 class SessionTest < Test::Unit::TestCase
 
   def setup
+    super
     ShopifyAPI::Session.secret = 'secret'
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -17,7 +17,7 @@ end
 
 class Test::Unit::TestCase < Minitest::Unit::TestCase
   def self.test(string, &block)
-    define_method("test:#{string}", &block)
+    define_method("test_#{string}", &block)
   end
 
   def self.should(string, &block)
@@ -46,6 +46,11 @@ class Test::Unit::TestCase < Minitest::Unit::TestCase
 
   def teardown
     FakeWeb.clean_registry
+
+    ShopifyAPI::Base.clear_session
+    ShopifyAPI::Base.site = nil
+    ShopifyAPI::Base.password = nil
+    ShopifyAPI::Base.user = nil
   end
 
   # Custom Assertions

--- a/test/transaction_test.rb
+++ b/test/transaction_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class TransactionTest < Test::Unit::TestCase
   def setup
+    super
     fake "orders/450789469/transactions/389404469", :method => :get, :body => load_fixture('transaction')
   end
 


### PR DESCRIPTION
In the test helper we generated the wrong test method name in the `def test` helper, meaning that all tests defined with the `should` or `test` methods weren't actually run. On top of that, because the setup method is an actual method that is overridden from the base class, we need to call `super` to ensure the base-setup is still performed properly. Since that setup sets global vars, most randomized runs will start with a test that will setup these globals correctly for the duration of the entire test-suite. But once in a while a badly setuo test will run first, failing because the base setup steps are not executed.

In this PR:
- Use `_` instead of `:` in generated test names forcing them to be run
- Use better teardown of globals in test helper to surface problems of leaking state between tests
- Call super in all `def setup` overrides to ensure base setup is performed
- Fix bug in `FulfillmentRequest` that was sending an empty message param if there was no message
- Fix tests that were not run but were actually failing  