### PR TITLE
Add release version and helper methods for switching versions

### DIFF
--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -30,6 +30,10 @@ module ShopifyAPI
       define_version(Unstable.new)
     end
 
+    def self.latest_stable_version
+      @versions.values.select(&:stable?).sort.last
+    end
+
     def to_s
       @version_name
     end
@@ -49,6 +53,10 @@ module ShopifyAPI
 
     def <=>(other)
       numeric_version <=> other.numeric_version
+    end
+
+    def stable?
+      false
     end
 
     def construct_api_path(_path)
@@ -107,6 +115,10 @@ module ShopifyAPI
         @version_name = version_number
         @url = "#{API_PREFIX}#{version_number}/"
         @numeric_version = version_number.tr('-', '').to_i
+      end
+
+      def stable?
+        true
       end
 
       def construct_api_path(path)

--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -25,10 +25,30 @@ module ShopifyAPI
 
       def initialize
         @version_name = "unstable"
+        @url = API_PREFIX
       end
 
       def construct_api_path(path)
-        "#{API_PREFIX}#{path}"
+        "#{@url}#{path}"
+      end
+
+      def construct_graphql_path
+        construct_api_path("graphql.json")
+      end
+    end
+
+    class Release < ApiVersion
+      FORMAT = /^\d{4}-\d{2}$/.freeze
+      API_PREFIX = '/admin/api/'.freeze
+
+      def initialize(version_number)
+        raise InvalidVersion, version_number unless version_number.match(FORMAT)
+        @version_name = version_number
+        @url = "#{API_PREFIX}#{version_number}/"
+      end
+
+      def construct_api_path(path)
+        "#{@url}#{path}"
       end
 
       def construct_graphql_path
@@ -84,5 +104,7 @@ module ShopifyAPI
     def construct_graphql_path
       raise NotImplementedError
     end
+
+    class InvalidVersion < StandardError; end
   end
 end

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -75,6 +75,37 @@ class ApiVersionTest < Test::Unit::TestCase
     ])
   end
 
+  test 'allows a release version with the correct format format to be created' do
+    assert ShopifyAPI::ApiVersion::Release.new('2019-03')
+  end
+
+  test 'release versions must follow the format' do
+    assert_raises ShopifyAPI::ApiVersion::InvalidVersion do
+      assert ShopifyAPI::ApiVersion::Release.new('crazy-name')
+    end
+  end
+
+  test 'release versions create a url that is /admin/api/<version_name>/' do
+    assert_equal(
+      '/admin/api/2022-03/shop.json',
+      ShopifyAPI::ApiVersion::Release.new('2022-03').construct_api_path('shop.json')
+    )
+  end
+
+  test 'two versions with the same version number are equal' do
+    version_1 = ShopifyAPI::ApiVersion::Release.new('2018-09')
+    version_2 = ShopifyAPI::ApiVersion::Release.new('2018-09')
+
+    assert_equal version_2, version_1
+  end
+
+  test 'two versions with the different version numbers are not equal' do
+    version_1 = ShopifyAPI::ApiVersion::Release.new('2019-07')
+    version_2 = ShopifyAPI::ApiVersion::Release.new('2019-11')
+
+    refute_equal version_2, version_1
+  end
+
   class TestApiVersion < ShopifyAPI::ApiVersion
     def initialize(name)
       @version_name = name

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -106,6 +106,31 @@ class ApiVersionTest < Test::Unit::TestCase
     refute_equal version_2, version_1
   end
 
+  test 'release versions are ordered by version number with unstable always being the newest and no version always being the oldest' do
+    version_1 = ShopifyAPI::ApiVersion::Release.new('2017-11')
+    version_2 = ShopifyAPI::ApiVersion::Release.new('2019-11')
+    version_3 = ShopifyAPI::ApiVersion::Release.new('2039-01')
+    version_4 = ShopifyAPI::ApiVersion::Release.new('2039-02')
+    unstable = ShopifyAPI::ApiVersion::Unstable.new
+    no_version = ShopifyAPI::ApiVersion::NoVersion.new
+
+    assert_equal([
+      no_version,
+      version_1,
+      version_2,
+      version_3,
+      version_4,
+      unstable,
+    ], [
+      version_3,
+      version_1,
+      no_version,
+      version_4,
+      unstable,
+      version_2,
+    ].sort)
+  end
+
   class TestApiVersion < ShopifyAPI::ApiVersion
     def initialize(name)
       @version_name = name

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -106,6 +106,15 @@ class ApiVersionTest < Test::Unit::TestCase
     refute_equal version_2, version_1
   end
 
