### PR TITLE
Rails 5.2.1 session issues fixes

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -51,6 +51,7 @@ module ShopifyAPI
       end
 
       def validate_signature(params)
+        params = (params.respond_to?(:to_unsafe_hash) ? params.to_unsafe_hash : params).with_indifferent_access
         return false unless signature = params[:hmac]
 
         calculated_signature = OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new(), secret, encoded_params_for_signature(params))

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -216,8 +216,7 @@ class SessionTest < Test::Unit::TestCase
   test "return true when the signature is valid and the keys of params are strings" do
     params = { 'code' => 'any-code', 'timestamp' => Time.now }
     params[:hmac] = generate_signature(params)
-    action_params = ActionController::Parameters.new params
-    assert_equal true, ShopifyAPI::Session.validate_signature(action_params)
+    assert_equal true, ShopifyAPI::Session.validate_signature(params)
   end
 
   test "return true when validating signature of params with ampersand and equal sign characters" do
@@ -225,8 +224,7 @@ class SessionTest < Test::Unit::TestCase
     params = { 'a' => '1&b=2', 'c=3&d' => '4' }
     to_sign = 'a=1%26b=2&c%3D3%26d=4'
     params[:hmac] = generate_signature(to_sign)
-    action_params = ActionController::Parameters.new params
-    assert_equal true, ShopifyAPI::Session.validate_signature(action_params)
+    assert_equal true, ShopifyAPI::Session.validate_signature(params)
   end
 
   test "return true when validating signature of params with percent sign characters" do
@@ -234,8 +232,7 @@ class SessionTest < Test::Unit::TestCase
     params = { 'a%3D1%26b' => '2%26c%3D3' }
     to_sign = 'a%253D1%2526b=2%2526c%253D3'
     params[:hmac] = generate_signature(to_sign)
-    action_params = ActionController::Parameters.new params
-    assert_equal true, ShopifyAPI::Session.validate_signature(action_params)
+    assert_equal true, ShopifyAPI::Session.validate_signature(params)
   end
 
   private

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -216,7 +216,8 @@ class SessionTest < Test::Unit::TestCase
   test "return true when the signature is valid and the keys of params are strings" do
     params = { 'code' => 'any-code', 'timestamp' => Time.now }
     params[:hmac] = generate_signature(params)
-    assert_equal true, ShopifyAPI::Session.validate_signature(params)
+    action_params = ActionController::Parameters.new params
+    assert_equal true, ShopifyAPI::Session.validate_signature(action_params)
   end
 
   test "return true when validating signature of params with ampersand and equal sign characters" do
@@ -224,7 +225,8 @@ class SessionTest < Test::Unit::TestCase
     params = { 'a' => '1&b=2', 'c=3&d' => '4' }
     to_sign = 'a=1%26b=2&c%3D3%26d=4'
     params[:hmac] = generate_signature(to_sign)
-    assert_equal true, ShopifyAPI::Session.validate_signature(params)
+    action_params = ActionController::Parameters.new params
+    assert_equal true, ShopifyAPI::Session.validate_signature(action_params)
   end
 
   test "return true when validating signature of params with percent sign characters" do
@@ -232,8 +234,8 @@ class SessionTest < Test::Unit::TestCase
     params = { 'a%3D1%26b' => '2%26c%3D3' }
     to_sign = 'a%253D1%2526b=2%2526c%253D3'
     params[:hmac] = generate_signature(to_sign)
-
-    assert_equal true, ShopifyAPI::Session.validate_signature(params)
+    action_params = ActionController::Parameters.new params
+    assert_equal true, ShopifyAPI::Session.validate_signature(action_params)
   end
 
   private


### PR DESCRIPTION
Fixes to use of ActionParams rather than just hash (undefined method map for ActionController::Parameters).
The `encoded_params_for_signature` called map on ActionController::Parameters which was being an issue. I believe that the original PR was the correct one [#352](https://github.com/Shopify/shopify_api/pull/352)

ie. We can also enforce the use of `to_unsafe_hash` on params in `validate_signature` since the method is supposed to only be called with ActionController::Params but I don't know what it would actually mean in terms of retro-compatibility (prior to strong params) other. The safest way to do it is probably this one.
