### PR TITLE
Fetch order with custom properties

### DIFF
--- a/lib/shopify_api/resources/line_item.rb
+++ b/lib/shopify_api/resources/line_item.rb
@@ -1,6 +1,14 @@
 module ShopifyAPI
-  class LineItem < Base 
+  class LineItem < Base
     class Property < Base
+      def initialize(*args)
+        attributes = args[0] || {}
+        persisted = args[1] || false
+        super
+      rescue NameError
+        attributes = attributes.to_hash
+        self
+      end
     end
   end
 end

--- a/test/fixtures/order_with_properties.json
+++ b/test/fixtures/order_with_properties.json
@@ -1,0 +1,373 @@
+{
+  "order": {
+    "buyer_accepts_marketing": false,
+    "cancel_reason": null,
+    "cancelled_at": null,
+    "cart_token": "68778783ad298f1c80c3bafcddeea02f",
+    "checkout_token": null,
+    "closed_at": null,
+    "confirmed": false,
+    "created_at": "2008-01-10T11:00:00-05:00",
+    "currency": "USD",
+    "email": "bob.norman@hostmail.com",
+    "financial_status": "authorized",
+    "fulfillment_status": null,
+    "gateway": "authorize_net",
+    "id": 450789469,
+    "landing_site": "http://www.example.com?source=abc",
+    "location_id": null,
+    "name": "#1001",
+    "note": "Test note",
+    "number": 1,
+    "reference": "fhwdgads",
+    "referring_site": "http://www.otherexample.com",
+    "source": null,
+    "source_identifier": "fhwdgads",
+    "source_name": "web",
+    "source_url": null,
+    "subtotal_price": "398.00",
+    "taxes_included": false,
+    "test": false,
+    "token": "b1946ac92492d2347c6235b4d2611184",
+    "total_discounts": "0.00",
+    "total_line_items_price": "398.00",
+    "total_price": "409.94",
+    "total_price_usd": "409.94",
+    "total_tax": "11.94",
+    "total_weight": 0,
+    "updated_at": "2008-01-10T11:00:00-05:00",
+    "user_id": null,
+    "browser_ip": null,
+    "landing_site_ref": "abc",
+    "order_number": 1001,
+    "discount_codes": [],
+    "note_attributes": [],
+    "processing_method": "direct",
+    "checkout_id": 450789469,
+    "tax_lines": [
+      {
+        "price": "11.94",
+        "rate": 0.06,
+        "title": "State Tax"
+      }
+    ],
+    "tags": "",
+    "line_items": [
+      {
+        "fulfillment_service": "manual",
+        "fulfillment_status": null,
+        "grams": 1361,
+        "id": 466157049,
+        "price": "45.00",
+        "product_id": 632910392,
+        "quantity": 1,
+        "requires_shipping": true,
+        "sku": "",
+        "taxable": true,
+        "title": "Create Your Own Coffee 3 Pack",
+        "variant_id": 39072856,
+        "variant_title": "",
+        "vendor": "VCR",
+        "name": "Create Your Own Coffee 3 Pack",
+        "variant_inventory_management": null,
+        "properties": [
+          {
+            "name": "1st Coffee",
+            "value": "Coffee1"
+          },
+          {
+            "name": "2nd Coffee",
+            "value": "Coffee2"
+          },
+          {
+            "name": "3rd Coffee",
+            "value": "Coffee3"
+          },
+          {
+            "name": "Select Your Grind",
+            "value": "Ground"
+          }
+        ],
+        "product_exists": true,
+        "tax_lines": [
+
+        ]
+      },
+      {
+        "fulfillment_service": "manual",
+        "fulfillment_status": null,
+        "grams": 680,
+        "id": 641254555689,
+        "price": "24.00",
+        "product_id": 288331137065,
+        "quantity": 1,
+        "requires_shipping": true,
+        "sku": "",
+        "taxable": true,
+        "title": "Create Your Own Coffee 3 Pack (8oz bags)",
+        "variant_id": 4107806867497,
+        "variant_title": "",
+        "vendor": "OMC",
+        "name": "Create Your Own Coffee 3 Pack (8oz bags)",
+        "variant_inventory_management": null,
+        "properties": [
+          {
+            "name": "By default may label with \"Roasted for ",
+            "value": {
+              "Your First Name": {
+                "\". If you want something specific on the label, enter it here:": ""
+              }
+            }
+          },
+          {
+            "name": "Select Your Grind",
+            "value": "Ground"
+          },
+          {
+            "name": "Coffees",
+            "value": "Coffee blend 1"
+          },
+          {
+            "name": "Coffees",
+            "value": "Coffee blend 2"
+          },
+          {
+            "name": "Coffees",
+            "value": "Coffee blend 3"
+          }
+        ],
+        "product_exists": true,
+        "tax_lines": [
+
+        ]
+      }
+    ],
+    "shipping_lines": [
+      {
+        "code": "Free Shipping",
+        "price": "0.00",
+        "source": "shopify",
+        "title": "Free Shipping",
+        "tax_lines": [
+
+        ]
+      }
+    ],
+    "payment_details": {
+      "avs_result_code": null,
+      "credit_card_bin": null,
+      "cvv_result_code": null,
+      "credit_card_number": "XXXX-XXXX-XXXX-4242",
+      "credit_card_company": "Visa"
+    },
+    "billing_address": {
+      "address1": "Chestnut Street 92",
+      "address2": "",
+      "city": "Louisville",
+      "company": null,
+      "country": "United States",
+      "first_name": "Bob",
+      "last_name": "Norman",
+      "latitude": "45.41634",
+      "longitude": "-75.6868",
+      "phone": "555-625-1199",
+      "province": "Kentucky",
+      "zip": "40202",
+      "name": "Bob Norman",
+      "country_code": "US",
+      "province_code": "KY"
+    },
+    "shipping_address": {
+      "address1": "Chestnut Street 92",
+      "address2": "",
+      "city": "Louisville",
+      "company": null,
+      "country": "United States",
+      "first_name": "Bob",
+      "last_name": "Norman",
+      "latitude": "45.41634",
+      "longitude": "-75.6868",
+      "phone": "555-625-1199",
+      "province": "Kentucky",
+      "zip": "40202",
+      "name": "Bob Norman",
+      "country_code": "US",
+      "province_code": "KY"
+    },
+    "fulfillments": [
+      {
+        "created_at": "2014-03-07T16:14:08-05:00",
+        "id": 255858046,
+        "order_id": 450789469,
+        "service": "manual",
+        "status": "failure",
+        "tracking_company": null,
+        "updated_at": "2014-03-07T16:14:08-05:00",
+        "tracking_number": "1Z2345",
+        "tracking_numbers": [
+          "1Z2345"
+        ],
+        "tracking_url": "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track",
+        "tracking_urls": [
+          "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track"
+        ],
+        "receipt": {
+          "testcase": true,
+          "authorization": "123456"
+        },
+        "line_items": [
+          {
+            "fulfillment_service": "manual",
+            "fulfillment_status": null,
+            "grams": 680,
+            "id": 641254555689,
+            "price": "24.00",
+            "product_id": 288331137065,
+            "quantity": 1,
+            "requires_shipping": true,
+            "sku": "",
+            "taxable": true,
+            "title": "Create Your Own Coffee 3 Pack (8oz bags)",
+            "variant_id": 4107806867497,
+            "variant_title": "",
+            "vendor": "OMC",
+            "name": "Create Your Own Coffee 3 Pack (8oz bags)",
+            "variant_inventory_management": null,
+            "properties": [
+              {
+                "name": "By default may label with \"Roasted for ",
+                "value": {
+                  "Your First Name": {
+                    "\". If you want something specific on the label, enter it here:": ""
+                  }
+                }
+              },
+              {
+                "name": "Select Your Grind",
+                "value": "Ground"
+              },
+              {
+                "name": "Coffees",
+                "value": "Coffee blend 1"
+              },
+              {
+                "name": "Coffees",
+                "value": "Coffee blend 2"
+              },
+              {
+                "name": "Coffees",
+                "value": "Coffee blend 3"
+              }
+            ],
+            "product_exists": true,
+            "tax_lines": [
+
+            ]
+          }
+        ]
+      },
+      {
+        "created_at": "2014-03-07T16:14:08-05:00",
+        "id": 255858046,
+        "order_id": 450789469,
+        "service": "manual",
+        "status": "failure",
+        "tracking_company": null,
+        "updated_at": "2014-03-07T16:14:08-05:00",
+        "tracking_number": "1Z2345",
+        "tracking_numbers": [
+          "1Z2345"
+        ],
+        "tracking_url": "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track",
+        "tracking_urls": [
+          "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track"
+        ],
+        "receipt": {},
+        "line_items": [
+          {
+            "fulfillment_service": "manual",
+            "fulfillment_status": null,
+            "grams": 1361,
+            "id": 466157049,
+            "price": "45.00",
+            "product_id": 632910392,
+            "quantity": 1,
+            "requires_shipping": true,
+            "sku": "",
+            "taxable": true,
+            "title": "Create Your Own Coffee 3 Pack",
+            "variant_id": 39072856,
+            "variant_title": "",
+            "vendor": "VCR",
+            "name": "Create Your Own Coffee 3 Pack",
+            "variant_inventory_management": null,
+            "properties": [
+              {
+                "name": "1st Coffee",
+                "value": "Coffee1"
+              },
+              {
+                "name": "2nd Coffee",
+                "value": "Coffee2"
+              },
+              {
+                "name": "3rd Coffee",
+                "value": "Coffee3"
+              },
+              {
+                "name": "Select Your Grind",
+                "value": "Ground"
+              }
+            ],
+            "product_exists": true,
+            "tax_lines": [
+
+            ]
+          }
+        ]
+      }
+    ],
+    "client_details": {
+      "accept_language": null,
+      "browser_ip": "0.0.0.0",
+      "session_hash": null,
+      "user_agent": null
+    },
+    "customer": {
+      "accepts_marketing": false,
+      "created_at": "2014-03-07T16:14:08-05:00",
+      "email": "bob.norman@hostmail.com",
+      "first_name": "Bob",
+      "id": 207119551,
+      "last_name": "Norman",
+      "last_order_id": null,
+      "multipass_identifier": null,
+      "note": null,
+      "orders_count": 0,
+      "state": "disabled",
+      "total_spent": "0.00",
+      "updated_at": "2014-03-07T16:14:08-05:00",
+      "verified_email": true,
+      "tags": "",
+      "last_order_name": null,
+      "default_address": {
+        "address1": "Chestnut Street 92",
+        "address2": "",
+        "city": "Louisville",
+        "company": null,
+        "country": "United States",
+        "first_name": null,
+        "id": 207119551,
+        "last_name": null,
+        "phone": "555-625-1199",
+        "province": "Kentucky",
+        "zip": "40202",
+        "name": null,
+        "province_code": "KY",
+        "country_code": "US",
+        "country_name": "United States",
+        "default": true
+      }
+    }
+  }
+}

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -8,8 +8,21 @@ class OrderTest < Test::Unit::TestCase
     assert_equal 39072856, order.line_items.first.variant_id
   end
 
