### PR TITLE
fix set base api version

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -76,8 +76,8 @@ module ShopifyAPI
         end
       end
 
-      def api_version=(value)
-        self._api_version = value
+      def api_version=(version)
+        self._api_version = version.nil? ? nil : ApiVersion.coerce_to_version(version)
       end
 
       def prefix(options = {})

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -157,6 +157,11 @@ class BaseTest < Test::Unit::TestCase
     assert_equal 2, ShopifyAPI::Shop.current.id
   end
 
+  test "#api_version should set ApiVersion" do
+    ShopifyAPI::Base.api_version = '2019-04'
+    assert_equal '2019-04', ShopifyAPI::Base.api_version.to_s
+  end
+
   def clear_header(header)
     [ActiveResource::Base, ShopifyAPI::Base, ShopifyAPI::Product].each do |klass|
       klass.headers.delete(header)


### PR DESCRIPTION
# Issue
https://github.com/Shopify/shopify_api#getting-started
When I set like below, the error occurred.
`ShopifyAPI::Base.api_version = '2019-04'`
```
/shopify_api-7.0.0/lib/shopify_api/resources/base.rb:84:in `prefix': undefined method `construct_api_path' for "2019-04":String (NoMethodError)
```

# How
To Create ApiVersion like Session do.
