### PR TITLE
Update required Ruby version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ For more information and detailed documentation about the API visit https://deve
 
 #### Ruby version
 
-This gem requires Ruby 2.3.1 as of version 4.3. If you need to use an older Ruby version then update your `Gemfile` to lock onto an older release than 4.3.
+This gem requires Ruby 2.4 as of version 7.0.
 
 ### Installation
 


### PR DESCRIPTION
Replacement PR for #378. Updates required Ruby version to match [the gemspec](https://github.com/Shopify/shopify_api/blob/master/shopify_api.gemspec#L26).