### PR TITLE
Consolidate slash admin url prefix

### DIFF
--- a/lib/active_resource/disable_prefix_check.rb
+++ b/lib/active_resource/disable_prefix_check.rb
@@ -1,26 +1,28 @@
-module DisablePrefixCheck
-  extend ActiveSupport::Concern
+module ShopifyAPI
+  module DisablePrefixCheck
+    extend ActiveSupport::Concern
 
-  module ClassMethods
-    def check_prefix_options(options)
-    end
-
-    # `flexible = true` is hack to allow multiple things through the same AR class
-    def conditional_prefix(resource, flexible = false)
-      resource_id = "#{resource}_id".to_sym
-      resource_type = flexible ? ":#{resource}" : resource.to_s.pluralize
-
-      init_prefix_explicit resource_type, resource_id
-
-      define_singleton_method :prefix do |options = {}|
-        resource_type =  options[resource] if flexible
-
-        options[resource_id].nil? ? "/admin/" : "/admin/#{resource_type}/#{options[resource_id]}/"
+    module ClassMethods
+      def check_prefix_options(options)
       end
 
-      define_singleton_method :instantiate_record do |record, prefix_options = {}|
-        new(record, true).tap do |resource_instance|
-          resource_instance.prefix_options = prefix_options unless prefix_options.blank?
+      # `flexible = true` is hack to allow multiple things through the same AR class
+      def conditional_prefix(resource, flexible = false)
+        resource_id = "#{resource}_id".to_sym
+        resource_type = flexible ? ":#{resource}" : resource.to_s.pluralize
+
+        init_prefix_explicit resource_type, resource_id
+
+        define_singleton_method :prefix do |options = {}|
+          resource_type =  options[resource] if flexible
+
+          options[resource_id].nil? ? "/admin/" : "/admin/#{resource_type}/#{options[resource_id]}/"
+        end
+
+        define_singleton_method :instantiate_record do |record, prefix_options = {}|
+          new(record, true).tap do |resource_instance|
+            resource_instance.prefix_options = prefix_options unless prefix_options.blank?
+          end
         end
       end
     end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -8,7 +8,7 @@ require 'active_resource/detailed_log_subscriber'
 require 'shopify_api/limits'
 require 'shopify_api/json_format'
 require 'active_resource/json_errors'
-require 'active_resource/disable_prefix_check'
+require 'shopify_api/disable_prefix_check'
 require 'active_resource/base_ext'
 
 module ShopifyAPI

--- a/lib/shopify_api/disable_prefix_check.rb
+++ b/lib/shopify_api/disable_prefix_check.rb
@@ -17,7 +17,7 @@ module ShopifyAPI
         define_singleton_method :prefix do |options = {}|
           resource_type =  options[resource] if flexible
 
-          options[resource_id].nil? ? "/admin/" : "/admin/#{resource_type}/#{options[resource_id]}/"
+          options[resource_id].nil? ? api_prefix : "#{api_prefix}#{resource_type}/#{options[resource_id]}/"
         end
 
         define_singleton_method :instantiate_record do |record, prefix_options = {}|

--- a/lib/shopify_api/disable_prefix_check.rb
+++ b/lib/shopify_api/disable_prefix_check.rb
@@ -12,12 +12,12 @@ module ShopifyAPI
         resource_id = "#{resource}_id".to_sym
         resource_type = flexible ? ":#{resource}" : resource.to_s.pluralize
 
-        init_prefix_explicit resource_type, resource_id
+        init_prefix_explicit(resource_type, resource_id)
 
-        define_singleton_method :prefix do |options = {}|
-          resource_type =  options[resource] if flexible
+        define_singleton_method :resource_prefix do |options = {}|
+          resource_type = options[resource] if flexible
 
-          options[resource_id].nil? ? api_prefix : "#{api_prefix}#{resource_type}/#{options[resource_id]}/"
+          options[resource_id].nil? ? '' : "#{resource_type}/#{options[resource_id]}/"
         end
 
         define_singleton_method :instantiate_record do |record, prefix_options = {}|

--- a/lib/shopify_api/disable_prefix_check.rb
+++ b/lib/shopify_api/disable_prefix_check.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module ShopifyAPI
   module DisablePrefixCheck
     extend ActiveSupport::Concern

