### PR TITLE
Add support for new products endpoint

### DIFF
--- a/lib/shopify_api/resources/smart_collection.rb
+++ b/lib/shopify_api/resources/smart_collection.rb
@@ -3,8 +3,12 @@ module ShopifyAPI
     include Events
     include Metafields
 
-    def products
-      Product.find(:all, :params => {:collection_id => self.id})
+    def products(options = {})
+      if options.key?(:only_sorted)
+        Product.find(:all, from: "/admin/smart_collections/#{id}/products.json", params: options)
+      else
+        Product.find(:all, params: { collection_id: id })
+      end
     end
 
     def order(options={})

--- a/test/fixtures/smart_collection_products.json
+++ b/test/fixtures/smart_collection_products.json
@@ -1,0 +1,155 @@
+{
+  "products": [
+    {
+      "product_type": "Cult Products",
+      "handle": "ipod-nano",
+      "created_at": "2011-10-20T14:05:13-04:00",
+      "body_html": "<p>It's the small iPod with one very big idea: Video. Now the world's most popular music player, available in 4GB and 8GB models, lets you enjoy TV shows, movies, video podcasts, and more. The larger, brighter display means amazing picture quality. In six eye-catching colors, iPod nano is stunning all around. And with models starting at just $149, little speaks volumes.</p>",
+      "title": "IPod Nano - 8GB",
+      "template_suffix": null,
+      "updated_at": "2011-10-20T14:05:13-04:00",
+      "id": 632910392,
+      "tags": "Emotive, Flash Memory, MP3, Music",
+      "images": [
+        {
+          "position": 1,
+          "created_at": "2011-10-20T14:05:13-04:00",
+          "product_id": 632910392,
+          "updated_at": "2011-10-20T14:05:13-04:00",
+          "src": "http://static.shopify.com/s/files/1/6909/3384/products/ipod-nano.png?0",
+          "id": 850703190
+        }
+      ],
+      "variants": [
+        {
+          "position": 1,
+          "price": "199.00",
+          "product_id": 632910392,
+          "created_at": "2011-10-20T14:05:13-04:00",
+          "requires_shipping": true,
+          "title": "Pink",
+          "inventory_quantity": 10,
+          "compare_at_price": null,
+          "inventory_policy": "continue",
+          "updated_at": "2011-10-20T14:05:13-04:00",
+          "inventory_management": "shopify",
+          "id": 808950810,
+          "taxable": true,
+          "grams": 200,
+          "sku": "IPOD2008PINK",
+          "option1": "Pink",
+          "fulfillment_service": "manual",
+          "option2": null,
+          "option3": null
+        },
+        {
+          "position": 2,
+          "price": "199.00",
+          "product_id": 632910392,
+          "created_at": "2011-10-20T14:05:13-04:00",
+          "requires_shipping": true,
+          "title": "Red",
+          "inventory_quantity": 20,
+          "compare_at_price": null,
+          "inventory_policy": "continue",
+          "updated_at": "2011-10-20T14:05:13-04:00",
+          "inventory_management": "shopify",
+          "id": 49148385,
+          "taxable": true,
+          "grams": 200,
+          "sku": "IPOD2008RED",
+          "option1": "Red",
+          "fulfillment_service": "manual",
+          "option2": null,
+          "option3": null
+        },
+        {
+          "position": 3,
+          "price": "199.00",
+          "product_id": 632910392,
+          "created_at": "2011-10-20T14:05:13-04:00",
+          "requires_shipping": true,
+          "title": "Green",
+          "inventory_quantity": 30,
+          "compare_at_price": null,
+          "inventory_policy": "continue",
+          "updated_at": "2011-10-20T14:05:13-04:00",
+          "inventory_management": "shopify",
+          "id": 39072856,
+          "taxable": true,
+          "grams": 200,
+          "sku": "IPOD2008GREEN",
+          "option1": "Green",
+          "fulfillment_service": "manual",
+          "option2": null,
+          "option3": null
+        },
+        {
+          "position": 4,
+          "price": "199.00",
+          "product_id": 632910392,
+          "created_at": "2011-10-20T14:05:13-04:00",
+          "requires_shipping": true,
+          "title": "Black",
+          "inventory_quantity": 40,
+          "compare_at_price": null,
+          "inventory_policy": "continue",
+          "updated_at": "2011-10-20T14:05:13-04:00",
+          "inventory_management": "shopify",
+          "id": 457924702,
+          "taxable": true,
+          "grams": 200,
+          "sku": "IPOD2008BLACK",
+          "option1": "Black",
+          "fulfillment_service": "manual",
+          "option2": null,
+          "option3": null
+        }
+      ],
+      "vendor": "Apple",
+      "published_at": "2007-12-31T19:00:00-05:00",
+      "manually_sorted": true,
+      "options": [
+        {
+          "name": "Title"
+        }
+      ]
+    },
+    {
+      "product_type": "Cult Products",
+      "handle": "ipod-touch",
+      "created_at": "2018-09-26T14:05:13-04:00",
+      "body_html": "<p>The iPod Touch has the iPhone's multi-touch interface, with a physical home button off the touch screen. The home screen has a list of buttons for the available applications.</p>",
+      "title": "IPod Touch 8GB",
+      "template_suffix": null,
+      "updated_at": "2018-09-26T14:05:13-04:00",
+      "id": 921728736,
+      "tags": null,
+      "variants": [
+        {
+          "id": 447654529,
+          "title": "Black",
+          "price": "199.00",
+          "sku": "IPOD2009BLACK",
+          "position": 1,
+          "inventory_policy": "continue",
+          "compare_at_price": null,
+          "fulfillment_service": "manual",
+          "inventory_management": "shopify",
+          "option1": "Black",
+          "option2": null,
+          "option3": null,
+          "created_at": "2018-09-26T14:05:13-04:00",
+          "updated_at": "2018-09-26T14:05:13-04:00",
+          "taxable": true,
+          "grams": 567,
+          "inventory_quantity": 13,
+          "requires_shipping": true
+        }
+      ],
+      "vendor": "Apple",
+      "published_at": "2018-09-26T14:05:13-04:00",
+      "manually_sorted": true
+    }
+  ]
+}

