### PR TITLE
Add support for marketing event engagements

### DIFF
--- a/lib/shopify_api/resources/engagement.rb
+++ b/lib/shopify_api/resources/engagement.rb
@@ -1,0 +1,4 @@
+module ShopifyAPI
+  class Engagement < Base
+  end
+end

--- a/lib/shopify_api/resources/engagement.rb
+++ b/lib/shopify_api/resources/engagement.rb
@@ -1,4 +1,0 @@
-module ShopifyAPI
-  class Engagement < Base
-  end
-end

--- a/lib/shopify_api/resources/marketing_event.rb
+++ b/lib/shopify_api/resources/marketing_event.rb
@@ -1,7 +1,7 @@
 module ShopifyAPI
   class MarketingEvent < Base
     def add_engagements(engagements)
-      engagements = { engagements: Array(engagements) }
+      engagements = { engagements: Array.wrap(engagements) }
       post(:engagements, {}, engagements.to_json)
     end
   end

--- a/lib/shopify_api/resources/marketing_event.rb
+++ b/lib/shopify_api/resources/marketing_event.rb
@@ -1,4 +1,8 @@
 module ShopifyAPI
   class MarketingEvent < Base
+    def add_engagements(engagements)
+      engagements = {engagements: Array(engagements)}
+      post(:engagements, {}, engagements.to_json)
+    end
   end
 end

--- a/lib/shopify_api/resources/marketing_event.rb
+++ b/lib/shopify_api/resources/marketing_event.rb
@@ -1,7 +1,7 @@
 module ShopifyAPI
   class MarketingEvent < Base
     def add_engagements(engagements)
-      engagements = {engagements: Array(engagements)}
+      engagements = { engagements: Array(engagements) }
       post(:engagements, {}, engagements.to_json)
     end
   end

--- a/test/fixtures/engagement.json
+++ b/test/fixtures/engagement.json
@@ -1,0 +1,15 @@
+{
+  "engagements": [
+    {
+      "occurred_on": "2017-04-20",
+      "impressions_count": null,
+      "views_count": null,
+      "clicks_count": 10,
+      "shares_count": null,
+      "favorites_count": null,
+      "comments_count": null,
+      "ad_spend": null,
+      "is_cumulative": true
+    }
+  ]
+}

--- a/test/marketing_event_test.rb
+++ b/test/marketing_event_test.rb
@@ -49,7 +49,7 @@ class MarketingEventTest < Test::Unit::TestCase
 
   def test_add_engagements
     fake "marketing_events/1", method: :get, body: load_fixture('marketing_event')
-    marketing_events = ShopifyAPI::MarketingEvent.find(1)
+    marketing_event = ShopifyAPI::MarketingEvent.find(1)
     fake "marketing_events/1/engagements", method: :post, status: 201, body: load_fixture('engagement')
     engagement = ShopifyAPI::Engagement.new(
       occurred_on: "2017-04-20",
@@ -62,6 +62,7 @@ class MarketingEventTest < Test::Unit::TestCase
       ad_spend: nil,
       is_cumulative: true
     )
+    marketing_event.post(:engagements, {}, {engagements: Array(engagement)}.to_json)
     assert "2017-04-20", engagement.occurred_on
   end
 end

--- a/test/marketing_event_test.rb
+++ b/test/marketing_event_test.rb
@@ -62,7 +62,7 @@ class MarketingEventTest < Test::Unit::TestCase
       ad_spend: nil,
       is_cumulative: true
     )
-    marketing_event.post(:engagements, {}, {engagements: Array(engagement)}.to_json)
+    marketing_event.add_engagements(engagement)
     assert "2017-04-20", engagement.occurred_on
   end
 end

--- a/test/marketing_event_test.rb
+++ b/test/marketing_event_test.rb
@@ -51,7 +51,7 @@ class MarketingEventTest < Test::Unit::TestCase
     fake "marketing_events/1", method: :get, body: load_fixture('marketing_event')
     marketing_event = ShopifyAPI::MarketingEvent.find(1)
     fake "marketing_events/1/engagements", method: :post, status: 201, body: load_fixture('engagement')
-    engagement = ShopifyAPI::Engagement.new(
+    engagement = {
       occurred_on: "2017-04-20",
       impressions_count: nil,
       views_count: nil,
@@ -61,7 +61,7 @@ class MarketingEventTest < Test::Unit::TestCase
       comments_count: nil,
       ad_spend: nil,
       is_cumulative: true
-    )
+    }
     marketing_event.add_engagements(engagement)
     assert "2017-04-20", engagement.occurred_on
   end

--- a/test/marketing_event_test.rb
+++ b/test/marketing_event_test.rb
@@ -63,6 +63,6 @@ class MarketingEventTest < Test::Unit::TestCase
       is_cumulative: true
     }
     marketing_event.add_engagements(engagement)
-    assert "2017-04-20", engagement.occurred_on
+    assert "2017-04-20", engagement[:occurred_on]
   end
 end

--- a/test/marketing_event_test.rb
+++ b/test/marketing_event_test.rb
@@ -46,4 +46,22 @@ class MarketingEventTest < Test::Unit::TestCase
     marketing_events_count = ShopifyAPI::MarketingEvent.get(:count)
     assert_equal 2, marketing_events_count
   end
+
+  def test_add_engagements
+    fake "marketing_events/1", method: :get, body: load_fixture('marketing_event')
+    marketing_events = ShopifyAPI::MarketingEvent.find(1)
+    fake "marketing_events/1/engagements", method: :post, status: 201, body: load_fixture('engagement')
+    engagement = ShopifyAPI::Engagement.new(
+      occurred_on: "2017-04-20",
+      impressions_count: nil,
+      views_count: nil,
+      clicks_count: 10,
+      shares_count: nil,
+      favorites_count: nil,
+      comments_count: nil,
+      ad_spend: nil,
+      is_cumulative: true
+    )
+    assert "2017-04-20", engagement.occurred_on
+  end
 end


### PR DESCRIPTION
Hey Shopify team!

With the new announcement, and 1.0, of the Marketing Events API we are about to starting using it at Sweet Tooth to show real engagement statistics to merchants. 

As documented, marketing events have associated engagements which track views, clicks, etc. The endpoint is as follows:

![image](https://cloud.githubusercontent.com/assets/8283063/25496794/45f1a7ee-2b50-11e7-8598-23820a7b297f.png)

Right now there is no official support for engagement via this gem. And ideally, for best practice, we want to avoid directly using `ActiveResource` REST methods from within our codebase. This PR introduces a small wrapper, that allows us to nicely create engagements. 

The specs are included as well.