### PR TITLE
Remove default for version on session [Breaking change]

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -10,8 +10,9 @@ module ShopifyAPI
     cattr_accessor :api_key, :secret, :myshopify_domain
     self.myshopify_domain = 'myshopify.com'
 
-    attr_accessor :url, :token, :name, :extra
+    attr_accessor :domain, :token, :name, :extra
     attr_reader :api_version
+    alias_method :url, :domain
 
     class << self
 
@@ -19,12 +20,12 @@ module ShopifyAPI
         params.each { |k,value| public_send("#{k}=", value) }
       end
 
-      def temp(domain, token, api_version, &_block)
-        session = new(domain, token, api_version)
+      def temp(domain:, token:, api_version:, &_block)
+        session = new(domain: domain, token: token, api_version: api_version)
         original_site = ShopifyAPI::Base.site.to_s
         original_token = ShopifyAPI::Base.headers['X-Shopify-Access-Token']
         original_version = ShopifyAPI::Base.api_version
-        original_session = new(original_site, original_token, original_version)
+        original_session = new(domain: original_site, token: original_token, api_version: original_version)
 
         begin
           ShopifyAPI::Base.activate_session(session)
@@ -34,12 +35,12 @@ module ShopifyAPI
         end
       end
 
-      def prepare_url(url)
-        return nil if url.blank?
+      def prepare_domain(domain)
+        return nil if domain.blank?
         # remove http:// or https://
