### PR TITLE
Test build on multiple Ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 sudo: false
 
 rvm:
-  - '2.0'
-  - 2.3.1
-  - 2.4.0-preview1
+  - '2.2'
+  - 2.3.6
+  - 2.4.3
+  - 2.5.0
 
 gemfile:
   - Gemfile
@@ -15,22 +16,4 @@ gemfile:
   - Gemfile_ar_master
 
 matrix:
-  exclude:
-    - rvm: '2.0'
-      gemfile: Gemfile_ar_master
   fast_finish: true
-  allow_failures:
-    - rvm: 2.4.0-preview1
-      gemfile: Gemfile
-    - rvm: 2.4.0-preview1
-      gemfile: Gemfile_ar30
-    - rvm: 2.4.0-preview1
-      gemfile: Gemfile_ar31
-    - rvm: 2.4.0-preview1
-      gemfile: Gemfile_ar32
-    - rvm: 2.4.0-preview1
-      gemfile: Gemfile_ar40
-    - rvm: 2.4.0-preview1
-      gemfile: Gemfile_ar_master
-    - rvm: 2.3.1
-      gemfile: Gemfile_ar_master

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,5 +27,5 @@ matrix:
       gemfile: Gemfile_ar_master
     - rvm: 2.3.6
       gemfile: Gemfile_ar_master
-    - rvm: 2.2
+    - rvm: '2.2'
       gemfile: Gemfile_ar_master

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+before_install: gem update --system
 sudo: false
 
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,14 @@ gemfile:
 
 matrix:
   fast_finish: true
+  allow_failures:
+    - rvm: 2.5.0
+      gemfile: Gemfile_ar30
+    - rvm: 2.5.0
+      gemfile: Gemfile_ar_master
+    - rvm: 2.4.3
+      gemfile: Gemfile_ar_master
+    - rvm: 2.3.6
+      gemfile: Gemfile_ar_master
+    - rvm: 2.2
+      gemfile: Gemfile_ar_master

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -204,7 +204,7 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "raise error if timestamp is too old" do
-    params = {:code => "any-code", :timestamp => Time.now - 2.days}
+    params = {:code => "any-code", :timestamp => Time.now - 2.days.to_i}
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -204,7 +204,12 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "raise error if timestamp is too old" do
-    params = {:code => "any-code", :timestamp => Time.now - 2.days.to_i}
+    delay = begin
+      2.days.to_i
+    rescue TypeError # Bug with ActiveRecord 3.x and Ruby 2.4.3
+      172_800
+    end
+    params = {:code => "any-code", :timestamp => Time.now - delay}
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do


### PR DESCRIPTION
Note that `rails-observers` (`0.1.5`) requires Ruby version `>= 2.2.2`.