### PR TITLE
Add support for customer invites

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== Version 4.4.0
+
+* Added `ShopifyAPI::CustomerInvite`
+* Support for Customer#send_invite endpoint
+
 == Version 4.3.8
 
 * Added `ShopifyAPI::ResourceFeedback`

--- a/lib/shopify_api/resources/customer.rb
+++ b/lib/shopify_api/resources/customer.rb
@@ -20,5 +20,10 @@ module ShopifyAPI
       end
       result
     end
+
+    def send_invite(customer_invite = ShopifyAPI::CustomerInvite.new)
+      resource = post(:send_invite, {}, customer_invite.encode)
+      ShopifyAPI::CustomerInvite.new(ShopifyAPI::CustomerInvite.format.decode(resource.body))
+    end
   end
 end

--- a/lib/shopify_api/resources/customer_invite_message.rb
+++ b/lib/shopify_api/resources/customer_invite_message.rb
@@ -1,0 +1,4 @@
+module ShopifyAPI
+  class CustomerInvite < Base
+  end
+end

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "4.3.9"
+  VERSION = "4.4.0"
 end

--- a/test/customer_test.rb
+++ b/test/customer_test.rb
@@ -1,6 +1,13 @@
 require 'test_helper'
 
 class CustomerTest < Test::Unit::TestCase
+  def setup
+    super
+
+    fake 'customers/207119551', body: load_fixture('customers')
+
+    @customer = ShopifyAPI::Customer.find(207119551)
+  end
 
   test "search should get a customers collection" do
     fake "customers/search.json?query=Bob+country%3AUnited+States", :extension => false, :body => load_fixture('customers_search')
@@ -10,11 +17,34 @@ class CustomerTest < Test::Unit::TestCase
   end
 
   test "account_activation_url should create an account activation url" do
-    fake "customers/207119551", :body => load_fixture('customers')
     fake "customers/207119551/account_activation_url", :method => :post, :body => load_fixture('customers_account_activation_url')
 
-    customer = ShopifyAPI::Customer.find(207119551)
     activation_url = "http://apple.myshopify.com/account/activate/207119551/86688abf23572680740b1c062fa37111-1458248616"
-    assert_equal activation_url, customer.account_activation_url
+    assert_equal activation_url, @customer.account_activation_url
+  end
+
+  test "#send_invite with no params" do
+    customer_invite_fixture = load_fixture('customer_invite')
+    customer_invite = ActiveSupport::JSON.decode(customer_invite_fixture)
+    fake 'customers/207119551/send_invite', method: :post, body: customer_invite_fixture
+
+    customer_invite_response = @customer.send_invite
+
+    assert_equal '{"customer_invite":{}}', FakeWeb.last_request.body
+    assert_kind_of ShopifyAPI::CustomerInvite, customer_invite_response
+    assert_equal customer_invite['customer_invite']['to'], customer_invite_response.to
+  end
+
+  test "#send_invite with params" do
+    customer_invite_fixture = load_fixture('customer_invite')
+    customer_invite = ActiveSupport::JSON.decode(customer_invite_fixture)
+    fake 'customers/207119551/send_invite', method: :post, body: customer_invite_fixture
+
+
+    customer_invite_response = @customer.send_invite(ShopifyAPI::CustomerInvite.new(customer_invite['customer_invite']))
+
+    assert_equal customer_invite, ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_kind_of ShopifyAPI::CustomerInvite, customer_invite_response
+    assert_equal customer_invite['customer_invite']['to'], customer_invite_response.to
   end
 end

--- a/test/fixtures/customer_invite.json
+++ b/test/fixtures/customer_invite.json
@@ -1,0 +1,9 @@
+{
+  "customer_invite": {
+    "to": "paul.norman@example.com",
+    "from": "steve@apple.com",
+    "subject": "Welcome to my new store!",
+    "custom_message": "This is a test custom message.",
+    "bcc": [ ]
+  }
+}


### PR DESCRIPTION
Adds `ShopifyAPI::CustomerInvite` and exposes `Customer#send_invite`