-        url = url.strip.gsub(/\Ahttps?:\/\//, '')
+        domain = domain.strip.gsub(%r{\Ahttps?://}, '')
         # extract host, removing any username, password or path
-        shop = URI.parse("https://#{url}").host
+        shop = URI.parse("https://#{domain}").host
         # extract subdomain of .myshopify.com
         if idx = shop.index(".")
           shop = shop.slice(0, idx)
@@ -67,8 +68,8 @@ module ShopifyAPI
       end
     end
 
-    def initialize(url, token, api_version, extra = {})
-      self.url = self.class.prepare_url(url)
+    def initialize(domain:, token:, api_version:, extra: {})
+      self.domain = self.class.prepare_domain(domain)
       self.api_version = api_version
       self.token = token
       self.extra = extra
@@ -106,7 +107,7 @@ module ShopifyAPI
     end
 
     def site
-      "https://#{url}"
+      "https://#{domain}"
     end
 
     def api_version=(version)
@@ -114,7 +115,7 @@ module ShopifyAPI
     end
 
     def valid?
-      url.present? && token.present? && api_version.present?
+      domain.present? && token.present? && api_version.present?
     end
 
     def expires_in
@@ -149,7 +150,7 @@ module ShopifyAPI
 
     def construct_oauth_url(path, query_params = {})
       query_string = "?#{parameterize(query_params)}" unless query_params.empty?
-      "https://#{url}/admin/oauth/#{path}#{query_string}"
+      "https://#{domain}/admin/oauth/#{path}#{query_string}"
     end
   end
 end

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -19,7 +19,7 @@ module ShopifyAPI
         params.each { |k,value| public_send("#{k}=", value) }
       end
 
-      def temp(domain, token, api_version = :no_version, &_block)
+      def temp(domain, token, api_version, &_block)
         session = new(domain, token, api_version)
         original_site = ShopifyAPI::Base.site.to_s
         original_token = ShopifyAPI::Base.headers['X-Shopify-Access-Token']
@@ -67,7 +67,7 @@ module ShopifyAPI
       end
     end
 
-    def initialize(url, token = nil, api_version = :no_version, extra = {})
+    def initialize(url, token, api_version, extra = {})
       self.url = self.class.prepare_url(url)
       self.api_version = api_version
       self.token = token
@@ -110,11 +110,11 @@ module ShopifyAPI
     end
 
     def api_version=(version)
-      @api_version = ApiVersion.coerce_to_version(version)
+      @api_version = version.nil? ? nil : ApiVersion.coerce_to_version(version)
     end
 
     def valid?
-      url.present? && token.present?
+      url.present? && token.present? && api_version.present?
     end
 
     def expires_in

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -3,8 +3,8 @@ require "active_support/log_subscriber/test_helper"
 
 class BaseTest < Test::Unit::TestCase
   def setup
-    @session1 = ShopifyAPI::Session.new('shop1.myshopify.com', 'token1', :no_version)
-    @session2 = ShopifyAPI::Session.new('shop2.myshopify.com', 'token2', :no_version)
+    @session1 = ShopifyAPI::Session.new(domain: 'shop1.myshopify.com', token: 'token1', api_version: :no_version)
+    @session2 = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: :no_version)
   end
 
   def teardown
@@ -131,8 +131,8 @@ class BaseTest < Test::Unit::TestCase
   end
 
   test "using a different version changes the url" do
-    no_version = ShopifyAPI::Session.new('shop1.myshopify.com', 'token1', :no_version)
-    unstable_version = ShopifyAPI::Session.new('shop2.myshopify.com', 'token2', :unstable)
+    no_version = ShopifyAPI::Session.new(domain: 'shop1.myshopify.com', token: 'token1', api_version: :no_version)
+    unstable_version = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: :unstable)
 
     fake(
       "shop",

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -3,8 +3,8 @@ require "active_support/log_subscriber/test_helper"
 
 class BaseTest < Test::Unit::TestCase
   def setup
-    @session1 = ShopifyAPI::Session.new('shop1.myshopify.com', 'token1')
-    @session2 = ShopifyAPI::Session.new('shop2.myshopify.com', 'token2')
+    @session1 = ShopifyAPI::Session.new('shop1.myshopify.com', 'token1', :no_version)
+    @session2 = ShopifyAPI::Session.new('shop2.myshopify.com', 'token2', :no_version)
   end
 
   def teardown

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -15,7 +15,11 @@ class LogSubscriberTest < Test::Unit::TestCase
       "#{@ua_header}, \"X-Shopify-Access-Token\"=>\"access_token\"}"
 
     ShopifyAPI::Base.clear_session
-    session = ShopifyAPI::Session.new("https://this-is-my-test-shop.myshopify.com", "access_token", :no_version)
+    session = ShopifyAPI::Session.new(
+      domain: "https://this-is-my-test-shop.myshopify.com",
+      token: "access_token",
+      api_version: :no_version
+    )
 
     ShopifyAPI::Base.activate_session(session)
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -9,51 +9,62 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "not be valid without a url" do
-    session = ShopifyAPI::Session.new(nil, "any-token", any_api_version)
+    session = ShopifyAPI::Session.new(domain: nil, token: "any-token", api_version: any_api_version)
     assert_not session.valid?
   end
 
   test "not be valid without token" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: any_api_version)
     assert_not session.valid?
   end
 
   test "not be valid without an api version" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", nil)
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: nil)
     assert_not session.valid?
   end
 
   test "be valid with any token, any url and version" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version
+    )
     assert session.valid?
   end
 
   test "not raise error without params" do
     assert_nothing_raised do
-      ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
+      ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: any_api_version)
     end
   end
 
   test "ignore everything but the subdomain in the shop" do
     assert_equal(
       "https://testshop.myshopify.com",
-      ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token", any_api_version).site
+      ShopifyAPI::Session.new(
+        domain: "http://user:pass@testshop.notshopify.net/path",
+        token: "any-token",
+        api_version: any_api_version
+      ).site
     )
   end
 
   test "append the myshopify domain if not given" do
-    assert_equal "https://testshop.myshopify.com", ShopifyAPI::Session.new("testshop", "any-token", any_api_version).site
+    assert_equal(
+      "https://testshop.myshopify.com",
+      ShopifyAPI::Session.new(domain: "testshop", token: "any-token", api_version: any_api_version).site
+    )
   end
 
   test "not raise error without params" do
     assert_nothing_raised do
-      ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
+      ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: any_api_version)
     end
   end
 
   test "raise error if params passed but signature omitted" do
     assert_raises(ShopifyAPI::ValidationException) do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
+      session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: any_api_version)
       session.request_token({'code' => 'any-code'})
     end
   end
@@ -67,13 +78,14 @@ class SessionTest < Test::Unit::TestCase
   test "#temp reset ShopifyAPI::Base.site to original value" do
 
     ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
