### PR TITLE
Unwrap method body

### DIFF
--- a/lib/shopify_api/resources/order.rb
+++ b/lib/shopify_api/resources/order.rb
@@ -3,8 +3,13 @@ module ShopifyAPI
     include Events
     include Metafields
 
-    def close;  load_attributes_from_response(post(:close, {}, only_id)); end
-    def open;   load_attributes_from_response(post(:open, {}, only_id)); end
+    def close
+      load_attributes_from_response(post(:close, {}, only_id))
+    end
+
+    def open
+      load_attributes_from_response(post(:open, {}, only_id))
+    end
 
     def cancel(options = {})
       load_attributes_from_response(post(:cancel, {}, options.to_json))


### PR DESCRIPTION
This is needed to keep the class coding style, improving readability