### PR TITLE
Add new tender transaction resource

### DIFF
--- a/lib/shopify_api/resources/tender_transaction.rb
+++ b/lib/shopify_api/resources/tender_transaction.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ShopifyAPI
+  class TenderTransaction < Base
+  end
+end

--- a/test/fixtures/tender_transactions.json
+++ b/test/fixtures/tender_transactions.json
@@ -1,0 +1,52 @@
+{
+  "tender_transactions": [
+    {
+      "id": 1,
+      "order_id": 450789469,
+      "amount": "138.46",
+      "currency": "CAD",
+      "user_id": null,
+      "test": true,
+      "processed_at": "2018-08-09T15:43:39-04:00",
+      "updated_at": "2018-08-09T15:43:41-04:00",
+      "remote_reference": "1118366",
+      "payment_method": "credit_card",
+      "payment_details": {
+        "credit_card_number": "•••• •••• •••• 1",
+        "credit_card_company": "Bogus"
+      }
+    },
+    {
+      "id": 2,
+      "order_id": 450789469,
+      "amount": "128.16",
+      "currency": "CAD",
+      "user_id": null,
+      "test": true,
+      "processed_at": "2018-08-11T15:43:39-04:00",
+      "updated_at": "2018-08-09T15:43:41-04:00",
+      "remote_reference": "1118367",
+      "payment_method": "credit_card",
+      "payment_details": {
+        "credit_card_number": "•••• •••• •••• 2",
+        "credit_card_company": "Bogus"
+      }
+    },
+    {
+      "id": 3,
+      "order_id": 450789469,
+      "amount": "28.16",
+      "currency": "CAD",
+      "user_id": null,
+      "test": true,
+      "processed_at": "2018-08-12T15:43:39-04:00",
+      "updated_at": "2018-08-09T15:43:41-04:00",
+      "remote_reference": "1118368",
+      "payment_method": "credit_card",
+      "payment_details": {
+        "credit_card_number": "•••• •••• •••• 2",
+        "credit_card_company": "Bogus"
+      }
+    }
+  ]
+}

--- a/test/fixtures/tender_transactions.json
+++ b/test/fixtures/tender_transactions.json
@@ -44,7 +44,7 @@
       "remote_reference": "1118368",
       "payment_method": "credit_card",
       "payment_details": {
-        "credit_card_number": "•••• •••• •••• 2",
+        "credit_card_number": "•••• •••• •••• 3",
         "credit_card_company": "Bogus"
       }
     }

--- a/test/tender_transaction_test.rb
+++ b/test/tender_transaction_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+class TenderTransactionTest < Test::Unit::TestCase
+  def setup
+    super
+    fake "/tender_transactions.json", method: :get, body: load_fixture('tender_transactions')
+  end
+
+  context "Tender Transaction" do
+    should 'return a list of transactions' do
+      tender_transactions = ShopifyAPI::TenderTransaction.all
+    end
+  end
+end

--- a/test/tender_transaction_test.rb
+++ b/test/tender_transaction_test.rb
@@ -5,12 +5,14 @@ require 'test_helper'
 class TenderTransactionTest < Test::Unit::TestCase
   def setup
     super
-    fake "/tender_transactions.json", method: :get, body: load_fixture('tender_transactions')
+    fake "tender_transactions", method: :get, body: load_fixture('tender_transactions')
   end
 
   context "Tender Transaction" do
     should 'return a list of transactions' do
       tender_transactions = ShopifyAPI::TenderTransaction.all
+      assert_equal 3, tender_transactions.length
+      assert_equal [1, 2, 3], tender_transactions.map(&:id)
     end
   end
 end


### PR DESCRIPTION
**Issue**: https://github.com/Shopify/money-transactions/issues/688

As we prepare to launch the TenderTransaction Api, we need to update our respective Api libraries with the proper resources.

This PR adds a TenderTransaction resource to the gem, as well as a json fixture to test.