### PR TITLE
Drop no version.

### DIFF
--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -26,7 +26,6 @@ module ShopifyAPI
     end
 
     def self.define_known_versions
-      define_version(NoVersion.new)
       define_version(Unstable.new)
     end
 
@@ -70,23 +69,6 @@ module ShopifyAPI
     protected
 
     attr_reader :numeric_version
-
-    class NoVersion < ApiVersion
-      API_PREFIX = '/admin/'
-
-      def initialize
-        @version_name = "no_version"
-        @numeric_version = 0
-      end
-
-      def construct_api_path(path)
-        "#{API_PREFIX}#{path}"
-      end
-
-      def construct_graphql_path
-        '/admin/api/graphql.json'
-      end
-    end
 
     class Unstable < ApiVersion
       API_PREFIX = '/admin/api/unstable/'

--- a/lib/shopify_api/resources/inventory_level.rb
+++ b/lib/shopify_api/resources/inventory_level.rb
@@ -4,11 +4,11 @@ module ShopifyAPI
   class InventoryLevel < Base
 
     # The default path structure in ActiveResource for delete would result in:
-    # /admin/inventory_levels/#{ inventory_level.id }.json?#{ params }, but since
+    # /admin/api/<version>/inventory_levels/#{ inventory_level.id }.json?#{ params }, but since
     # InventroyLevels are a second class resource made up of a Where and a What
     # (Location and InventoryItem), it does not have a resource ID. Here we
     # redefine element_path to remove the id so HTTP DELETE requests go to
-    # /admin/inventory_levels.json?#{ params } instead.
+    # /admin/api/<version>/inventory_levels.json?#{ params } instead.
     #
     def self.element_path(prefix_options = {}, query_options = nil)
       prefix_options, query_options = split_options(prefix_options) if query_options.nil?

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -8,20 +8,6 @@ class ApiVersionTest < Test::Unit::TestCase
     ShopifyAPI::ApiVersion.define_known_versions
   end
 
