### PR TITLE
Fix Rails 5 deprecation warning with_indifferent_access

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -51,7 +51,7 @@ module ShopifyAPI
       end
 
       def validate_signature(params)
-        params = params.with_indifferent_access
+        params = (params.respond_to?(:to_unsafe_hash) ? params.to_unsafe_hash : params).with_indifferent_access
         return false unless signature = params[:hmac]
 
         calculated_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), secret, encoded_params_for_signature(params))


### PR DESCRIPTION
When running the shopify_api with Rails 5, you'll see the following
deprecation warning:

```
DEPRECATION WARNING: Method with_indifferent_access is deprecated and will be
removed in Rails 5.1, as `ActionController::Parameters` no longer inherits from
hash. Using this deprecated behavior exposes potential security problems. If
you continue to use this method you may be creating a security vulnerability in
your app that can be exploited. Instead, consider using one of these documented
methods which are not deprecated:
http://api.rubyonrails.org/v5.0.2/classes/ActionController/Parameters.html
(called from validate_signature at /../shopify/shopify_api/lib/shopify_api/session.rb:54)
```

This patch checks for and calls `to_unsafe_hash` on the `params`
argument to convert the params to a hash before calling
`with_indifferent_access`. It supports working with
`ActionController::Parameters` as well as plain hashes because the tests
use plain hashes.