### PR TITLE
Add optional currency parameter to Order#capture

### DIFF
--- a/lib/shopify_api/resources/order.rb
+++ b/lib/shopify_api/resources/order.rb
@@ -19,8 +19,15 @@ module ShopifyAPI
       Transaction.find(:all, :params => { :order_id => id })
     end
 
-    def capture(amount = "")
-      Transaction.create(:amount => amount, :kind => "capture", :order_id => id)
+    def capture(amount = "", currency: nil)
+      capture_transaction = {
+        amount: amount,
+        kind: "capture",
+        order_id: id,
+      }
+      capture_transaction[:currency] = currency if currency
+
+      Transaction.create(capture_transaction)
     end
 
     class ClientDetails < Base

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -56,4 +56,20 @@ class OrderTest < Test::Unit::TestCase
     order.cancel(email: false, restock: true)
     assert_request_body({'email' => false, 'restock' => true}.to_json)
   end
+
+  test "capture an order with currency param" do
+    fake 'orders/450789469', body: load_fixture('order')
+    order = ShopifyAPI::Order.find(450789469)
+
+    fake 'orders/450789469/transactions', method: :post, status: 201, body: load_fixture('transaction')
+    order.capture(100.00, currency: 'CAD')
+
+    assert_request_body({
+      transaction: {
+        amount: 100.00,
+        kind: 'capture',
+        currency: 'CAD',
+      },
+    }.to_json)
+  end
 end


### PR DESCRIPTION
Adds the optional `currency` argument to Order#capture, as per the [API reference](https://help.shopify.com/en/api/reference/orders/transaction).

Apps that are part of the multi-currency beta need to send this parameter to the Transactions API.

cc @kieranmasterton 