-  test "no version creates url that start with /admin/" do
-    assert_equal(
-      "/admin/resource_path/id.json",
-      ShopifyAPI::ApiVersion::NoVersion.new.construct_api_path("resource_path/id.json")
-    )
-  end
-
-  test "no version creates graphql url that start with /admin/api" do
-    assert_equal(
-      "/admin/api/graphql.json",
-      ShopifyAPI::ApiVersion::NoVersion.new.construct_graphql_path
-    )
-  end
-
   test "unstable version creates url that start with /admin/api/unstable/" do
     assert_equal(
       "/admin/api/unstable/resource_path/id.json",
@@ -44,12 +30,12 @@ class ApiVersionTest < Test::Unit::TestCase
   test "coerce_to_version converts a known version into a version object" do
     versions = [
       ShopifyAPI::ApiVersion::Unstable.new,
-      ShopifyAPI::ApiVersion::NoVersion.new,
+      ShopifyAPI::ApiVersion::Release.new('2019-01'),
     ]
 
     assert_equal(versions, [
       ShopifyAPI::ApiVersion.coerce_to_version('unstable'),
-      ShopifyAPI::ApiVersion.coerce_to_version(:no_version),
+      ShopifyAPI::ApiVersion.coerce_to_version('2019-01'),
     ])
   end
 
@@ -111,20 +97,17 @@ class ApiVersionTest < Test::Unit::TestCase
   end
 
   test 'no release version are not stable' do
-    refute_predicate ShopifyAPI::ApiVersion::NoVersion.new, :stable?
     refute_predicate ShopifyAPI::ApiVersion::Unstable.new, :stable?
   end
 
-  test 'release versions are ordered by version number with unstable always being the newest and no version always being the oldest' do
+  test 'release versions are ordered by version number with unstable always being the newest' do
     version_1 = ShopifyAPI::ApiVersion::Release.new('2017-11')
     version_2 = ShopifyAPI::ApiVersion::Release.new('2019-11')
     version_3 = ShopifyAPI::ApiVersion::Release.new('2039-01')
     version_4 = ShopifyAPI::ApiVersion::Release.new('2039-02')
     unstable = ShopifyAPI::ApiVersion::Unstable.new
-    no_version = ShopifyAPI::ApiVersion::NoVersion.new
 
     assert_equal([
-      no_version,
       version_1,
       version_2,
       version_3,
@@ -133,7 +116,6 @@ class ApiVersionTest < Test::Unit::TestCase
     ], [
       version_3,
       version_1,
-      no_version,
       version_4,
       unstable,
       version_2,
@@ -147,7 +129,6 @@ class ApiVersionTest < Test::Unit::TestCase
     ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2039-01'))
     ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2039-02'))
     ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Unstable.new)
-    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::NoVersion.new)
 
     assert_equal(
       ShopifyAPI::ApiVersion::Release.new('2039-02'),

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -14,11 +14,13 @@ class LogSubscriberTest < Test::Unit::TestCase
     @request_headers = "Headers: {\"Accept\"=>\"application/json\", " \
       "#{@ua_header}, \"X-Shopify-Access-Token\"=>\"access_token\"}"
 
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2019-01'))
+
     ShopifyAPI::Base.clear_session
     session = ShopifyAPI::Session.new(
       domain: "https://this-is-my-test-shop.myshopify.com",
       token: "access_token",
-      api_version: :no_version
+      api_version: '2019-01'
     )
 
     ShopifyAPI::Base.activate_session(session)
@@ -37,7 +39,10 @@ class LogSubscriberTest < Test::Unit::TestCase
     ShopifyAPI::Page.find(1)
 
     assert_equal(4, @logger.logged(:info).size)
-    assert_equal("GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/1.json", @logger.logged(:info)[0])
+    assert_equal(
+      "GET https://this-is-my-test-shop.myshopify.com:443/admin/api/2019-01/pages/1.json",
+      @logger.logged(:info)[0]
+    )
     assert_match(/\-\-\> 200/, @logger.logged(:info)[1])
     assert_equal(request_headers, @logger.logged(:info)[2])
     assert_match(
@@ -56,13 +61,19 @@ class LogSubscriberTest < Test::Unit::TestCase
 
     if ar_version_before?('5.1.0')
       assert_equal(4, @logger.logged(:info).size)
-      assert_equal("GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:info)[0])
+      assert_equal(
+        "GET https://this-is-my-test-shop.myshopify.com:443/admin/api/2019-01/pages/2.json",
+        @logger.logged(:info)[0]
+      )
       assert_match(/\-\-\> 404/, @logger.logged(:info)[1])
       assert_equal(request_headers, @logger.logged(:info)[2])
       assert_equal("Response:", @logger.logged(:info)[3])
     else
       assert_equal(2, @logger.logged(:error).size)
-      assert_equal("GET https://this-is-my-test-shop.myshopify.com:443/admin/pages/2.json", @logger.logged(:error)[0])
+      assert_equal(
+        "GET https://this-is-my-test-shop.myshopify.com:443/admin/api/2019-01/pages/2.json",
+        @logger.logged(:error)[0]
+      )
       assert_match(/\-\-\> 404/, @logger.logged(:error)[1])
 
       assert_equal(2, @logger.logged(:info).size)
@@ -83,7 +94,10 @@ class LogSubscriberTest < Test::Unit::TestCase
 
     assert_equal 1, @logger.logged(:warn).size
 
-    assert_match(%r{\[DEPRECATED\] ShopifyAPI made a call to GET \/admin\/pages\/1.json}, @logger.logged(:warn).first)
+    assert_match(
+      %r{\[DEPRECATED\] ShopifyAPI made a call to GET /admin/api/2019-01/pages/1.json},
+      @logger.logged(:warn).first
+    )
     assert_match(
       %r{See https:\/\/help.shopify.com\/en\/api\/getting-started\/api-deprecations for more details.},
       @logger.logged(:warn).first

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -76,7 +76,7 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "#temp reset ShopifyAPI::Base.site to original value" do
-    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: '2019-01')
     ShopifyAPI::Base.activate_session(session1)
 
     ShopifyAPI::Session.temp(domain: "testshop.myshopify.com", token: "any-token", api_version: :unstable) do
@@ -88,11 +88,11 @@ class SessionTest < Test::Unit::TestCase
     assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
 
     assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)
-    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+    assert_equal(ShopifyAPI::ApiVersion::Release.new('2019-01'), ShopifyAPI::Base.api_version)
   end
 
   test "#with_session activates the session for the duration of the block" do
-    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: '2019-01')
     ShopifyAPI::Base.activate_session(session1)
 
     other_session = ShopifyAPI::Session.new(
@@ -110,11 +110,11 @@ class SessionTest < Test::Unit::TestCase
     assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
 
     assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)
-    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+    assert_equal(ShopifyAPI::ApiVersion::Release.new('2019-01'), ShopifyAPI::Base.api_version)
   end
 
   test "#with_session resets the activated session even if there an exception during the block" do
-    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: '2019-01')
     ShopifyAPI::Base.activate_session(session1)
 
     other_session = ShopifyAPI::Session.new(
@@ -128,11 +128,11 @@ class SessionTest < Test::Unit::TestCase
     end
 
     assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
-    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+    assert_equal(ShopifyAPI::ApiVersion::Release.new('2019-01'), ShopifyAPI::Base.api_version)
   end
 
   test "#with_version will adjust the actvated api version for the duration of the block" do
-    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: :no_version)
+    session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: '2019-01')
     ShopifyAPI::Base.activate_session(session1)
 
     ShopifyAPI::Session.with_version(:unstable) do
