### PR TITLE
Add Access Scope

### DIFF
--- a/lib/shopify_api/resources/access_scope.rb
+++ b/lib/shopify_api/resources/access_scope.rb
@@ -1,0 +1,5 @@
+module ShopifyAPI
+  class AccessScope < Base
+    self.prefix = '/admin/oauth/'
+  end
+end


### PR DESCRIPTION
Added `AccessScope` to the ShopifyAPI in https://github.com/Shopify/shopify/pull/145004 via `test/api/unit/access_scope_api_test.rb`, but now I will be removing it from that file via https://github.com/Shopify/shopify/pull/146422 and adding it directly to the API in this PR.