--- a/lib/shopify_api/resources/access_scope.rb
+++ b/lib/shopify_api/resources/access_scope.rb
@@ -1,5 +1,5 @@
 module ShopifyAPI
   class AccessScope < Base
-    self.prefix = '/admin/oauth/'
+    self.prefix = "#{api_prefix}oauth/"
   end
 end

--- a/lib/shopify_api/resources/access_scope.rb
+++ b/lib/shopify_api/resources/access_scope.rb
@@ -1,5 +1,5 @@
 module ShopifyAPI
   class AccessScope < Base
-    self.prefix = "#{api_prefix}oauth/"
+    self.resource_prefix = "oauth/"
   end
 end

--- a/lib/shopify_api/resources/asset.rb
+++ b/lib/shopify_api/resources/asset.rb
@@ -10,24 +10,24 @@ module ShopifyAPI
   #
   # Initialize with a key:
   #   asset = ShopifyAPI::Asset.new(:key => 'assets/special.css', :theme_id => 12345)
-  # 
+  #
   # Find by key:
   #   asset = ShopifyAPI::Asset.find('assets/image.png', :params => {:theme_id => 12345})
-  # 
+  #
   # Get the text or binary value:
   #   asset.value # decodes from attachment attribute if necessary
-  # 
+  #
   # You can provide new data for assets in a few different ways:
-  # 
+  #
   #   * assign text data for the value directly:
   #       asset.value = "div.special {color:red;}"
-  #     
+  #
   #   * provide binary data for the value:
   #       asset.attach(File.read('image.png'))
-  #     
+  #
   #   * set a URL from which Shopify will fetch the value:
   #       asset.src = "http://mysite.com/image.png"
-  #     
+  #
   #   * set a source key of another of your assets from which
   #     the value will be copied:
   #       asset.source_key = "assets/another_image.png"
@@ -44,15 +44,15 @@ module ShopifyAPI
     end
 
     # find an asset by key:
-    #   ShopifyAPI::Asset.find('layout/theme.liquid', :params => {:theme_id => 99})
+    #   ShopifyAPI::Asset.find('layout/theme.liquid', :params => { theme_id: 99 })
     def self.find(*args)
       if args[0].is_a?(Symbol)
         super
       else
-        params = {:asset => {:key => args[0]}}
+        params = { asset: { key: args[0] } }
         params = params.merge(args[1][:params]) if args[1] && args[1][:params]
-        path_prefix = params[:theme_id] ? "/admin/themes/#{params[:theme_id]}" : "/admin"
-        resource = find(:one, :from => "#{path_prefix}/assets.#{format.extension}", :params => params)
+        path_prefix = params[:theme_id] ? "themes/#{params[:theme_id]}/" : ""
+        resource = find(:one, from: "#{api_prefix}#{path_prefix}assets.#{format.extension}", params: params)
         resource.prefix_options[:theme_id] = params[:theme_id] if resource && params[:theme_id]
         resource
       end

--- a/lib/shopify_api/resources/asset.rb
+++ b/lib/shopify_api/resources/asset.rb
@@ -52,7 +52,11 @@ module ShopifyAPI
         params = { asset: { key: args[0] } }
         params = params.merge(args[1][:params]) if args[1] && args[1][:params]
         path_prefix = params[:theme_id] ? "themes/#{params[:theme_id]}/" : ""
-        resource = find(:one, from: "#{api_prefix}#{path_prefix}assets.#{format.extension}", params: params)
+        resource = find(
+          :one,
+          from: "#{api_prefix}#{path_prefix}assets.#{format.extension}",
+          params: params
+        )
         resource.prefix_options[:theme_id] = params[:theme_id] if resource && params[:theme_id]
         resource
       end

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -10,6 +10,8 @@ module ShopifyAPI
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",
                                   "Ruby/#{RUBY_VERSION}"].join(' ')
 
+    API_PREFIX = '/admin/'.freeze
+
     def encode(options = {})
       same = dup
       same.attributes = {self.class.element_name => same.attributes} if self.class.format.extension == 'json'
@@ -63,12 +65,21 @@ module ShopifyAPI
         self.headers.delete('X-Shopify-Access-Token')
       end
 
