### PR TITLE
Add ResourceFeedback and Bump Version to 4.3.8

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 4.3.8
+
+* Added `ShopifyAPI::ResourceFeedback`
+
 == Version 4.3.7
 
 * Added support for `complete` in `ShopifyAPI::DraftOrder`

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -81,6 +81,7 @@ module ShopifyAPI
     end
 
     private
+
     def only_id
       encode(:only => :id, :include => [], :methods => [])
     end

--- a/lib/shopify_api/resources/resource_feedback.rb
+++ b/lib/shopify_api/resources/resource_feedback.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module ShopifyAPI
+  class ResourceFeedback < Base
+    class ExistingFeedbackSaved < StandardError; end
+    include DisablePrefixCheck
+
+    STATE_SUCCESS = 'success'
+    STATE_REQUIRES_ACTION = 'requires_action'
+
+    conditional_prefix :product, false
+
+    EXISTING_FEEDBACK_SAVED_ERROR_MESSAGE = 'WARNING: Attempted call to ShopifyAPI::ResourceFeedback#save' \
+      'after it was already persisted. Updating an existing ShopifyAPI::ResourceFeedback is not supported.'
+
+    def save
+      return super unless persisted?
+      raise ExistingFeedbackSaved.new(EXISTING_FEEDBACK_SAVED_ERROR_MESSAGE)
+    end
+  end
+end

--- a/lib/shopify_api/resources/resource_feedback.rb
+++ b/lib/shopify_api/resources/resource_feedback.rb
@@ -5,9 +5,6 @@ module ShopifyAPI
     class ExistingFeedbackSaved < StandardError; end
     include DisablePrefixCheck
 
-    STATE_SUCCESS = 'success'
-    STATE_REQUIRES_ACTION = 'requires_action'
-
     conditional_prefix :product, false
 
     EXISTING_FEEDBACK_SAVED_ERROR_MESSAGE = 'WARNING: Attempted call to ShopifyAPI::ResourceFeedback#save' \

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.3.7"
+  VERSION = "4.3.8"
 end

--- a/test/resource_feedback_test.rb
+++ b/test/resource_feedback_test.rb
@@ -1,0 +1,28 @@
+class ResourceFeedbackTest < Test::Unit::TestCase
+  def test_save_with_resource_feedbacks_endpoint
+    body = { resource_feedback: {} }.to_json
+    fake 'resource_feedbacks', method: :post, body: body
+    ShopifyAPI::ResourceFeedback.new.save
+    assert_request_body body
+  end
+
+  def test_save_with_product_id_resource_feedbacks_endpoint
+    body = { resource_feedback: {} }.to_json
+    fake 'products/42/resource_feedbacks', method: :post, body: body
+    ShopifyAPI::ResourceFeedback.new(product_id: 42).save
+    assert_request_body body
+  end
+
+  def test_save_notify_via_bugsnag_when_already_persisted
+    body = { resource_feedback: {} }.to_json
+    fake 'resource_feedbacks', method: :post, body: body
+    resource_feedback = ShopifyAPI::ResourceFeedback.new
+    resource_feedback.save
+    assert_request_body body
+
+    ShopifyAPI::ResourceFeedback.any_instance.expects(:persisted?).returns(true)
+    assert_raises ShopifyAPI::ResourceFeedback::ExistingFeedbackSaved do
+      resource_feedback.save
+    end
+  end
+end

--- a/test/resource_feedback_test.rb
+++ b/test/resource_feedback_test.rb
@@ -13,7 +13,7 @@ class ResourceFeedbackTest < Test::Unit::TestCase
     assert_request_body body
   end
 
-  def test_save_notify_via_bugsnag_when_already_persisted
+  def test_save_raises_exception_when_already_persisted
     body = { resource_feedback: {} }.to_json
     fake 'resource_feedbacks', method: :post, body: body
     resource_feedback = ShopifyAPI::ResourceFeedback.new


### PR DESCRIPTION
Add ResourceFeedback and bump gem version to 4.3.8

Issue: https://github.com/Shopify/product-publishing-feedback/issues/193