### PR TITLE
Adds a 2019-10 prerelease API version

### DIFF
--- a/README.md
+++ b/README.md
@@ -393,7 +393,7 @@ while products.next_page?
 end
 ```
 
-Relative cursor pagination is currently available for all endpoints using the `unstable` API version.
+Relative cursor pagination is currently available for all endpoints using the `2019-10` and later API versions.
 
 ## Using Development Version
 

--- a/lib/shopify_api/defined_versions.rb
+++ b/lib/shopify_api/defined_versions.rb
@@ -5,6 +5,7 @@ module ShopifyAPI
       define_version(ShopifyAPI::ApiVersion::Unstable.new)
       define_version(ShopifyAPI::ApiVersion::Release.new('2019-04'))
       define_version(ShopifyAPI::ApiVersion::Release.new('2019-07'))
+      define_version(ShopifyAPI::ApiVersion::Release.new('2019-10'))
     end
   end
 end


### PR DESCRIPTION
Adds a 2019-10 API version, which will contain, among other items, full relative cursor pagination from https://github.com/Shopify/shopify_api/pull/594.