### PR TITLE
Singularize ResourceFeedback collection_name

### DIFF
--- a/lib/shopify_api/resources/resource_feedback.rb
+++ b/lib/shopify_api/resources/resource_feedback.rb
@@ -5,6 +5,7 @@ module ShopifyAPI
     class ExistingFeedbackSaved < StandardError; end
     include DisablePrefixCheck
 
+    self.collection_name = 'resource_feedback'
     conditional_prefix :product, false
 
     EXISTING_FEEDBACK_SAVED_ERROR_MESSAGE = 'WARNING: Attempted call to ShopifyAPI::ResourceFeedback#save' \

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.3.8"
+  VERSION = "4.3.9"
 end

--- a/test/resource_feedback_test.rb
+++ b/test/resource_feedback_test.rb
@@ -1,21 +1,35 @@
 class ResourceFeedbackTest < Test::Unit::TestCase
-  def test_save_with_resource_feedbacks_endpoint
+  def test_get_resource_feedback
+    body = { resource_feedback: [ { resource_type: 'Shop' } ] }.to_json
+    fake 'resource_feedback', method: :get, body: body
+    resource_feedback = ShopifyAPI::ResourceFeedback.find(:all)
+    assert_equal 'Shop', resource_feedback.first.resource_type
+  end
+
+  def test_save_with_resource_feedback_endpoint
     body = { resource_feedback: {} }.to_json
-    fake 'resource_feedbacks', method: :post, body: body
+    fake 'resource_feedback', method: :post, body: body
     ShopifyAPI::ResourceFeedback.new.save
     assert_request_body body
   end
 
-  def test_save_with_product_id_resource_feedbacks_endpoint
+  def test_get_resource_feedback_with_product_id
+    body = { resource_feedback: [ { resource_type: 'Product' } ] }.to_json
+    fake 'products/42/resource_feedback', method: :get, body: body
+    resource_feedback = ShopifyAPI::ResourceFeedback.find(:all, params: { product_id: 42 })
+    assert_equal 'Product', resource_feedback.first.resource_type
+  end
+
+  def test_save_with_product_id_resource_feedback_endpoint
     body = { resource_feedback: {} }.to_json
-    fake 'products/42/resource_feedbacks', method: :post, body: body
+    fake 'products/42/resource_feedback', method: :post, body: body
     ShopifyAPI::ResourceFeedback.new(product_id: 42).save
     assert_request_body body
   end
 
   def test_save_raises_exception_when_already_persisted
     body = { resource_feedback: {} }.to_json
-    fake 'resource_feedbacks', method: :post, body: body
+    fake 'resource_feedback', method: :post, body: body
     resource_feedback = ShopifyAPI::ResourceFeedback.new
     resource_feedback.save
     assert_request_body body


### PR DESCRIPTION
Singularize ResourceFeedback `collection_name`, to coincide with API path change to rename endpoint to `/admin/resource_feedback`