### PR TITLE
Add support for ApiPermission#destroy

### DIFF
--- a/lib/shopify_api/resources/api_permission.rb
+++ b/lib/shopify_api/resources/api_permission.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ShopifyAPI
+  class ApiPermission < Base
+    def self.destroy
+      delete(:current)
+    end
+  end
+end

--- a/lib/shopify_api/resources/o_auth.rb
+++ b/lib/shopify_api/resources/o_auth.rb
@@ -1,8 +1,16 @@
+# frozen_string_literal: true
+
+# This resource is deprecated and will be removed in a future version of this gem.
+# Use ShopifyAPI::ApiPermission.destroy instead
+
 module ShopifyAPI
   class OAuth < Base
     self.collection_name = 'oauth'
 
     def self.revoke
+      warn '[DEPRECATED] ShopifyAPI::OAuth#revoke is deprecated and will be removed in a future version. ' \
+        'Use ShopifyAPI::ApiPermission#destroy instead.'
+
       delete(:revoke)
     end
   end

--- a/test/api_permission_test.rb
+++ b/test/api_permission_test.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class ApiPermissionTest < Test::Unit::TestCase
+  test "revoke access token" do
+    fake "api_permissions/current", method: :delete, status: 200, body: "{}"
+    assert ShopifyAPI::ApiPermission.destroy
+  end
+end


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify_api/issues/438.

Adds support for ApiPermission#destroy, which allows applications to remotely uninstall themselves.

~Removes the OAuth class as it's now deprecated.~