### PR TITLE
Add gem documentation link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ rake install
 
 API Reference: https://help.shopify.com/api/reference
 
+`shopify_api` gem documentation: https://www.rubydoc.info/github/Shopify/shopify_api/
+
 Ask questions on the forums: http://ecommerce.shopify.com/c/shopify-apis-and-technology
 
 ## Copyright


### PR DESCRIPTION
There's no reference to the code documentation, available on RubyDoc.

https://www.rubydoc.info/github/Shopify/shopify_api/