-    session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com', 'token1', :no_version)
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
     ShopifyAPI::Base.activate_session(session1)
 
-    ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token", :unstable) {
+    ShopifyAPI::Session.temp(domain: "testshop.myshopify.com", token: "any-token", api_version: :unstable) do
       @assigned_site = ShopifyAPI::Base.site
       @assigned_version = ShopifyAPI::Base.api_version
-    }
+    end
+
     assert_equal('https://testshop.myshopify.com', @assigned_site.to_s)
     assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
 
@@ -83,7 +95,11 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with single scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
+    session = ShopifyAPI::Session.new(
+      domain: 'http://localhost.myshopify.com',
+      token: 'any-token',
+      api_version: any_api_version
+    )
     scope = ["write_products"]
     permission_url = session.create_permission_url(scope)
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
@@ -91,7 +107,11 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with single scope and redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
+    session = ShopifyAPI::Session.new(
+      domain: 'http://localhost.myshopify.com',
+      token: 'any-token',
+      api_version: any_api_version
+    )
     scope = ["write_products"]
     permission_url = session.create_permission_url(scope, "http://my_redirect_uri.com")
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com", permission_url
@@ -99,7 +119,11 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with dual scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
+    session = ShopifyAPI::Session.new(
+      domain: 'http://localhost.myshopify.com',
+      token: 'any-token',
+      api_version: any_api_version
+    )
     scope = ["write_products","write_customers"]
     permission_url = session.create_permission_url(scope)
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
@@ -107,7 +131,11 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with no scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
+    session = ShopifyAPI::Session.new(
+      domain: 'http://localhost.myshopify.com',
+      token: 'any-token',
+      api_version: any_api_version
+    )
     scope = []
     permission_url = session.create_permission_url(scope)
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=", permission_url
@@ -115,16 +143,30 @@ class SessionTest < Test::Unit::TestCase
 
   test "raise exception if code invalid in request token" do
     ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', nil, any_api_version)
-    fake nil, :url => 'https://localhost.myshopify.com/admin/oauth/access_token',:method => :post, :status => 404, :body => '{"error" : "invalid_request"}'
+    session = ShopifyAPI::Session.new(
+      domain: 'http://localhost.myshopify.com',
+      token: nil,
+      api_version: any_api_version
+    )
+    fake(
+      nil,
+      url: 'https://localhost.myshopify.com/admin/oauth/access_token',
+      method: :post,
+      status: 404,
+      body: '{"error" : "invalid_request"}'
+    )
     assert_raises(ShopifyAPI::ValidationException) do
-      session.request_token(params={:code => "bad-code"})
+      session.request_token(code: "bad-code")
     end
     assert_equal false, session.valid?
   end
 
   test "return site for session" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version
+    )
     assert_equal "https://testshop.myshopify.com", session.site
   end
 
@@ -134,7 +176,7 @@ class SessionTest < Test::Unit::TestCase
       url: "https://testshop.myshopify.com/admin/oauth/access_token",
       method: :post,
       body: '{"access_token":"any-token"}'
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, api_version)
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: api_version)
 
     params = { code: 'any-code', timestamp: Time.now }
     token = session.request_token(params.merge(hmac: generate_signature(params)))
@@ -149,7 +191,7 @@ class SessionTest < Test::Unit::TestCase
       url: "https://testshop.myshopify.com/admin/oauth/access_token",
       method: :post,
       body: '{"access_token":"any-token","foo":"example"}'
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, api_version)
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: api_version)
 
     params = { code: 'any-code', timestamp: Time.now }
     assert session.request_token(params.merge(hmac: generate_signature(params)))
@@ -163,7 +205,7 @@ class SessionTest < Test::Unit::TestCase
       url: "https://testshop.myshopify.com/admin/oauth/access_token",
       method: :post,
       body: '{"access_token":"any-token","expires_in":86393}'
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, api_version)
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: api_version)
 
     Timecop.freeze do
       params = { code: 'any-code', timestamp: Time.now }
@@ -187,7 +229,7 @@ class SessionTest < Test::Unit::TestCase
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
+      session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: any_api_version)
       session.request_token(params.merge(:hmac => signature))
     end
   end
