### PR TITLE
Fix README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,9 +262,8 @@ bundle exec rake test
 
 ## Additional Resources
 
-API Reference: https://help.shopify.com/api/reference
-
-Ask questions on the forums: http://ecommerce.shopify.com/c/shopify-apis-and-technology
+* [API Reference](https://help.shopify.com/api/reference)
+* [Ask questions on the forums](http://ecommerce.shopify.com/c/shopify-apis-and-technology)
 
 ## Copyright
 

--- a/lib/shopify_api/resources/abandoned_checkout.rb
+++ b/lib/shopify_api/resources/abandoned_checkout.rb
@@ -1,5 +1,0 @@
-module ShopifyAPI
-  class AbandonedCheckout < Base
-    init_prefix :checkout
-  end
-end

--- a/lib/shopify_api/resources/abandoned_checkout.rb
+++ b/lib/shopify_api/resources/abandoned_checkout.rb
@@ -1,0 +1,5 @@
+module ShopifyAPI
+  class AbandonedCheckout < Base
+    init_prefix :checkout
+  end
+end


### PR DESCRIPTION
Quick markdown fix to display the links as such on the [Github pages](http://shopify.github.io/shopify_api/).