### PR TITLE
Update DeliveryConfirmation and Conversation Ping resources for Feedback API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+== Version 5.2.3
+
+* Update delivery confirmation resource to delivery confirmation details resource.
+
 == Version 5.2.2
 
 * Add delivery confirmation endpoint to Ping resources.

--- a/lib/shopify_api/resources/ping/conversation.rb
+++ b/lib/shopify_api/resources/ping/conversation.rb
@@ -15,27 +15,23 @@ module ShopifyAPI
       end
 
       def successful_delivery(message_id:, delivery_timestamp:)
-        delivery_details = ShopifyAPI::Ping::DeliveryConfirmation.new(
+        delivery_details = ShopifyAPI::Ping::DeliveryConfirmationDetails.new(
           conversation_id: id,
           message_id: message_id,
-          delivery_confirmation_details: {
-            delivered: true,
-            confirmation_timestamp: delivery_timestamp,
-          }
+          delivered: true,
+          confirmation_timestamp: delivery_timestamp
         )
         delivery_details.save
         delivery_details
       end
 
       def failed_delivery(message_id:, delivery_timestamp:, details:)
-        delivery_details = ShopifyAPI::Ping::DeliveryConfirmation.new(
+        delivery_details = ShopifyAPI::Ping::DeliveryConfirmationDetails.new(
           conversation_id: id,
           message_id: message_id,
-          delivery_confirmation_details: {
-            delivered: false,
-            confirmation_timestamp: delivery_timestamp,
-            details: details,
-          }
+          delivered: false,
+          confirmation_timestamp: delivery_timestamp,
+          details: details
         )
         delivery_details.save
         delivery_details

--- a/lib/shopify_api/resources/ping/conversation.rb
+++ b/lib/shopify_api/resources/ping/conversation.rb
@@ -16,10 +16,7 @@ module ShopifyAPI
 
       def successful_delivery(message_id:, delivery_timestamp:)
         delivery_details = ShopifyAPI::Ping::DeliveryConfirmationDetails.new(
-          conversation_id: id,
-          message_id: message_id,
-          delivered: true,
-          confirmation_timestamp: delivery_timestamp
+          delivery_attrs(message_id, delivery_timestamp).merge(delivered: true)
         )
         delivery_details.save
         delivery_details
@@ -27,14 +24,18 @@ module ShopifyAPI
 
       def failed_delivery(message_id:, delivery_timestamp:, details:)
         delivery_details = ShopifyAPI::Ping::DeliveryConfirmationDetails.new(
-          conversation_id: id,
-          message_id: message_id,
-          delivered: false,
-          confirmation_timestamp: delivery_timestamp,
-          details: details
+          delivery_attrs(message_id, delivery_timestamp).merge(delivered: false, details: details)
         )
         delivery_details.save
         delivery_details
+      end
+
+      def delivery_attrs(message_id, delivery_timestamp)
+        {
+          conversation_id: id,
+          message_id: message_id,
+          confirmation_timestamp: delivery_timestamp,
+        }
       end
     end
   end

--- a/lib/shopify_api/resources/ping/delivery_confirmation_details.rb
+++ b/lib/shopify_api/resources/ping/delivery_confirmation_details.rb
@@ -2,7 +2,7 @@
 
 module ShopifyAPI
   module Ping
-    class DeliveryConfirmation < Base
+    class DeliveryConfirmationDetails < Base
       self.prefix = "/admin/api/ping-api/v1/conversations/:conversation_id/messages/:message_id/"
       self.collection_name = "delivery_confirmation"
     end

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "5.2.2"
+  VERSION = "5.2.3"
 end


### PR DESCRIPTION
Updated DeliveryConfirmation resource and Conversation methods to un-nest delivery_confirmation_details hash required for Feedback API endpoint.