+      def api_prefix
+        API_PREFIX
+      end
+
+      def prefix(options = {})
+        self.prefix = api_prefix
+        prefix(options)
+      end
+
       def init_prefix(resource)
         init_prefix_explicit(resource.to_s.pluralize, "#{resource}_id")
       end
 
       def init_prefix_explicit(resource_type, resource_id)
-        self.prefix = "/admin/#{resource_type}/:#{resource_id}/"
+        self.prefix = "#{api_prefix}#{resource_type}/:#{resource_id}/"
 
         define_method resource_id.to_sym do
           @prefix_options[resource_id]

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -101,8 +101,19 @@ module ShopifyAPI
         raise
       end
 
-      alias_method :set_prefix, :resource_prefix=
-      alias_method :prefix=, :resource_prefix=
+      def prefix=(value)
+        if value.start_with?('/admin')
+          raise ArgumentError, "'#{value}' can no longer start /admin/. Change to using resource_prefix="
+        end
+
+        warn(
+          '[DEPRECATED] ShopifyAPI::Base#prefix= is deprecated and will be removed in a future version. ' \
+            'Use `self.resource_prefix=` instead.'
+        )
+        self.resource_prefix = value
+      end
+
+      alias_method :set_prefix, :prefix=
 
       def init_prefix(resource)
         init_prefix_explicit(resource.to_s.pluralize, "#{resource}_id")

--- a/lib/shopify_api/resources/fulfillment_event.rb
+++ b/lib/shopify_api/resources/fulfillment_event.rb
@@ -1,6 +1,6 @@
 module ShopifyAPI
   class FulfillmentEvent < Base
-    self.prefix = '/admin/orders/:order_id/fulfillments/:fulfillment_id/'
+    self.prefix = "#{api_prefix}orders/:order_id/fulfillments/:fulfillment_id/"
     self.collection_name = 'events'
     self.element_name = 'event'
 

--- a/lib/shopify_api/resources/fulfillment_event.rb
+++ b/lib/shopify_api/resources/fulfillment_event.rb
@@ -1,6 +1,6 @@
 module ShopifyAPI
   class FulfillmentEvent < Base
-    self.prefix = "#{api_prefix}orders/:order_id/fulfillments/:fulfillment_id/"
+    self.resource_prefix = "orders/:order_id/fulfillments/:fulfillment_id/"
     self.collection_name = 'events'
     self.element_name = 'event'
 

--- a/lib/shopify_api/resources/location.rb
+++ b/lib/shopify_api/resources/location.rb
@@ -2,7 +2,7 @@ module ShopifyAPI
   class Location < Base
 
     def inventory_levels
-      ShopifyAPI::InventoryLevel.find(:all, from: "/admin/locations/#{id}/inventory_levels.json")
+      ShopifyAPI::InventoryLevel.find(:all, from: "#{self.class.prefix}locations/#{id}/inventory_levels.json")
     end
   end
 end

--- a/lib/shopify_api/resources/payment.rb
+++ b/lib/shopify_api/resources/payment.rb
@@ -2,6 +2,6 @@
 
 module ShopifyAPI
   class Payment < Base
-    self.prefix = "#{api_prefix}checkouts/:checkout_id/"
+    self.resource_prefix = "checkouts/:checkout_id/"
   end
 end

--- a/lib/shopify_api/resources/payment.rb
+++ b/lib/shopify_api/resources/payment.rb
@@ -2,6 +2,6 @@
 
 module ShopifyAPI
   class Payment < Base
-    self.prefix = '/admin/checkouts/:checkout_id/'
+    self.prefix = "#{api_prefix}checkouts/:checkout_id/"
   end
 end

--- a/lib/shopify_api/resources/ping/conversation.rb
+++ b/lib/shopify_api/resources/ping/conversation.rb
@@ -3,7 +3,7 @@
 module ShopifyAPI
   module Ping
     class Conversation < Base
