### PR TITLE
Adds state parameter to create_permission_url

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,10 +98,11 @@ ShopifyAPI uses ActiveResource to communicate with the REST web service. ActiveR
    permission_url = session.create_permission_url(scope)
    ```
 
-   or if you want a custom redirect_uri:
+   or if you want a custom redirect_uri and/or state:
 
    ```ruby
-   permission_url = session.create_permission_url(scope, "https://my_redirect_uri.com")
+   state = SecureRandom.hex
+   permission_url = session.create_permission_url(scope, "https://my_redirect_uri.com", state)
    ```
 
 4. Once authorized, the shop redirects the owner to the return URL of your application with a parameter named 'code'. This is a temporary token that the app can exchange for a permanent access token.

--- a/README.md
+++ b/README.md
@@ -101,8 +101,7 @@ ShopifyAPI uses ActiveResource to communicate with the REST web service. ActiveR
    or if you want a custom redirect_uri and/or state:
 
    ```ruby
-   state = SecureRandom.hex
-   permission_url = session.create_permission_url(scope, "https://my_redirect_uri.com", state)
+   permission_url = session.create_permission_url(scope, :redirect_uri => "https://my_redirect_uri.com", :state => "foobar")
    ```
 
 4. Once authorized, the shop redirects the owner to the return URL of your application with a parameter named 'code'. This is a temporary token that the app can exchange for a permanent access token.

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -73,9 +73,10 @@ module ShopifyAPI
       self.extra = extra
     end
 
-    def create_permission_url(scope, redirect_uri = nil)
+    def create_permission_url(scope, options = {})
       params = {:client_id => api_key, :scope => scope.join(',')}
-      params[:redirect_uri] = redirect_uri if redirect_uri
+      params[:redirect_uri] = options[:redirect_uri] if options[:redirect_uri]
+      params[:state] = options[:state] if options[:state]
       "#{site}/oauth/authorize?#{parameterize(params)}"
     end
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -73,7 +73,7 @@ class SessionTest < Test::Unit::TestCase
     assert_equal 'https://fakeshop.myshopify.com/admin', ShopifyAPI::Base.site.to_s
   end
 
-  test "create_permission_url returns correct url with single scope no redirect uri" do
+  test "create_permission_url returns correct url with single scope no redirect uri no state" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
     session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
     scope = ["write_products"]
@@ -81,15 +81,15 @@ class SessionTest < Test::Unit::TestCase
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
   end
 
-  test "create_permission_url returns correct url with single scope and redirect uri" do
+  test "create_permission_url returns correct url with single scope and redirect uri no state" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
     session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
     scope = ["write_products"]
-    permission_url = session.create_permission_url(scope, "http://my_redirect_uri.com")
+    permission_url = session.create_permission_url(scope, :redirect_uri => "http://my_redirect_uri.com")
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com", permission_url
   end
 
-  test "create_permission_url returns correct url with dual scope no redirect uri" do
+  test "create_permission_url returns correct url with dual scope no redirect uri no state" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
     session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
     scope = ["write_products","write_customers"]
@@ -97,12 +97,22 @@ class SessionTest < Test::Unit::TestCase
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
   end
 
-  test "create_permission_url returns correct url with no scope no redirect uri" do
+  test "create_permission_url returns correct url with single scope and redirect uri and state" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
     session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
-    scope = []
-    permission_url = session.create_permission_url(scope)
-    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=", permission_url
+    scope = ["write_products"]
+    state = "My_test_state"
+    permission_url = session.create_permission_url(scope, :redirect_uri => "http://my_redirect_uri.com", :state => state)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com&state=My_test_state", permission_url
+  end
+
+  test "create_permission_url returns correct url with single scope and state no redirect uri" do
+    ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    scope = ["write_products"]
+    state = "My_test_state"
+    permission_url = session.create_permission_url(scope, :state => state)
+    assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&state=My_test_state", permission_url
   end
 
   test "raise exception if code invalid in request token" do


### PR DESCRIPTION
Closes #466 

Title says it all. Because we'd now be looking at multiple optional arguments I decided to convert the single optional redirect_uri argument into a an `options` hash:

```rb
session = ShopifyAPI::Session.new("snowdevil.myshopify.com", "access_token")
scope = ["write_products"]
redirect_uri = "snowdevil.myshopify.com/redirect_uri"
state = "foobar"
session.create_permission_url(scope, :redirect_uri => redirect_uri, :state => state)
```

Tests 🍏