### PR TITLE
Remove support for non-standard protocols and ports.

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -126,17 +126,18 @@ module ShopifyAPI
     end
 
     private
-      def parameterize(params)
-        URI.escape(params.collect{|k,v| "#{k}=#{v}"}.join('&'))
-      end
 
-      def access_token_request(code)
-        uri = URI.parse("https://#{url}/admin/oauth/access_token")
-        https = Net::HTTP.new(uri.host, uri.port)
-        https.use_ssl = true
-        request = Net::HTTP::Post.new(uri.request_uri)
-        request.set_form_data({"client_id" => api_key, "client_secret" => secret, "code" => code})
-        https.request(request)
-      end
+    def parameterize(params)
+      URI.escape(params.collect { |k, v| "#{k}=#{v}" }.join('&'))
+    end
+
+    def access_token_request(code)
+      uri = URI.parse("https://#{url}/admin/oauth/access_token")
+      https = Net::HTTP.new(uri.host, uri.port)
+      https.use_ssl = true
+      request = Net::HTTP::Post.new(uri.request_uri)
+      request.set_form_data('client_id' => api_key, 'client_secret' => secret, 'code' => code)
+      https.request(request)
+    end
   end
 end

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -7,8 +7,7 @@ module ShopifyAPI
   end
 
   class Session
-    cattr_accessor :api_key, :secret, :protocol, :myshopify_domain, :port
-    self.protocol = 'https'
+    cattr_accessor :api_key, :secret, :myshopify_domain
     self.myshopify_domain = 'myshopify.com'
 
     attr_accessor :url, :token, :name, :extra
@@ -44,8 +43,7 @@ module ShopifyAPI
           shop = shop.slice(0, idx)
         end
         return nil if shop.empty?
-        shop = "#{shop}.#{myshopify_domain}"
-        port ? "#{shop}:#{port}" : shop
+        "#{shop}.#{myshopify_domain}"
       rescue URI::InvalidURIError
         nil
       end
@@ -105,7 +103,7 @@ module ShopifyAPI
     end
 
     def site
-      "#{protocol}://#{url}/admin"
+      "https://#{url}/admin"
     end
 
     def valid?
@@ -133,7 +131,7 @@ module ShopifyAPI
       end
 
       def access_token_request(code)
-        uri = URI.parse("#{protocol}://#{url}/admin/oauth/access_token")
+        uri = URI.parse("https://#{url}/admin/oauth/access_token")
         https = Net::HTTP.new(uri.host, uri.port)
         https.use_ssl = true
         request = Net::HTTP::Post.new(uri.request_uri)

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -56,10 +56,6 @@ class SessionTest < Test::Unit::TestCase
     assert_equal "My test secret", ShopifyAPI::Session.secret
   end
 
-  test "use 'https' protocol by default for all sessions" do
-    assert_equal 'https', ShopifyAPI::Session.protocol
-  end
-
   test "#temp reset ShopifyAPI::Base.site to original value" do
 
     ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
@@ -113,28 +109,6 @@ class SessionTest < Test::Unit::TestCase
       session.request_token(params={:code => "bad-code"})
     end
     assert_equal false, session.valid?
-  end
-
-  test "#temp reset ShopifyAPI::Base.site to original value when using a non-standard port" do
-    ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
-    session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com:3000', 'token1')
-    ShopifyAPI::Base.activate_session(session1)
-  end
-
-  test "myshopify_domain supports non-standard ports" do
-    begin
-      ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret", :myshopify_domain => 'localhost', port: '3000')
-      session = ShopifyAPI::Session.new('fakeshop.localhost:3000', 'token1')
-      ShopifyAPI::Base.activate_session(session)
-      assert_equal 'https://fakeshop.localhost:3000/admin', ShopifyAPI::Base.site.to_s
-
-      session = ShopifyAPI::Session.new('fakeshop', 'token1')
-      ShopifyAPI::Base.activate_session(session)
-      assert_equal 'https://fakeshop.localhost:3000/admin', ShopifyAPI::Base.site.to_s
-    ensure
-      ShopifyAPI::Session.myshopify_domain = "myshopify.com"
-      ShopifyAPI::Session.port = nil
-    end
   end
 
   test "return site for session" do


### PR DESCRIPTION
The Shopify API is only available via HTTPS on port 443. I suspect the `protocol` and `port` options in `ShopifyAPI::Session` were added to support local testing, but even our local development environment now uses HTTPS on port 443. I couldn't find any projects that are setting a custom `protocol` or `port` so I think we can safely remove these options.