### PR TITLE
Add test support for ActiveResource 5.x 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,8 @@ gemfile:
   - Gemfile_ar31
   - Gemfile_ar32
   - Gemfile_ar40
+  - Gemfile_ar50
+  - Gemfile_ar51
   - Gemfile_ar_master
 
 matrix:
@@ -26,6 +28,10 @@ matrix:
       gemfile: Gemfile_ar32
     - rvm: 2.4.0-preview1
       gemfile: Gemfile_ar40
+    - rvm: 2.4.0-preview1
+      gemfile: Gemfile_ar50
+    - rvm: 2.4.0-preview1
+      gemfile: Gemfile_ar51
     - rvm: 2.4.0-preview1
       gemfile: Gemfile_ar_master
     - rvm: 2.3.1

--- a/Gemfile_ar50
+++ b/Gemfile_ar50
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "activeresource", "5.0.0"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/Gemfile_ar51
+++ b/Gemfile_ar51
@@ -1,0 +1,6 @@
+source "https://rubygems.org"
+
+gemspec
+
+gem "activeresource", "5.1.0"
+gem "rack", "< 2" if RUBY_VERSION < "2.2"

--- a/lib/shopify_api/resources/marketing_event.rb
+++ b/lib/shopify_api/resources/marketing_event.rb
@@ -1,5 +1,7 @@
 module ShopifyAPI
   class MarketingEvent < Base
+    include Countable
+
     def add_engagements(engagements)
       engagements = { engagements: Array.wrap(engagements) }
       post(:engagements, {}, engagements.to_json)

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -39,11 +39,21 @@ class LogSubscriberTest < Test::Unit::TestCase
       ShopifyAPI::Page.find(2)
     end
 
-    assert_equal 4, @logger.logged(:info).size
-    assert_equal "GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:info)[0]
-    assert_match /\-\-\> 404/, @logger.logged(:info)[1]
-    assert_equal "Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[2]
-    assert_equal "Response:", @logger.logged(:info)[3]
+    if ar_version_before?('5.1.0')
+      assert_equal(4, @logger.logged(:info).size)
+      assert_equal("GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:info)[0])
+      assert_match(/\-\-\> 404/, @logger.logged(:info)[1])
+      assert_equal("Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[2])
+      assert_equal("Response:", @logger.logged(:info)[3])
+    else
+      assert_equal(2, @logger.logged(:error).size)
+      assert_equal("GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:error)[0])
+      assert_match(/\-\-\> 404/, @logger.logged(:error)[1])
+
+      assert_equal(2, @logger.logged(:info).size)
+      assert_equal("Headers: {\"Accept\"=>\"application/json\", #{@ua_header}}", @logger.logged(:info)[0])
+      assert_equal("Response:", @logger.logged(:info)[1])
+    end
   end
 
   test "warns when the server responds with a x-shopify-api-deprecated-reason header" do

--- a/test/marketing_event_test.rb
+++ b/test/marketing_event_test.rb
@@ -43,7 +43,7 @@ class MarketingEventTest < Test::Unit::TestCase
 
   def test_count_marketing_events
     fake "marketing_events/count", :method => :get, :body => '{"count": 2}'
-    marketing_events_count = ShopifyAPI::MarketingEvent.get(:count)
+    marketing_events_count = ShopifyAPI::MarketingEvent.count
     assert_equal 2, marketing_events_count
   end
 

--- a/test/recurring_application_charge_test.rb
+++ b/test/recurring_application_charge_test.rb
@@ -137,7 +137,7 @@ class RecurringApplicationChargeTest < Test::Unit::TestCase
     fake "recurring_application_charges", body: '{"errors":"Not Found"}', status: 404
 
     all_application_charges = ShopifyAPI::RecurringApplicationCharge.all
-    if ActiveResource::VERSION::MAJOR >= 5 || (ActiveResource::VERSION::MAJOR == 4 && ActiveResource::VERSION::MINOR >= 2)
+    if ActiveResource::VERSION::MAJOR == 4 && ActiveResource::VERSION::MINOR >= 2
       assert_equal [], all_application_charges
     else
       assert_equal nil, all_application_charges

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -95,4 +95,12 @@ class Test::Unit::TestCase < Minitest::Unit::TestCase
 
     FakeWeb.register_uri(method, url, {:body => body, :status => 200, :content_type => "text/#{format}", :content_length => 1}.merge(options))
   end
+
+  def ar_version_before?(version_string)
+    Gem::Version.new(ActiveResource::VERSION::STRING) < Gem::Version.new(version_string)
+  end
+
+  def ar_version_after?(version_string)
+    Gem::Version.new(version_string) < Gem::Version.new(ActiveResource::VERSION::STRING)
+  end
 end


### PR DESCRIPTION
Updating test suite to support ActiveResource 5.x

Updated our CI run to require passing tests for AR 5.0 and 5.1  anything on master can still fail and not fail the build.

The Countable module correctly handles the difference result structure for custom methods that are in the gem.

The other test failure was only a variation in results in the Shopify threadsafe Active Resource extension.