-      self.prefix = "/admin/api/ping-api/v1/"
+      self.prefix = "#{api_prefix}api/ping-api/v1/"
 
       def send_message(message_attrs)
         message = ShopifyAPI::Ping::Message.new(

--- a/lib/shopify_api/resources/ping/conversation.rb
+++ b/lib/shopify_api/resources/ping/conversation.rb
@@ -3,7 +3,7 @@
 module ShopifyAPI
   module Ping
     class Conversation < Base
-      self.prefix = "#{api_prefix}api/ping-api/v1/"
+      self.resource_prefix = "api/ping-api/v1/"
 
       def send_message(message_attrs)
         message = ShopifyAPI::Ping::Message.new(

--- a/lib/shopify_api/resources/ping/delivery_confirmation_details.rb
+++ b/lib/shopify_api/resources/ping/delivery_confirmation_details.rb
@@ -3,7 +3,7 @@
 module ShopifyAPI
   module Ping
     class DeliveryConfirmationDetails < Base
-      self.prefix = "/admin/api/ping-api/v1/conversations/:conversation_id/messages/:message_id/"
+      self.prefix = "#{api_prefix}api/ping-api/v1/conversations/:conversation_id/messages/:message_id/"
       self.collection_name = "delivery_confirmation"
     end
   end

--- a/lib/shopify_api/resources/ping/delivery_confirmation_details.rb
+++ b/lib/shopify_api/resources/ping/delivery_confirmation_details.rb
@@ -3,7 +3,7 @@
 module ShopifyAPI
   module Ping
     class DeliveryConfirmationDetails < Base
-      self.prefix = "#{api_prefix}api/ping-api/v1/conversations/:conversation_id/messages/:message_id/"
+      self.resource_prefix = "api/ping-api/v1/conversations/:conversation_id/messages/:message_id/"
       self.collection_name = "delivery_confirmation"
     end
   end

--- a/lib/shopify_api/resources/ping/message.rb
+++ b/lib/shopify_api/resources/ping/message.rb
@@ -2,7 +2,7 @@
 module ShopifyAPI
   module Ping
     class Message < Base
-      self.prefix = "/admin/api/ping-api/v1/conversations/:conversation_id/"
+      self.prefix = "#{api_prefix}api/ping-api/v1/conversations/:conversation_id/"
     end
   end
 end

--- a/lib/shopify_api/resources/ping/message.rb
+++ b/lib/shopify_api/resources/ping/message.rb
@@ -2,7 +2,7 @@
 module ShopifyAPI
   module Ping
     class Message < Base
-      self.prefix = "#{api_prefix}api/ping-api/v1/conversations/:conversation_id/"
+      self.resource_prefix = "api/ping-api/v1/conversations/:conversation_id/"
     end
   end
 end

--- a/lib/shopify_api/resources/refund.rb
+++ b/lib/shopify_api/resources/refund.rb
@@ -4,9 +4,10 @@ module ShopifyAPI
 
     def self.calculate(*args)
       options = { :refund => args[0] }
-      params = options.merge(args[1][:params]) if args[1] && args[1][:params]
-      self.prefix = "/admin/orders/#{params[:order_id]}/"
-      resource = post(:calculate, {}, options.to_json)
+      params = {}
+      params = args[1][:params] if args[1] && args[1][:params]
+
+      resource = post(:calculate, params, options.to_json)
       instantiate_record(format.decode(resource.body), {})
     end
   end

--- a/lib/shopify_api/resources/shipping_rate.rb
+++ b/lib/shopify_api/resources/shipping_rate.rb
@@ -2,6 +2,6 @@
 
 module ShopifyAPI
   class ShippingRate < Base
-    self.prefix = '/admin/checkouts/:checkout_id/'
+    self.prefix = "#{api_prefix}checkouts/:checkout_id/"
   end
 end

--- a/lib/shopify_api/resources/shipping_rate.rb
+++ b/lib/shopify_api/resources/shipping_rate.rb
@@ -2,6 +2,6 @@
 
 module ShopifyAPI
   class ShippingRate < Base
-    self.prefix = "#{api_prefix}checkouts/:checkout_id/"
+    self.resource_prefix = "checkouts/:checkout_id/"
   end
 end

--- a/lib/shopify_api/resources/shop.rb
+++ b/lib/shopify_api/resources/shop.rb
@@ -5,12 +5,12 @@ module ShopifyAPI
     if ActiveResource::VERSION::MAJOR >= 4
       include ActiveResource::Singleton
 
-      def self.current(options={})
+      def self.current(options = {})
         find(options)
       end
     else
-      def self.current(options={})
-        find(:one, options.merge({from: "/admin/shop.#{format.extension}"}))
+      def self.current(options = {})
+        find(:one, options.merge(from: "#{api_prefix}shop.#{format.extension}"))
       end
     end
 

--- a/lib/shopify_api/resources/shop.rb
+++ b/lib/shopify_api/resources/shop.rb
@@ -2,8 +2,16 @@ module ShopifyAPI
   # Shop object. Use Shop.current to receive
   # the shop.
   class Shop < Base
-    def self.current(options={})
-      find(:one, options.merge({from: "/admin/shop.#{format.extension}"}))
+    if ActiveResource::VERSION::MAJOR >= 4
+      include ActiveResource::Singleton
+
+      def self.current(options={})
+        find(options)
+      end
+    else
+      def self.current(options={})
+        find(:one, options.merge({from: "/admin/shop.#{format.extension}"}))
+      end
     end
 
     def metafields(**options)

--- a/lib/shopify_api/resources/smart_collection.rb
+++ b/lib/shopify_api/resources/smart_collection.rb
@@ -5,7 +5,7 @@ module ShopifyAPI
 
     def products(options = {})
       if options.present?
-        Product.find(:all, from: "/admin/smart_collections/#{id}/products.json", params: options)
+        Product.find(:all, from: "#{self.class.prefix}smart_collections/#{id}/products.json", params: options)
       else
         Product.find(:all, params: { collection_id: id })
       end

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -74,7 +74,7 @@ module ShopifyAPI
     def create_permission_url(scope, redirect_uri = nil)
       params = {:client_id => api_key, :scope => scope.join(',')}
       params[:redirect_uri] = redirect_uri if redirect_uri
-      "#{site}/oauth/authorize?#{parameterize(params)}"
+      "https://#{url}/admin/oauth/authorize?#{parameterize(params)}"
     end
 
     def request_token(params)
@@ -103,7 +103,7 @@ module ShopifyAPI
     end
 
     def site
-      "https://#{url}/admin"
+      "https://#{url}"
     end
 
     def valid?

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -132,7 +132,7 @@ module ShopifyAPI
     end
 
     def access_token_request(code)
-      uri = URI.parse("https://#{url}/admin/oauth/access_token")
+      uri = URI.parse("https://#{url}#{Base.api_prefix}oauth/access_token")
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       request = Net::HTTP::Post.new(uri.request_uri)

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -74,7 +74,7 @@ module ShopifyAPI
     def create_permission_url(scope, redirect_uri = nil)
       params = {:client_id => api_key, :scope => scope.join(',')}
       params[:redirect_uri] = redirect_uri if redirect_uri
-      "https://#{url}/admin/oauth/authorize?#{parameterize(params)}"
+      construct_oauth_url("authorize", params)
     end
 
     def request_token(params)
@@ -132,12 +132,17 @@ module ShopifyAPI
     end
 
     def access_token_request(code)
-      uri = URI.parse("https://#{url}#{Base.api_prefix}oauth/access_token")
+      uri = URI.parse(construct_oauth_url('access_token'))
       https = Net::HTTP.new(uri.host, uri.port)
       https.use_ssl = true
       request = Net::HTTP::Post.new(uri.request_uri)
       request.set_form_data('client_id' => api_key, 'client_secret' => secret, 'code' => code)
       https.request(request)
+    end
+
+    def construct_oauth_url(path, query_params = {})
+      query_string = "?#{parameterize(query_params)}" unless query_params.empty?
+      "https://#{url}/admin/oauth/#{path}#{query_string}"
     end
   end
 end

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency("minitest", ">= 4.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("timecop")
+  s.add_development_dependency("rubocop")
   s.add_development_dependency("pry")
   s.add_development_dependency("pry-byebug")
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -1,8 +1,7 @@
 require 'test_helper'
-
+require "active_support/log_subscriber/test_helper"
 
 class BaseTest < Test::Unit::TestCase
-
   def setup
     @session1 = ShopifyAPI::Session.new('shop1.myshopify.com', 'token1')
     @session2 = ShopifyAPI::Session.new('shop2.myshopify.com', 'token2')
@@ -86,6 +85,18 @@ class BaseTest < Test::Unit::TestCase
     thread.join
   end
 
+  test "prefix= will forward to resource when the value does not start with admin" do
+    TestResource.prefix = 'a/regular/path/'
+
+    assert_equal('/admin/a/regular/path/', TestResource.prefix)
+  end
+
+  test "prefix= will raise an error if value starts with with /admin" do
+    assert_raises ArgumentError do
+      TestResource.prefix = '/admin/old/prefix/structure/'
+    end
+  end
+
   if ActiveResource::VERSION::MAJOR >= 4
     test "#headers propagates changes to subclasses" do
       ShopifyAPI::Base.headers['X-Custom'] = "the value"
@@ -121,5 +132,8 @@ class BaseTest < Test::Unit::TestCase
     [ActiveResource::Base, ShopifyAPI::Base, ShopifyAPI::Product].each do |klass|
       klass.headers.delete(header)
     end
+  end
+
+  class TestResource < ShopifyAPI::Base
   end
 end

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -16,8 +16,8 @@ class BaseTest < Test::Unit::TestCase
     ShopifyAPI::Base.activate_session @session1
 
     assert_nil ActiveResource::Base.site
-    assert_equal 'https://shop1.myshopify.com/admin', ShopifyAPI::Base.site.to_s
-    assert_equal 'https://shop1.myshopify.com/admin', ShopifyAPI::Shop.site.to_s
+    assert_equal 'https://shop1.myshopify.com', ShopifyAPI::Base.site.to_s
+    assert_equal 'https://shop1.myshopify.com', ShopifyAPI::Shop.site.to_s
 
     assert_nil ActiveResource::Base.headers['X-Shopify-Access-Token']
     assert_equal 'token1', ShopifyAPI::Base.headers['X-Shopify-Access-Token']
@@ -56,8 +56,8 @@ class BaseTest < Test::Unit::TestCase
     ShopifyAPI::Base.activate_session @session2
 
     assert_nil ActiveResource::Base.site
-    assert_equal 'https://shop2.myshopify.com/admin', ShopifyAPI::Base.site.to_s
-    assert_equal 'https://shop2.myshopify.com/admin', ShopifyAPI::Shop.site.to_s
+    assert_equal 'https://shop2.myshopify.com', ShopifyAPI::Base.site.to_s
+    assert_equal 'https://shop2.myshopify.com', ShopifyAPI::Shop.site.to_s
 
     assert_nil ActiveResource::Base.headers['X-Shopify-Access-Token']
     assert_equal 'token2', ShopifyAPI::Base.headers['X-Shopify-Access-Token']

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -30,11 +30,14 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "ignore everything but the subdomain in the shop" do
-    assert_equal "https://testshop.myshopify.com/admin", ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token").site
+    assert_equal(
+      "https://testshop.myshopify.com",
+      ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token").site
+    )
   end
 
   test "append the myshopify domain if not given" do
-    assert_equal "https://testshop.myshopify.com/admin", ShopifyAPI::Session.new("testshop", "any-token").site
+    assert_equal "https://testshop.myshopify.com", ShopifyAPI::Session.new("testshop", "any-token").site
   end
 
   test "not raise error without params" do
@@ -65,8 +68,8 @@ class SessionTest < Test::Unit::TestCase
     ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token") {
       @assigned_site = ShopifyAPI::Base.site
     }
-    assert_equal 'https://testshop.myshopify.com/admin', @assigned_site.to_s
-    assert_equal 'https://fakeshop.myshopify.com/admin', ShopifyAPI::Base.site.to_s
+    assert_equal 'https://testshop.myshopify.com', @assigned_site.to_s
+    assert_equal 'https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s
   end
 
   test "create_permission_url returns correct url with single scope no redirect uri" do
@@ -113,7 +116,7 @@ class SessionTest < Test::Unit::TestCase
 
   test "return site for session" do
     session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
-    assert_equal "https://testshop.myshopify.com/admin", session.site
+    assert_equal "https://testshop.myshopify.com", session.site
   end
 
   test "return_token_if_signature_is_valid" do


### PR DESCRIPTION
Bring all the definitions of the `/admin/` rest url prefix into 1 place.

This change is breaking for any Resource that has set a prefix.
`self.prefix = '/admin/orders/:order_id/fulfillments/:fulfillment_id/'`
  

The change will be to not include `/admin/` at the beginning of the prefix and switch from `prefix=` to `resource_prefix=` .
Example of the change
`self.prefix = '/admin/orders/:order_id/fulfillments/:fulfillment_id/'` 
`self.resource_prefix = "orders/:order_id/fulfillments/:fulfillment_id/"`