@@ -197,7 +239,7 @@ class SessionTest < Test::Unit::TestCase
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
+      session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: nil, api_version: any_api_version)
       session.request_token(params.merge(:hmac => signature))
     end
   end
@@ -222,6 +264,16 @@ class SessionTest < Test::Unit::TestCase
     to_sign = 'a%253D1%2526b=2%2526c%253D3'
     params[:hmac] = generate_signature(to_sign)
     assert_equal true, ShopifyAPI::Session.validate_signature(params)
+  end
+
+  test "url is aliased to domain to minimize the upgrade changes" do
+    session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version
+    )
+
+    assert_equal('testshop.myshopify.com', session.url)
   end
 
   private

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -9,46 +9,51 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "not be valid without a url" do
-    session = ShopifyAPI::Session.new(nil, "any-token")
+    session = ShopifyAPI::Session.new(nil, "any-token", any_api_version)
     assert_not session.valid?
   end
 
   test "not be valid without token" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com")
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
     assert_not session.valid?
   end
 
-  test "be valid with any token and any url" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
+  test "not be valid without an api version" do
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", nil)
+    assert_not session.valid?
+  end
+
+  test "be valid with any token, any url and version" do
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
     assert session.valid?
   end
 
   test "not raise error without params" do
     assert_nothing_raised do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
+      ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
     end
   end
 
   test "ignore everything but the subdomain in the shop" do
     assert_equal(
       "https://testshop.myshopify.com",
-      ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token").site
+      ShopifyAPI::Session.new("http://user:pass@testshop.notshopify.net/path", "any-token", any_api_version).site
     )
   end
 
   test "append the myshopify domain if not given" do
-    assert_equal "https://testshop.myshopify.com", ShopifyAPI::Session.new("testshop", "any-token").site
+    assert_equal "https://testshop.myshopify.com", ShopifyAPI::Session.new("testshop", "any-token", any_api_version).site
   end
 
   test "not raise error without params" do
     assert_nothing_raised do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
+      ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
     end
   end
 
   test "raise error if params passed but signature omitted" do
     assert_raises(ShopifyAPI::ValidationException) do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com")
+      session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
       session.request_token({'code' => 'any-code'})
     end
   end
@@ -62,19 +67,23 @@ class SessionTest < Test::Unit::TestCase
   test "#temp reset ShopifyAPI::Base.site to original value" do
 
     ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
-    session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com', 'token1')
+    session1 = ShopifyAPI::Session.new('fakeshop.myshopify.com', 'token1', :no_version)
     ShopifyAPI::Base.activate_session(session1)
 
-    ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token") {
+    ShopifyAPI::Session.temp("testshop.myshopify.com", "any-token", :unstable) {
       @assigned_site = ShopifyAPI::Base.site
+      @assigned_version = ShopifyAPI::Base.api_version
     }
-    assert_equal 'https://testshop.myshopify.com', @assigned_site.to_s
-    assert_equal 'https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s
+    assert_equal('https://testshop.myshopify.com', @assigned_site.to_s)
+    assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
+
+    assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)
+    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
   end
 
   test "create_permission_url returns correct url with single scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
     scope = ["write_products"]
     permission_url = session.create_permission_url(scope)
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products", permission_url
@@ -82,7 +91,7 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with single scope and redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
     scope = ["write_products"]
     permission_url = session.create_permission_url(scope, "http://my_redirect_uri.com")
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products&redirect_uri=http://my_redirect_uri.com", permission_url
@@ -90,7 +99,7 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with dual scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
     scope = ["write_products","write_customers"]
     permission_url = session.create_permission_url(scope)
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=write_products,write_customers", permission_url
@@ -98,7 +107,7 @@ class SessionTest < Test::Unit::TestCase
 
   test "create_permission_url returns correct url with no scope no redirect uri" do
     ShopifyAPI::Session.setup(:api_key => "My_test_key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', 'any-token', any_api_version)
     scope = []
     permission_url = session.create_permission_url(scope)
     assert_equal "https://localhost.myshopify.com/admin/oauth/authorize?client_id=My_test_key&scope=", permission_url
@@ -106,7 +115,7 @@ class SessionTest < Test::Unit::TestCase
 
   test "raise exception if code invalid in request token" do
     ShopifyAPI::Session.setup(:api_key => "My test key", :secret => "My test secret")
-    session = ShopifyAPI::Session.new('http://localhost.myshopify.com')
+    session = ShopifyAPI::Session.new('http://localhost.myshopify.com', nil, any_api_version)
     fake nil, :url => 'https://localhost.myshopify.com/admin/oauth/access_token',:method => :post, :status => 404, :body => '{"error" : "invalid_request"}'
     assert_raises(ShopifyAPI::ValidationException) do
       session.request_token(params={:code => "bad-code"})
@@ -115,16 +124,17 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "return site for session" do
-    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token")
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", "any-token", any_api_version)
     assert_equal "https://testshop.myshopify.com", session.site
   end
 
   test "return_token_if_signature_is_valid" do
+    api_version = any_api_version
     fake nil,
-      url: 'https://testshop.myshopify.com/admin/oauth/access_token',
+      url: "https://testshop.myshopify.com/admin/oauth/access_token",
       method: :post,
       body: '{"access_token":"any-token"}'
-    session = ShopifyAPI::Session.new("testshop.myshopify.com")
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, api_version)
 
     params = { code: 'any-code', timestamp: Time.now }
     token = session.request_token(params.merge(hmac: generate_signature(params)))
