### PR TITLE
Use new products endpoint only when no params are passed

### DIFF
--- a/lib/shopify_api/resources/smart_collection.rb
+++ b/lib/shopify_api/resources/smart_collection.rb
@@ -4,7 +4,7 @@ module ShopifyAPI
     include Metafields
 
     def products(options = {})
-      if options.key?(:only_sorted)
+      if options.present?
         Product.find(:all, from: "/admin/smart_collections/#{id}/products.json", params: options)
       else
         Product.find(:all, params: { collection_id: id })


### PR DESCRIPTION
This PR updates `SmartCollection#products` in the following way: 

- If no params are passed then it uses the old endpoint.
- Otherwise, it uses the new one.

Note: This PR is backward compatible since the new endpoint was introduced a week ago and it's still on beta.