### PR TITLE
Remove application_id param from listing endpoints

### DIFF
--- a/lib/shopify_api/resources/collection_listing.rb
+++ b/lib/shopify_api/resources/collection_listing.rb
@@ -1,9 +1,7 @@
 module ShopifyAPI
   class CollectionListing < Base
-    init_prefix :application
-
-    def product_ids(options = {})
-      get("#{collection_id}/product_ids", options[:params])
+    def product_ids
+      get("#{collection_id}/product_ids")
     end
   end
 end

--- a/lib/shopify_api/resources/product_listing.rb
+++ b/lib/shopify_api/resources/product_listing.rb
@@ -1,9 +1,7 @@
 module ShopifyAPI
   class ProductListing < Base
-    init_prefix :application
-
-    def self.product_ids(options = {})
-      get(:product_ids, options[:params])
+    def self.product_ids
+      get(:product_ids)
     end
   end
 end

--- a/test/collection_listing_test.rb
+++ b/test/collection_listing_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class CollectionListingTest < Test::Unit::TestCase
 
   def test_get_collection_listings
-    fake "applications/999/collection_listings", method: :get, status: 201, body: load_fixture('collection_listings')
+    fake "collection_listings", method: :get, status: 201, body: load_fixture('collection_listings')
 
-    collection_listings = ShopifyAPI::CollectionListing.find(:all, params: { application_id: 999 })
+    collection_listings = ShopifyAPI::CollectionListing.find(:all)
 
     assert_equal 1, collection_listings.count
     assert_equal 1, collection_listings.first.collection_id
@@ -13,10 +13,10 @@ class CollectionListingTest < Test::Unit::TestCase
   end
 
   def test_get_collection_listing_for_collection_id
-    fake "applications/999/collection_listings/1", method: :get, status: 201, body: load_fixture('collection_listing')
-    fake "applications/999/collection_listings//1/product_ids", method: :get, status: 201, body: load_fixture('collection_listing_product_ids')
+    fake "collection_listings/1", method: :get, status: 201, body: load_fixture('collection_listing')
+    fake "collection_listings//1/product_ids", method: :get, status: 201, body: load_fixture('collection_listing_product_ids')
 
-    collection_listing = ShopifyAPI::CollectionListing.find(1, params: { application_id: 999 })
+    collection_listing = ShopifyAPI::CollectionListing.find(1)
 
     assert_equal 1, collection_listing.collection_id
     assert_equal 'Home page', collection_listing.title

--- a/test/product_listing_test.rb
+++ b/test/product_listing_test.rb
@@ -3,9 +3,9 @@ require 'test_helper'
 class ProductListingTest < Test::Unit::TestCase
 
   def test_get_product_listings
-    fake "applications/999/product_listings", method: :get, status: 201, body: load_fixture('product_listings')
+    fake "product_listings", method: :get, status: 201, body: load_fixture('product_listings')
 
-    product_listings = ShopifyAPI::ProductListing.find(:all, params: { application_id: 999 })
+    product_listings = ShopifyAPI::ProductListing.find(:all)
     assert_equal 2, product_listings.count
     assert_equal 2, product_listings.first.product_id
     assert_equal 1, product_listings.last.product_id
@@ -14,16 +14,16 @@ class ProductListingTest < Test::Unit::TestCase
   end
 
   def test_get_product_listing_for_product_id
-    fake "applications/999/product_listings/2", method: :get, status: 201, body: load_fixture('product_listing')
+    fake "product_listings/2", method: :get, status: 201, body: load_fixture('product_listing')
 
-    product_listing = ShopifyAPI::ProductListing.find(2, params: { application_id: 999 })
+    product_listing = ShopifyAPI::ProductListing.find(2)
     assert_equal 'Synergistic Silk Chair', product_listing.title
   end
 
   def test_get_product_listing_product_ids
-    fake "applications/999/product_listings/product_ids", method: :get, status: 201, body: load_fixture('product_listing_product_ids')
+    fake "product_listings/product_ids", method: :get, status: 201, body: load_fixture('product_listing_product_ids')
 
-    product_ids = ShopifyAPI::ProductListing.product_ids(params: { application_id: 999 })
+    product_ids = ShopifyAPI::ProductListing.product_ids
     assert_equal 2, product_ids.count
     assert_equal 2, product_ids.first
     assert_equal 1, product_ids.last


### PR DESCRIPTION
We've deprecated the endpoint in Shopify that took an application id as part of the URL, because the application can be assumed from the context of the request.

This changes our Ruby library to reflect these changes.