@@ -134,11 +144,12 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "extra parameters are stored in session" do
+    api_version = ShopifyAPI::ApiVersion::Unstable.new
     fake nil,
-      url: 'https://testshop.myshopify.com/admin/oauth/access_token',
+      url: "https://testshop.myshopify.com/admin/oauth/access_token",
       method: :post,
       body: '{"access_token":"any-token","foo":"example"}'
-    session = ShopifyAPI::Session.new("testshop.myshopify.com")
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, api_version)
 
     params = { code: 'any-code', timestamp: Time.now }
     assert session.request_token(params.merge(hmac: generate_signature(params)))
@@ -147,11 +158,12 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "expires_in is automatically converted in expires_at" do
+    api_version = any_api_version
     fake nil,
-      url: 'https://testshop.myshopify.com/admin/oauth/access_token',
+      url: "https://testshop.myshopify.com/admin/oauth/access_token",
       method: :post,
       body: '{"access_token":"any-token","expires_in":86393}'
-    session = ShopifyAPI::Session.new("testshop.myshopify.com")
+    session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, api_version)
 
     Timecop.freeze do
       params = { code: 'any-code', timestamp: Time.now }
@@ -175,7 +187,7 @@ class SessionTest < Test::Unit::TestCase
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com")
+      session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
       session.request_token(params.merge(:hmac => signature))
     end
   end
@@ -185,7 +197,7 @@ class SessionTest < Test::Unit::TestCase
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do
-      session = ShopifyAPI::Session.new("testshop.myshopify.com")
+      session = ShopifyAPI::Session.new("testshop.myshopify.com", nil, any_api_version)
       session.request_token(params.merge(:hmac => signature))
     end
   end
@@ -223,5 +235,9 @@ class SessionTest < Test::Unit::TestCase
   def generate_signature(params)
     params = make_sorted_params(params) if params.is_a?(Hash)
     OpenSSL::HMAC.hexdigest(OpenSSL::Digest::SHA256.new, ShopifyAPI::Session.secret, params)
+  end
+
+  def any_api_version
+    [ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::ApiVersion::Unstable.new].sample(1).first
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,11 @@ class Test::Unit::TestCase < Minitest::Unit::TestCase
     end
 
     ShopifyAPI::Base.clear_session
-    session = ShopifyAPI::Session.new("https://this-is-my-test-shop.myshopify.com", "token_test_helper", :no_version)
+    session = ShopifyAPI::Session.new(
+      domain: "https://this-is-my-test-shop.myshopify.com",
+      token: "token_test_helper",
+      api_version: :no_version
+    )
 
     ShopifyAPI::Base.activate_session(session)
   end


### PR DESCRIPTION
Version will now be required when creating a session and using the `temp` method. 

At the same time the session methods have bee updated to use keyword arguments.  4 positional arguments is a bit too hard to remember.