### PR TITLE
Added currency endpoint to api gem

### DIFF
--- a/lib/shopify_api/resources/currency.rb
+++ b/lib/shopify_api/resources/currency.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+module ShopifyAPI
+  class Currency < Base
+  end
+end

--- a/test/currency_test.rb
+++ b/test/currency_test.rb
@@ -1,0 +1,21 @@
+
+# frozen_string_literal: true
+require 'test_helper'
+class CurrencyTest < Test::Unit::TestCase
+  def setup
+    super
+    fake "currencies", method: :get, body: load_fixture('currencies')
+  end
+
+  context "Currency" do
+    should 'return a list of enabled currencies' do
+      currencies = ShopifyAPI::Currency.all
+      assert_equal 4, currencies.count
+      assert_equal %w(AUD EUR GBP HKD), currencies.map(&:currency)
+      assert_equal [true, true, true, false], currencies.map(&:enabled)
+      currencies.each do |currency|
+        assert_equal "2018-10-03T14:44:08-04:00", currency.rate_updated_at
+      end
+    end
+  end
+end

--- a/test/fixtures/currencies.json
+++ b/test/fixtures/currencies.json
@@ -1,0 +1,25 @@
+{
+  "currencies": [
+    {
+        "currency": "AUD",
+        "rate_updated_at": "2018-10-03T14:44:08-04:00",
+        "enabled": true
+    },
+    {
+        "currency": "EUR",
+        "rate_updated_at": "2018-10-03T14:44:08-04:00",
+        "enabled": true
+    },
+    {
+        "currency": "GBP",
+        "rate_updated_at": "2018-10-03T14:44:08-04:00",
+        "enabled": true
+    },
+    {
+        "currency": "HKD",
+        "rate_updated_at": "2018-10-03T14:44:08-04:00",
+        "enabled": false
+    }
+  ]
+}
+


### PR DESCRIPTION
Adds the new Currency endpoint to the api gem, following similar pattern to what was done for tender transactions being added to the gem.

Docs are here: https://github.com/Shopify/shopify/pull/174966 which are monkey patched currently while this gets updated.