### PR TITLE
Assume threadsafe headers.

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -30,26 +30,13 @@ module ShopifyAPI
 
     class << self
       threadsafe_attribute(:_api_version)
-
-      if ActiveResource::Base.respond_to?(:_headers) && ActiveResource::Base.respond_to?(:_headers_defined?)
-        def headers
-          if _headers_defined?
-            _headers
-          elsif superclass != Object && superclass.headers
-            superclass.headers
-          else
-            _headers ||= {}
-          end
-        end
-      else
-        def headers
-          if defined?(@headers)
-            @headers
-          elsif superclass != Object && superclass.headers
-            superclass.headers
-          else
-            @headers ||= {}
-          end
+      def headers
+        if _headers_defined?
+          _headers
+        elsif superclass != Object && superclass.headers
+          superclass.headers
+        else
+          _headers ||= {}
         end
       end
 


### PR DESCRIPTION
Since we only support ActiveResource 4.1 and above, we no longer need to check if the `headers` threadsafe attribute exists.

The threadsafe and non-threadsafe version checks were added in https://github.com/Shopify/shopify_api/pull/95, before we could rely on the threadsafe attributes existing.
