### PR TITLE
Added a custom ActiveResource::Collection

### DIFF
--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -19,6 +19,7 @@ end
 require 'shopify_api/events'
 require 'shopify_api/metafields'
 require 'shopify_api/countable'
+require 'shopify_api/collection'
 require 'shopify_api/resources'
 require 'shopify_api/session'
 require 'shopify_api/connection'

--- a/lib/shopify_api/collection.rb
+++ b/lib/shopify_api/collection.rb
@@ -44,7 +44,7 @@ module ShopifyAPI
     #
     # @return [Integer] Maximum number entries per page.
     def limit
-      @limit_value ||= original_params.fetch(:limit, DEFAULT_LIMIT).to_i
+      @limit ||= original_params.fetch(:limit, DEFAULT_LIMIT).to_i
     end
 
     # Gets the number of the next page.

--- a/lib/shopify_api/collection.rb
+++ b/lib/shopify_api/collection.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module ShopifyAPI
   # The Shopify API paginates the resources on the server. By default it will
   # return 50 entries, and a maximum of 250. This custom collection for

--- a/lib/shopify_api/collection.rb
+++ b/lib/shopify_api/collection.rb
@@ -1,0 +1,86 @@
+module ShopifyAPI
+  # The Shopify API paginates the resources on the server. By default it will
+  # return 50 entries, and a maximum of 250. This custom collection for
+  # ActiveResource provides the current page, limit, and total number of
+  # entries available.
+  #
+  # @example
+  #   # Assuming there are 1,000 products in the shop.
+  #   products = ShopifyAPI::Product.all(params: { page: 2, limit: 100 })
+  #   products.current_page # => 2
+  #   products.count # => 100
+  #   products.total_count # => 1000
+  #   products.total_pages # => 10
+  #   products.prev_page # => 1
+  #   products.next_page # => 3
+  class Collection < ActiveResource::Collection
+    # The default amount of entries Shopify responds with if no limit is set.
+    DEFAULT_LIMIT = 50
+
+    # The page number that the collection is currently populated with.
+    #
+    # @return [Integer] The current page.
+    def current_page
+      @current_page ||= original_params.fetch(:page, 1).to_i
+    end
+
+    # Checks if the collection is on the first page.
+    #
+    # @return [true, false] If the current page is the first one.
+    def first_page?
+      current_page.equal?(1)
+    end
+
+    # Checks if the collection is on the last page.
+    #
+    # @return [true, false] If the current page is the last one.
+    def last_page?
+      current_page.equal?(total_pages)
+    end
+
+    # The maximum amount of records each page can have.
+    #
+    # @return [Integer] Maximum number entries per page.
+    def limit
+      @limit_value ||= original_params.fetch(:limit, DEFAULT_LIMIT).to_i
+    end
+
+    # Gets the number of the next page.
+    #
+    # @return [Integer, NilClass] The next page, or nil if on the last one.
+    def next_page
+      current_page + 1 unless last_page?
+    end
+
+    # Gets the number of the previous page.
+    #
+    # @return [Integer, NilClass] The previous page, or nil if on the first one.
+    def prev_page
+      current_page - 1 unless first_page?
+    end
+
+    # Gets the total number of entries available for the given request. The
+    # #count method will return the number of entries in the current
+    # collection. This will return the total number of entries available for
+    # the parameters provided to the request.
+    #
+    # @return [Integer] Total number of non-paginated entries.
+    def total_count
+      @total_count ||= begin
+        # Get the parameters without the pagination parameters.
+        params = original_params.with_indifferent_access.except(:page, :limit)
+
+        # Ask Shopify how many records there are for the given query.
+        resource_class.count(params)
+      end
+    end
+
+    # Calculates the total number of expected pages based on the number
+    # reported by the API.
+    #
+    # @return [Integer] Total number of pages.
+    def total_pages
+      @total_pages ||= (total_count.to_f / limit.to_f).ceil
+    end
+  end
+end

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -4,6 +4,7 @@ module ShopifyAPI
   class Base < ActiveResource::Base
     class InvalidSessionError < StandardError; end
     extend Countable