+  test "create should create an order with custom properties" do
+    props = [{ :"By default may label with \"Roasted for " => { :"Your First Name" => { :"\". If you want something specific on the label, enter it here:" => "" }}}]
+    fake 'orders', :method => :post, :status => 201, :body => load_fixture('order_with_properties')
+    order = ShopifyAPI::Order.create(line_items: [{quantity:1, variant_id:39072856, properties:props}], financial_status:"authorized")
+    assert_equal 39072856, order.line_items.first.variant_id
+  end
+
   test "get should get an order" do
     fake 'orders/450789469', :method => :get, :status => 200, :body => load_fixture('order')
+    order = ShopifyAPI::Order.find(450789469)
+    assert_equal 450789469, order.id
+  end
+
+  test "get should get an order with custom properties" do
+    fake 'orders/450789469', :method => :get, :status => 200, :body => load_fixture('order_with_properties')
     order = ShopifyAPI::Order.find(450789469)
     assert_equal 450789469, order.id
   end
@@ -44,4 +57,3 @@ class OrderTest < Test::Unit::TestCase
     assert_request_body({'email' => false, 'restock' => true}.to_json)
   end
 end
-


### PR DESCRIPTION
We are seeing an error where `ActiveResource` tries to (incorrectly) create a resource to load an order's line_item property hash value. The workaround in this PR is to rescue the `NameError` and return the attributes as a hash (and not a resource).