@@ -144,7 +144,7 @@ class SessionTest < Test::Unit::TestCase
     assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
 
     assert_equal(ShopifyAPI::ApiVersion::Unstable.new, @assigned_version)
-    assert_equal(ShopifyAPI::ApiVersion::NoVersion.new, ShopifyAPI::Base.api_version)
+    assert_equal(ShopifyAPI::ApiVersion::Release.new('2019-01'), ShopifyAPI::Base.api_version)
   end
 
   test "create_permission_url returns correct url with single scope no redirect uri" do
@@ -344,7 +344,7 @@ class SessionTest < Test::Unit::TestCase
   end
 
   def any_api_version
-    version_name = [:no_version, :unstable].sample(1).first
+    version_name = ['2019-01', :unstable].sample(1).first
     ShopifyAPI::ApiVersion.coerce_to_version(version_name)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,11 +41,13 @@ class Test::Unit::TestCase < Minitest::Unit::TestCase
       end
     end
 
+    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2019-01'))
+
     ShopifyAPI::Base.clear_session
     session = ShopifyAPI::Session.new(
       domain: "https://this-is-my-test-shop.myshopify.com",
       token: "token_test_helper",
-      api_version: :no_version
+      api_version: '2019-01',
     )
 
     ShopifyAPI::Base.activate_session(session)
@@ -58,6 +60,9 @@ class Test::Unit::TestCase < Minitest::Unit::TestCase
     ShopifyAPI::Base.site = nil
     ShopifyAPI::Base.password = nil
     ShopifyAPI::Base.user = nil
+
+    ShopifyAPI::ApiVersion.clear_defined_versions
+    ShopifyAPI::ApiVersion.define_known_versions
   end
 
   # Custom Assertions
@@ -89,7 +94,7 @@ class Test::Unit::TestCase < Minitest::Unit::TestCase
     body   = options.has_key?(:body) ? options.delete(:body) : load_fixture(endpoint)
     format = options.delete(:format) || :json
     method = options.delete(:method) || :get
-    api_version = options.delete(:api_version) || ShopifyAPI::ApiVersion.coerce_to_version(:no_version)
+    api_version = options.delete(:api_version) || ShopifyAPI::ApiVersion.coerce_to_version('2019-01')
     extension = ".#{options.delete(:extension)||'json'}" unless options[:extension]==false
 
     url = if options.has_key?(:url)


### PR DESCRIPTION
Remove the NoVersion.  The NoVersion was an intermediate step and is no longer need to be supported.