+    self.collection_parser = ShopifyAPI::Collection
     self.timeout = 90
     self.include_root_in_json = false
     self.headers['User-Agent'] = ["ShopifyAPI/#{ShopifyAPI::VERSION}",

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -15,62 +15,50 @@ class CollectionTest < Test::Unit::TestCase
     assert_equal ShopifyAPI::Base.collection_parser, ShopifyAPI::Collection
   end
 
-  test '#current_page on the first page' do
+  test '#current_page' do
     fake_first_page
     assert_equal 1, fetch.current_page
-  end
 
-  test '#current_page on the second page' do
     fake_page2
     assert_equal 2, fetch(page: 2).current_page
   end
 
-  test '#first_page? on the first page' do
+  test '#first_page?' do
     fake_first_page
     assert fetch.first_page?
-  end
 
-  test '#first_page? when not on the first page' do
     fake_page2
     refute fetch(page: 2).first_page?
   end
 
-  test '#last_page? when not on the last page' do
+  test '#last_page?' do
     fake_first_page
     refute fetch.last_page?
-  end
 
-  test '#last_page when on the last page' do
     fake_last_page
     assert fetch(page: 3).last_page?
   end
 
-  test 'default #limit' do
+  test '#limit' do
     fake_first_page
     assert_equal 50, fetch.limit
-  end
 
-  test 'custom #limit' do
     fake_limit25
     assert_equal 25, fetch(limit: 25).limit
   end
 
-  test '#next_page when not on the last page' do
+  test '#next_page' do
     fake_page2
     assert_equal 3, fetch(page: 2).next_page
-  end
 
-  test '#next_page when on the last page' do
     fake_last_page
     assert_nil fetch(page: 3).next_page
   end
 
-  test '#prev_page when not on the first page' do
+  test '#prev_page' do
     fake_last_page
     assert_equal 2, fetch(page: 3).prev_page
-  end
 
-  test '#prev_page when on the first page' do
     fake_first_page
     assert_nil fetch.prev_page
   end

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -6,84 +6,136 @@ class CollectionTest < Test::Unit::TestCase
   def setup
     super
 
-    fake 'products/count', body: { count: 127 }.to_json
-    fake :products, url: products_url, body: first_page.to_json
-    fake :products, url: products_url(page: 2), body: page2.to_json
-    fake :products, url: products_url(page: 3), body: last_page.to_json
-    fake :products, url: products_url(limit: 25), body: limit25.to_json
+    fake_count
   end
 
   test 'ShopifyAPI::Base::collection_parser' do
+    next if ActiveResource::VERSION::MAJOR < 4
+
     assert_equal ShopifyAPI::Base.collection_parser, ShopifyAPI::Collection
   end
 
-  test '#current_page' do
+  test '#current_page on the first page' do
+    fake_first_page
     assert_equal 1, fetch.current_page
+  end
+
+  test '#current_page on the second page' do
+    fake_page2
     assert_equal 2, fetch(page: 2).current_page
   end
 
-  test '#first_page?' do
+  test '#first_page? on the first page' do
+    fake_first_page
     assert fetch.first_page?
+  end
+
+  test '#first_page? when not on the first page' do
+    fake_page2
     refute fetch(page: 2).first_page?
   end
 
-  test '#last_page?' do
+  test '#last_page? when not on the last page' do
+    fake_first_page
     refute fetch.last_page?
+  end
+
+  test '#last_page when on the last page' do
+    fake_last_page
     assert fetch(page: 3).last_page?
   end
 
-  test '#limit' do
+  test 'default #limit' do
+    fake_first_page
     assert_equal 50, fetch.limit
+  end
+
+  test 'custom #limit' do
+    fake_limit25
     assert_equal 25, fetch(limit: 25).limit
   end
 
-  test '#next_page' do
+  test '#next_page when not on the last page' do
+    fake_page2
     assert_equal 3, fetch(page: 2).next_page
+  end
+
+  test '#next_page when on the last page' do
+    fake_last_page
     assert_nil fetch(page: 3).next_page
   end
 
-  test '#prev_page' do
+  test '#prev_page when not on the first page' do
+    fake_last_page
     assert_equal 2, fetch(page: 3).prev_page
+  end
+
+  test '#prev_page when on the first page' do
+    fake_first_page
     assert_nil fetch.prev_page
   end
 
   test '#total_count' do
+    fake_first_page
     assert_equal 127, fetch.total_count
+
+    fake_page2
     assert_equal 127, fetch(page: 2).total_count
+
+    fake_limit25
     assert_equal 127, fetch(limit: 25).total_count
   end
 
   test '#total_pages' do
+    fake_count
+
+    fake_first_page
     assert_equal 3, fetch.total_pages
+
+    fake_limit25
     assert_equal 6, fetch(limit: 25).total_pages
   end
 
   private
 
+  def fake_count
+    body = { count: 127 }.to_json
+
+    fake 'products/count', body: body
+  end
+
+  def fake_first_page
+    body = fake_products[1..50].to_json
+
+    fake :products, url: products_url, body: body
+  end
+
+  def fake_page2
+    body = fake_products[51..101].to_json
+
+    fake :products, url: products_url(page: 2), body: body
+  end
+
+  def fake_last_page
+    body = fake_products[77..127].to_json
+
+    fake :products, url: products_url(page: 3), body: body
+  end
+
+  def fake_limit25
+    body = fake_products[1..25].to_json
+
+    fake :products, url: products_url(limit: 25), body: body
+  end
+
   def fake_products
-    @fake_products ||= 127.times.map { |index| { id: index } }
+    @fake_products ||= Array.new(127).map { |index| { id: index } }
   end
 
   def fetch(params = {})
     options = params.empty? ? {} : { params: params }
 
     ShopifyAPI::Product.all(options)
-  end
-
-  def first_page
-    @page1 ||= fake_products[1..50]
-  end
-
-  def last_page
-    @last_page ||= fake_products[77..127]
-  end
-
-  def limit25
-    @limit25 = fake_products[1..25]
-  end
-
-  def page2
-    @page2 ||= fake_products[51..101]
   end
 
   def products_url(params = {})

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -1,0 +1,94 @@
+require 'test_helper'
+
+class CollectionTest < Test::Unit::TestCase
+  def setup
+    super
+
+    fake 'products/count', body: { count: 127 }.to_json
+    fake :products, url: products_url, body: first_page.to_json
+    fake :products, url: products_url(page: 2), body: page2.to_json
+    fake :products, url: products_url(page: 3), body: last_page.to_json
+    fake :products, url: products_url(limit: 25), body: limit25.to_json
+  end
+
+  test 'ShopifyAPI::Base::collection_parser' do
+    assert_equal ShopifyAPI::Base.collection_parser, ShopifyAPI::Collection
+  end
+
+  test '#current_page' do
+    assert_equal 1, fetch.current_page
+    assert_equal 2, fetch(page: 2).current_page
+  end
+
+  test '#first_page?' do
+    assert fetch.first_page?
+    refute fetch(page: 2).first_page?
+  end
+
+  test '#last_page?' do
+    refute fetch.last_page?
+    assert fetch(page: 3).last_page?
+  end
+
+  test '#limit' do
+    assert_equal 50, fetch.limit
+    assert_equal 25, fetch(limit: 25).limit
+  end
+
+  test '#next_page' do
+    assert_equal 3, fetch(page: 2).next_page
+    assert_nil fetch(page: 3).next_page
+  end
+
+  test '#prev_page' do
+    assert_equal 2, fetch(page: 3).prev_page
+    assert_nil fetch.prev_page
+  end
+
+  test '#total_count' do
+    assert_equal 127, fetch.total_count
+    assert_equal 127, fetch(page: 2).total_count
+    assert_equal 127, fetch(limit: 25).total_count
+  end
+
+  test '#total_pages' do
+    assert_equal 3, fetch.total_pages
+    assert_equal 6, fetch(limit: 25).total_pages
+  end
+
+  private
+
+  def fake_products
+    @fake_products ||= 127.times.map { |index| { id: index } }
+  end
+
+  def fetch(params={})
+    options = params.empty? ? {} : { params: params }
+
+    ShopifyAPI::Product.all(options)
+  end
+
+  def first_page
+    @page1 ||= fake_products[1..50]
+  end
+
+  def last_page
+    @last_page ||= fake_products[77..127]
+  end
+
+  def limit25
+    @limit25 = fake_products[1..25]
+  end
+
+  def page2
+    @page2 ||= fake_products[51..101]
+  end
+
+  def products_url(params={})
+    endpoint = 'products.json'
+
+    query = params.empty? ? '' : "?#{params.to_query}"
+
+    "https://this-is-my-test-shop.myshopify.com/admin/#{endpoint}#{query}"
+  end
+end

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'test_helper'
 
 class CollectionTest < Test::Unit::TestCase
@@ -62,7 +64,7 @@ class CollectionTest < Test::Unit::TestCase
     @fake_products ||= 127.times.map { |index| { id: index } }
   end
 
-  def fetch(params={})
+  def fetch(params = {})
     options = params.empty? ? {} : { params: params }
 
     ShopifyAPI::Product.all(options)
@@ -84,7 +86,7 @@ class CollectionTest < Test::Unit::TestCase
     @page2 ||= fake_products[51..101]
   end
 
-  def products_url(params={})
+  def products_url(params = {})
     endpoint = 'products.json'
 
     query = params.empty? ? '' : "?#{params.to_query}"


### PR DESCRIPTION
As you know, Shopify paginates the resources server-side. For example, if you call `ShopifyAPI::Product.all`, you're not actually getting all of the products, just the first 50. Merging this will add the following methods to any collection of Shopify resources:

- `#current_page` - The current page number.
- `#first_page?` - If the current page is the first one.
- `#last_page?` - If the current page is the last one.
- `#limit` - The maximum number of entries each page will have.
- `#next_page` - The number of the next page, or nil if on the last.
- `#prev_page` - The number of the previous page, or nil if on the first.
- `#total_count` - The total number of entries available for the given request parameters.
- `#total_pages` - The total number of pages available for the given request parameters.

For example:
```ruby
products = ShopifyAPI::Product.all(params: { page: 2, limit: 100 })
products.current_page # => 2
products.limit # => 100
```