--- a/test/smart_collection_test.rb
+++ b/test/smart_collection_test.rb
@@ -7,4 +7,29 @@ class SmartCollectionTest < Test::Unit::TestCase
     smart_collection = ShopifyAPI::SmartCollection.create(:title => "Macbooks", :rules => rules)
     assert_equal 1063001432, smart_collection.id
   end
+
+  test "Smart Collection get products gets all products in a smart collection" do
+    fake "smart_collections/1063001432", method: :get, status: 200, body: load_fixture('smart_collection')
+    smart_collection = ShopifyAPI::SmartCollection.find(1063001432)
+
+    fake "products.json?collection_id=1063001432",
+      method: :get,
+      status: 200,
+      body:
+      load_fixture('smart_collection_products'),
+      extension: false
+    assert_equal [632910392, 921728736], smart_collection.products.map(&:id)
+  end
+
+  test "Smart Collection get products with only_sorted=only_manual gets only manually sorted products" do
+    fake "smart_collections/1063001432", method: :get, status: 200, body: load_fixture('smart_collection')
+    smart_collection = ShopifyAPI::SmartCollection.find(1063001432)
+
+    fake "smart_collections/1063001432/products.json?only_sorted=only_manual",
+      method: :get,
+      status: 200,
+      body: load_fixture('smart_collection_products'),
+      extension: false
+    assert_equal [632910392, 921728736], smart_collection.products(only_sorted: "only_manual").map(&:id)
+  end
 end


### PR DESCRIPTION
We're introducing a new feature for merchants, to provide the ability to sort a subset of products at the top of the collection as detailed [here](https://help.shopify.com/en/manual/products/collections/automated-collections/auto-sort). 

In support of these changes, we are making modifications to the SmartCollection API. Specifically, the behaviour of the **order** endpoint will change as detailed in the [updated API docs](https://help.shopify.com/en/api/reference/products/smartcollection). Additionally, we are adding a new products endpoint, to provide the ability to retrieve products in the collection, filtered by manually sorted or automatically sorted.

This PR adds support to the Shopify API gem for the new products endpoint. Since ShopifyAPI already has SmartCollection.products defined to so a search for products on collections, this will be a two step process:
1 - Add support for existing SmartCollection.products to call the new products endpoint. Prior to the new manual sort feature being on all shops, we will only use the endpoint when only_sorted is provided as a filter.
2 - Once the new manual sort feature is available on all shops, change products to always use the products endpoint on the controller. This will change the sort order of the products, but I think that will be ok. Also for the test/example we can add the new column for manually sorted to the results to provide a better example.

**WHAT TO FOCUS ON**

- Are there any risks with reusing the products method? Should we give a different name to our new endpoint? We know that the sort order will change from find, to our new endpoint. Could this be a risk to API clients using this gem?
- I still need to decide if I should bump the version now, or only after the entire change. Opinions?


For more context, see https://github.com/Shopify/core/issues/1509