### PR TITLE
Remove trailing whitespaces from lib/

### DIFF
--- a/lib/shopify_api/resources/asset.rb
+++ b/lib/shopify_api/resources/asset.rb
@@ -42,7 +42,7 @@ module ShopifyAPI
       prefix_options, query_options = split_options(prefix_options) if query_options.nil?
       "#{prefix(prefix_options)}#{collection_name}.#{format.extension}#{query_string(query_options)}"
     end
-    
+
     # find an asset by key:
     #   ShopifyAPI::Asset.find('layout/theme.liquid', :params => {:theme_id => 99})
     def self.find(*args)
@@ -57,7 +57,7 @@ module ShopifyAPI
         resource
       end
     end
-    
+
     # For text assets, Shopify returns the data in the 'value' attribute.
     # For binary assets, the data is base-64-encoded and returned in the
     # 'attachment' attribute. This accessor returns the data in both cases.
@@ -65,28 +65,28 @@ module ShopifyAPI
       attributes['value'] ||
       (attributes['attachment'] ? Base64.decode64(attributes['attachment']) : nil)
     end
-    
+
     def attach(data)
       self.attachment = Base64.encode64(data)
     end
-    
+
     def destroy
       connection.delete(element_path(prefix_options.merge(:asset => {:key => key})), self.class.headers)
     end
-    
+
     def new?
       false
     end
-    
+
     def method_missing(method_symbol, *arguments) #:nodoc:
       if %w{value= attachment= src= source_key=}.include?(method_symbol)
         wipe_value_attributes
       end
       super
     end
-    
+
     private
-    
+
     def wipe_value_attributes
       %w{value attachment src source_key}.each do |attr|
         attributes.delete(attr)

--- a/lib/shopify_api/resources/billing_address.rb
+++ b/lib/shopify_api/resources/billing_address.rb
@@ -1,4 +1,4 @@
 module ShopifyAPI
   class BillingAddress < Base
-  end         
+  end
 end

--- a/lib/shopify_api/resources/custom_collection.rb
+++ b/lib/shopify_api/resources/custom_collection.rb
@@ -6,14 +6,14 @@ module ShopifyAPI
     def products
       Product.find(:all, :params => {:collection_id => self.id})
     end
-    
+
     def add_product(product)
       Collect.create(:collection_id => self.id, :product_id => product.id)
     end
-    
+
     def remove_product(product)
       collect = Collect.find(:first, :params => {:collection_id => self.id, :product_id => product.id})
       collect.destroy if collect
     end
-  end                                                                 
+  end
 end

--- a/lib/shopify_api/resources/image.rb
+++ b/lib/shopify_api/resources/image.rb
@@ -1,13 +1,13 @@
 module ShopifyAPI
   class Image < Base
     init_prefix :product
-    
+
     # generate a method for each possible image variant
     [:pico, :icon, :thumb, :small, :compact, :medium, :large, :grande, :original].each do |m|
       reg_exp_match = "/\\1_#{m}.\\2"
       define_method(m) { src.gsub(/\/(.*)\.(\w{2,4})/, reg_exp_match) }
     end
-    
+
     def attach_image(data, filename = nil)
       attributes['attachment'] = Base64.encode64(data)
       attributes['filename'] = filename unless filename.nil?

--- a/lib/shopify_api/resources/product.rb
+++ b/lib/shopify_api/resources/product.rb
@@ -13,19 +13,19 @@ module ShopifyAPI
         format % prices.min
       end
     end
-    
+
     def collections
       CustomCollection.find(:all, :params => {:product_id => self.id})
     end
-    
+
     def smart_collections
       SmartCollection.find(:all, :params => {:product_id => self.id})
     end
-    
+
     def add_to_collection(collection)
       collection.add_product(self)
     end
-    
+
     def remove_from_collection(collection)
       collection.remove_product(self)
     end

--- a/lib/shopify_api/resources/shipping_line.rb
+++ b/lib/shopify_api/resources/shipping_line.rb
@@ -1,4 +1,4 @@
 module ShopifyAPI
   class ShippingLine < Base
-  end  
+  end
 end

--- a/lib/shopify_api/resources/shop.rb
+++ b/lib/shopify_api/resources/shop.rb
@@ -1,5 +1,5 @@
 module ShopifyAPI
-  # Shop object. Use Shop.current to receive 
+  # Shop object. Use Shop.current to receive
   # the shop.
   class Shop < Base
     def self.current(options={})
@@ -11,13 +11,13 @@ module ShopifyAPI
     end
 
     def add_metafield(metafield)
-      raise ArgumentError, "You can only add metafields to resource that has been saved" if new?      
+      raise ArgumentError, "You can only add metafields to resource that has been saved" if new?
       metafield.save
       metafield
     end
-    
+
     def events
       Event.find(:all)
     end
-  end               
+  end
 end


### PR DESCRIPTION
This will prevent linters to complain and code editors that has a line wrapping feature enabled to work properly 