### PR TITLE
Restrict X-Shopify-Checkout-Version header to ShopifyAPI::Checkout

### DIFF
--- a/lib/shopify_api/resources/checkout.rb
+++ b/lib/shopify_api/resources/checkout.rb
@@ -3,7 +3,10 @@
 module ShopifyAPI
   class Checkout < Base
     self.primary_key = :token
-    headers['X-Shopify-Checkout-Version'] = '2016-09-06'
+
+    def self.headers
+      super.merge('X-Shopify-Checkout-Version' => '2016-09-06')
+    end
 
     def complete
       post(:complete)

--- a/test/checkouts_test.rb
+++ b/test/checkouts_test.rb
@@ -9,6 +9,11 @@ class CheckoutsTest < Test::Unit::TestCase
     @expected_checkout_id = JSON.parse(load_fixture('checkout'))['checkout']['token']
   end
 
+  test ".headers includes a version" do
+    assert_equal "2016-09-06", ShopifyAPI::Checkout.headers["X-Shopify-Checkout-Version"]
+    assert_nil ShopifyAPI::Base.headers["X-Shopify-Checkout-Version"]
+  end
+
   test ":create creates a checkout" do
     fake 'checkouts', method: :post, status: 201, body: load_fixture('checkout')
 

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -8,7 +8,6 @@ class LogSubscriberTest < Test::Unit::TestCase
     super
     @page = { :page => { :id => 1, :title => 'Shopify API' } }.to_json
     @ua_header = "\"User-Agent\"=>\"ShopifyAPI/#{ShopifyAPI::VERSION} ActiveResource/#{ActiveResource::VERSION::STRING} Ruby/#{RUBY_VERSION}\""
-    @ver_header = "\"X-Shopify-Checkout-Version\"=>\"2016-09-06\""
 
     ShopifyAPI::Base.clear_session
     ShopifyAPI::Base.site = "https://this-is-my-test-shop.myshopify.com/admin"
@@ -29,7 +28,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     assert_equal 4, @logger.logged(:info).size
     assert_equal "GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/1.json", @logger.logged(:info)[0]
     assert_match /\-\-\> 200/, @logger.logged(:info)[1]
-    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}, #{@ver_header}}", @logger.logged(:info)[2]
+    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[2]
     assert_match /Response:\n\{\"page\"\:\{((\"id\"\:1)|(\"title\"\:\"Shopify API\")),((\"id\"\:1)|(\"title\"\:\"Shopify API\"))\}\}/,  @logger.logged(:info)[3]
 
   end
@@ -44,7 +43,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     assert_equal 4, @logger.logged(:info).size
     assert_equal "GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:info)[0]
     assert_match /\-\-\> 404/, @logger.logged(:info)[1]
-    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}, #{@ver_header}}", @logger.logged(:info)[2]
+    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[2]
     assert_equal "Response:", @logger.logged(:info)[3]
   end
 end


### PR DESCRIPTION
As far as I can tell, all subclasses of `ShopifyAPI::Base` [share the same `headers` object](https://github.com/Shopify/shopify_api/blob/master/lib/shopify_api/resources/base.rb#L32-L40), unlike `ActiveResource::Base` which [creates a copy in each subclass](https://github.com/rails/activeresource/blob/0ae3010f505b5e6063b7acbcd22cc221995e7873/lib/active_resource/base.rb#L661-L668).

This is intentional, because in ShopifyAPI it's a common pattern to change the access token header to connect to a different shop, and we wouldn't want copies of an access token stored in every subclass.

This means that setting the checkout version header like this ended up setting it for every resource, not just the Checkout resource. Unfortunately, some resources, like the AbandonedCheckout resource, rely on that header not being present.

This PR changes the Checkout resource to inject the header at runtime, rather that store it permanently at class-load time.