### PR TITLE
[WIP] GraphQL client memoization

### DIFF
--- a/lib/shopify_api/resources/graphql.rb
+++ b/lib/shopify_api/resources/graphql.rb
@@ -23,7 +23,7 @@ module ShopifyAPI
         self.class.graphql_client = ::GraphQL::Client.new(schema: schema, execute: @http_client)
       end
 
-      client.instance_variable_set(:@execute, @http_client)
+      graphql_client.instance_variable_set(:@execute, @http_client)
     end
 
     delegate :parse, :query, to: :graphql_client


### PR DESCRIPTION
Background: https://github.com/Shopify/shopify_api/issues/511

This is an attempt at memoizing the `::GraphQL::Client` instance so it's only created once on app boot instead of on every request (this will also avoid an introspection request each time).

@chrisbutcher and I worked on this a while ago. Wanted to open it up before I forgot about it again.

cc @Shopify/api-patterns-team 