### PR TITLE
Fix bug with listing classes

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,4 @@
-== Version 4.6.0
+== Version 4.7.0
 
 * Removed the mandatory `application_id` parameter from `ShopifyAPI::ProductListing` and `ShopifyAPI::CollectionListing`
 * Fixed a bug related to the non-standard primary key for `ShopifyAPI::ProductListing` and `ShopifyAPI::CollectionListing`

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,6 +1,7 @@
 == Version 4.6.0
 
 * Removed the mandatory `application_id` parameter from `ShopifyAPI::ProductListing` and `ShopifyAPI::CollectionListing`
+* Fixed a bug related to the non-standard primary key for `ShopifyAPI::ProductListing` and `ShopifyAPI::CollectionListing`
 
 == Version 4.6.0
 

--- a/lib/shopify_api/resources/collection_listing.rb
+++ b/lib/shopify_api/resources/collection_listing.rb
@@ -1,7 +1,9 @@
 module ShopifyAPI
   class CollectionListing < Base
+    self.primary_key = :collection_id
+
     def product_ids
-      get("#{collection_id}/product_ids")
+      get(:product_ids)
     end
   end
 end

--- a/lib/shopify_api/resources/product_listing.rb
+++ b/lib/shopify_api/resources/product_listing.rb
@@ -1,5 +1,7 @@
 module ShopifyAPI
   class ProductListing < Base
+    self.primary_key = :product_id
+
     def self.product_ids
       get(:product_ids)
     end

--- a/test/collection_listing_test.rb
+++ b/test/collection_listing_test.rb
@@ -12,14 +12,30 @@ class CollectionListingTest < Test::Unit::TestCase
     assert_equal 'Home page', collection_listings.first.title
   end
 
-  def test_get_collection_listing_for_collection_id
+  def test_get_collection_listing
     fake "collection_listings/1", method: :get, status: 201, body: load_fixture('collection_listing')
-    fake "collection_listings//1/product_ids", method: :get, status: 201, body: load_fixture('collection_listing_product_ids')
 
     collection_listing = ShopifyAPI::CollectionListing.find(1)
 
     assert_equal 1, collection_listing.collection_id
     assert_equal 'Home page', collection_listing.title
+  end
+
+  def test_get_collection_listing_reload
+    fake "collection_listings/1", method: :get, status: 201, body: load_fixture('collection_listing')
+
+    collection_listing = ShopifyAPI::CollectionListing.new(collection_id: 1)
+    collection_listing.reload
+
+    assert_equal 1, collection_listing.collection_id
+    assert_equal 'Home page', collection_listing.title
+  end
+
+  def test_get_collection_listing_product_ids
+    fake "collection_listings/1/product_ids", method: :get, status: 201, body: load_fixture('collection_listing_product_ids')
+
+    collection_listing = ShopifyAPI::CollectionListing.new(collection_id: 1)
+
     assert_equal [1, 2], collection_listing.product_ids
   end
 end

--- a/test/product_listing_test.rb
+++ b/test/product_listing_test.rb
@@ -13,10 +13,19 @@ class ProductListingTest < Test::Unit::TestCase
     assert_equal 'Rustic Copper Bottle', product_listings.last.title
   end
 
-  def test_get_product_listing_for_product_id
+  def test_get_product_listing
     fake "product_listings/2", method: :get, status: 201, body: load_fixture('product_listing')
 
     product_listing = ShopifyAPI::ProductListing.find(2)
+    assert_equal 'Synergistic Silk Chair', product_listing.title
+  end
+
+  def test_reload_product_listing
+    fake "product_listings/2", method: :get, status: 201, body: load_fixture('product_listing')
+
+    product_listing = ShopifyAPI::ProductListing.new(product_id: 2)
+    product_listing.reload
+
     assert_equal 'Synergistic Silk Chair', product_listing.title
   end
 


### PR DESCRIPTION
The listing classes were broken, because they were trying to use the `id` field as a primary key, which doesn't exist for listings. This tells ActiveResource to use the underlying object id as the primary key.

This was the reason the URL for fetching the product ids for collections was "/admin/collection_listings//123/product_ids.json" (note the double "//") -- ActiveResource was trying to fill in an id between the slashes, but just ended up rendering an empty string (`nil.to_s`)