### PR TITLE
Change init_prefix_explicit to use self.resource_prefix.

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -120,7 +120,7 @@ module ShopifyAPI
       end
 
       def init_prefix_explicit(resource_type, resource_id)
-        self.prefix = "#{resource_type}/:#{resource_id}/"
+        self.resource_prefix = "#{resource_type}/:#{resource_id}/"
 
         define_method resource_id.to_sym do
           @prefix_options[resource_id]


### PR DESCRIPTION
Missed 1 use of `prefix=` that should have been migrated to `resource_prefix=` to avoid depreciation warnings.