### PR TITLE
Update call limit header

### DIFF
--- a/lib/shopify_api/limits.rb
+++ b/lib/shopify_api/limits.rb
@@ -8,13 +8,14 @@ module ShopifyAPI
 
     module ClassMethods
 
-      # Takes form num_requests_executed/max_requests
-      # Eg: 101/3000
+      # Takes form <call count>/<bucket size>
+      # See https://help.shopify.com/en/api/getting-started/api-call-limit
+      # Eg: 2/40
       CREDIT_LIMIT_HEADER_PARAM = {
-        :shop => 'http_x_shopify_shop_api_call_limit'
+        :shop => 'X-Shopify-Shop-Api-Call-Limit'
       }
 
-        ##
+      ##
       # How many more API calls can I make?
       # @return {Integer}
       #

--- a/lib/shopify_api/limits.rb
+++ b/lib/shopify_api/limits.rb
@@ -7,12 +7,11 @@ module ShopifyAPI
     end
 
     module ClassMethods
-
       # Takes form <call count>/<bucket size>
       # See https://help.shopify.com/en/api/getting-started/api-call-limit
       # Eg: 2/40
       CREDIT_LIMIT_HEADER_PARAM = {
-        :shop => 'X-Shopify-Shop-Api-Call-Limit'
+        shop: 'X-Shopify-Shop-Api-Call-Limit',
       }
 
       ##

--- a/test/limits_test.rb
+++ b/test/limits_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class LimitsTest < Test::Unit::TestCase
   def setup
     super
-    @header_hash = {'http_x_shopify_shop_api_call_limit' => '100/300'}
+    @header_hash = {'X-Shopify-Shop-Api-Call-Limit' => '100/300'}
     ShopifyAPI::Base.connection.expects(:response).at_least(0).returns(@header_hash)
   end
 
@@ -22,7 +22,7 @@ class LimitsTest < Test::Unit::TestCase
 
     should "flag maxed out credits" do
       assert !ShopifyAPI.maxed?
-      @header_hash = {'http_x_shopify_shop_api_call_limit' => '299/300'}
+      @header_hash = {'X-Shopify-Shop-Api-Call-Limit' => '299/300'}
       ShopifyAPI::Base.connection.expects(:response).at_least(1).returns(@header_hash)
       assert ShopifyAPI.maxed?
     end

--- a/test/limits_test.rb
+++ b/test/limits_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class LimitsTest < Test::Unit::TestCase
   def setup
     super
-    @header_hash = {'X-Shopify-Shop-Api-Call-Limit' => '100/300'}
+    @header_hash = { 'X-Shopify-Shop-Api-Call-Limit' => '100/300' }
     ShopifyAPI::Base.connection.expects(:response).at_least(0).returns(@header_hash)
   end
 
@@ -22,7 +22,7 @@ class LimitsTest < Test::Unit::TestCase
 
     should "flag maxed out credits" do
       assert !ShopifyAPI.maxed?
-      @header_hash = {'X-Shopify-Shop-Api-Call-Limit' => '299/300'}
+      @header_hash = { 'X-Shopify-Shop-Api-Call-Limit' => '299/300' }
       ShopifyAPI::Base.connection.expects(:response).at_least(1).returns(@header_hash)
       assert ShopifyAPI.maxed?
     end


### PR DESCRIPTION
`http_x_shopify_shop_api_call_limit` is the legacy header so this updates to use the proper one.

edit: this is *not* a breaking change since we respond with both headers. This is better future compatibility.