+  test 'release verions are stable' do
+    assert_predicate ShopifyAPI::ApiVersion::Release.new('2019-11'), :stable?
+  end
+
+  test 'no release version are not stable' do
+    refute_predicate ShopifyAPI::ApiVersion::NoVersion.new, :stable?
+    refute_predicate ShopifyAPI::ApiVersion::Unstable.new, :stable?
+  end
+
   test 'release versions are ordered by version number with unstable always being the newest and no version always being the oldest' do
     version_1 = ShopifyAPI::ApiVersion::Release.new('2017-11')
     version_2 = ShopifyAPI::ApiVersion::Release.new('2019-11')
@@ -129,6 +138,21 @@ class ApiVersionTest < Test::Unit::TestCase
       unstable,
       version_2,
     ].sort)
+  end
+
+  test 'latest_stable_version will return the version that is newest and stable' do
+    ShopifyAPI::ApiVersion.clear_defined_versions
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2017-11'))
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2019-11'))
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2039-01'))
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2039-02'))
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Unstable.new)
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::NoVersion.new)
+
+    assert_equal(
+      ShopifyAPI::ApiVersion::Release.new('2039-02'),
+      ShopifyAPI::ApiVersion.latest_stable_version
+    )
   end
 
   class TestApiVersion < ShopifyAPI::ApiVersion

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -290,6 +290,7 @@ class SessionTest < Test::Unit::TestCase
   end
 
   def any_api_version
-    [ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::ApiVersion::Unstable.new].sample(1).first
+    version_name = [:no_version, :unstable].sample(1).first
+    ShopifyAPI::ApiVersion.coerce_to_version(version_name)
   end
 end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -76,8 +76,6 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "#temp reset ShopifyAPI::Base.site to original value" do
-
-    ShopifyAPI::Session.setup(:api_key => "key", :secret => "secret")
     session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
     ShopifyAPI::Base.activate_session(session1)
 
@@ -87,6 +85,62 @@ class SessionTest < Test::Unit::TestCase
     end
 
     assert_equal('https://testshop.myshopify.com', @assigned_site.to_s)
+    assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
+
+    assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)
+    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+  end
+
+  test "#with_session activates the session for the duration of the block" do
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    ShopifyAPI::Base.activate_session(session1)
+
+    other_session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: :unstable
+    )
+
+    ShopifyAPI::Session.with_session(other_session) do
+      @assigned_site = ShopifyAPI::Base.site
+      @assigned_version = ShopifyAPI::Base.api_version
+    end
+
+    assert_equal('https://testshop.myshopify.com', @assigned_site.to_s)
+    assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
+
+    assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)
+    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+  end
+
+  test "#with_session resets the activated session even if there an exception during the block" do
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    ShopifyAPI::Base.activate_session(session1)
+
+    other_session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: :unstable
+    )
+
+    assert_raises StandardError do
+      ShopifyAPI::Session.with_session(other_session) { raise StandardError, "" }
+    end
+
+    assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
+    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+  end
+
+  test "#with_version will adjust the actvated api version for the duration of the block" do
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    ShopifyAPI::Base.activate_session(session1)
+
+    ShopifyAPI::Session.with_version(:unstable) do
+      @assigned_site = ShopifyAPI::Base.site
+      @assigned_version = ShopifyAPI::Base.api_version
+    end
+
+    assert_equal('https://fakeshop.myshopify.com', @assigned_site.to_s)
     assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
 
     assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)


### PR DESCRIPTION
## What has been added
Release version type. 

Versions are marked as stable or not stable, Release versions are the only stable versions.

Versions can now be ordered, this allows us to pull the `latest_stable_version` for use in the shopify_app gem config generation.

Helper method for cleanly changing versions.
```
ShopifyAPI::Session.temp(domain: 'shop1.myshopify.com', token: token, api_version: :unstable) do
  Shop.current # calls https://shop1.myshopify.com/admin/api/unstable/shop.json
  ShopifyAPI::Session.with_version(:no_version) do     
    Shop.current # calls https://shop1.myshopify.com/admin/shop.json
  end
end
```