### PR TITLE
[Do not merge] Switching to legacy path for discounts

### DIFF
--- a/lib/shopify_api/resources/discount.rb
+++ b/lib/shopify_api/resources/discount.rb
@@ -1,9 +1,11 @@
 module ShopifyAPI
   class Discount < Base
+    self.element_name = 'legacy_discount'
+
     def disable
       load_attributes_from_response(post(:disable))
     end
-    
+
     def enable
       load_attributes_from_response(post(:enable))
     end

--- a/test/discount_test.rb
+++ b/test/discount_test.rb
@@ -2,50 +2,50 @@ require 'test_helper'
 
 class DiscountTest < Test::Unit::TestCase
   test 'get should get a discount' do
-    fake 'discounts/680866', method: :get, status: 200, body: load_fixture('discount')
-    
+    fake 'legacy_discounts/680866', method: :get, status: 200, body: load_fixture('discount')
+
     discount = ShopifyAPI::Discount.find(680866)
     assert_equal 680866, discount.id
   end
-  
+
   test 'get should get all discounts' do
-    fake 'discounts', method: :get, status: 200, body: load_fixture('discounts')
-    
+    fake 'legacy_discounts', method: :get, status: 200, body: load_fixture('discounts')
+
     discounts = ShopifyAPI::Discount.all
     assert_equal 'TENOFF', discounts.first.code
   end
-  
+
   test 'create should create a discount' do
-    fake 'discounts', method: :post, status: 201, body: load_fixture('discount')
-    
+    fake 'legacy_discounts', method: :post, status: 201, body: load_fixture('discount')
+
     discount = ShopifyAPI::Discount.create(code: 'TENOFF', discount_type: 'percentage')
     assert_equal 'TENOFF', discount.code
   end
-  
+
   test 'should disable discount' do
-    fake 'discounts/680866', method: :get, status: 200, body: load_fixture('discount')
-    fake 'discounts/680866/disable', method: :post, status: 201, body: load_fixture('discount_disabled')
-    
+    fake 'legacy_discounts/680866', method: :get, status: 200, body: load_fixture('discount')
+    fake 'legacy_discounts/680866/disable', method: :post, status: 201, body: load_fixture('discount_disabled')
+
     discount = ShopifyAPI::Discount.find(680866)
     discount.disable
-    
+
     assert_equal "disabled", discount.status
   end
-  
+
   test 'should enable discount' do
-    fake 'discounts/680866', method: :get, status: 200, body: load_fixture('discount')
-    fake 'discounts/680866/enable', method: :post, status: 201, body: load_fixture('discount')
-    
+    fake 'legacy_discounts/680866', method: :get, status: 200, body: load_fixture('discount')
+    fake 'legacy_discounts/680866/enable', method: :post, status: 201, body: load_fixture('discount')
+
     discount = ShopifyAPI::Discount.find(680866)
     discount.enable
-    
+
     assert_equal "enabled", discount.status
   end
-  
+
   test 'delete should delete discount' do
-    fake 'discounts/680866', method: :get, status: 200, body: load_fixture('discount')
-    fake 'discounts/680866', method: :delete, status: 200, body: 'destroyed'
-    
+    fake 'legacy_discounts/680866', method: :get, status: 200, body: load_fixture('discount')
+    fake 'legacy_discounts/680866', method: :delete, status: 200, body: 'destroyed'
+
     discount = ShopifyAPI::Discount.find(680866)
     assert discount.destroy
   end


### PR DESCRIPTION
[Do not merge] This is not ready yet!

The Discounts API is deprecated in Shopify, **only one internal app uses it** and we'd like to have it use `legacy_discounts/` until we completely 🔥  it.

 This PR adds an `element_name` to the `Discount` resource to use the `legacy_discounts/` path instead of `discounts/`.
