### PR TITLE
Packaging for release 5.2.4

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,8 @@
+== Version 5.2.4
+
+* Added `currency` parameter to `ShopifyAPI::Order#capture`. This parameter is required for apps that belong to the
+multi-currency beta program.
+
 == Version 5.2.3
 
 * Update delivery confirmation resource to delivery confirmation details resource.

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "5.2.3"
+  VERSION = "5.2.4"
 end


### PR DESCRIPTION
Releasing a new patch version.

```
== Version 5.2.4

* Added `currency` parameter to `ShopifyAPI::Order#capture`. This parameter is required for apps that belong to the
multi-currency beta program.

```