### PR TITLE
[WIP] Force use of checkout api latest version

### DIFF
--- a/lib/shopify_api/resources/checkout.rb
+++ b/lib/shopify_api/resources/checkout.rb
@@ -1,4 +1,5 @@
 module ShopifyAPI
   class Checkout < Base
+    headers['X-Shopify-Checkout-Version'] = '2017-09-03'
   end
 end

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -8,6 +8,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     super
     @page = { :page => { :id => 1, :title => 'Shopify API' } }.to_json
     @ua_header = "\"User-Agent\"=>\"ShopifyAPI/#{ShopifyAPI::VERSION} ActiveResource/#{ActiveResource::VERSION::STRING} Ruby/#{RUBY_VERSION}\""
+    @ver_header = "\"X-Shopify-Checkout-Version\"=>\"2017-09-03\""
 
     ShopifyAPI::Base.clear_session
     ShopifyAPI::Base.site = "https://this-is-my-test-shop.myshopify.com/admin"
@@ -28,7 +29,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     assert_equal 4, @logger.logged(:info).size
     assert_equal "GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/1.json", @logger.logged(:info)[0]
     assert_match /\-\-\> 200/, @logger.logged(:info)[1]
-    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[2]
+    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}, #{@ver_header}}", @logger.logged(:info)[2]
     assert_match /Response:\n\{\"page\"\:\{((\"id\"\:1)|(\"title\"\:\"Shopify API\")),((\"id\"\:1)|(\"title\"\:\"Shopify API\"))\}\}/,  @logger.logged(:info)[3]
 
   end
@@ -43,7 +44,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     assert_equal 4, @logger.logged(:info).size
     assert_equal "GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:info)[0]
     assert_match /\-\-\> 404/, @logger.logged(:info)[1]
-    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[2]
+    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}, #{@ver_header}}", @logger.logged(:info)[2]
     assert_equal "Response:", @logger.logged(:info)[3]
   end
 end


### PR DESCRIPTION
Clients need to send a specific header version to be routed to the latest version of the Checkout controller. This gem does not allow sending this header, thus locking all clients using it on the legacy version.

This PR allows sending the version header.

Note: this version of code actually forces sending the header, which might cause problem. Well, it's WIP.