### PR TITLE
Techdebt

### DIFF
--- a/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
+++ b/.rubocop-https---shopify-github-io-ruby-style-guide-rubocop-yml
@@ -1,0 +1,1027 @@
+AllCops:
+  Exclude:
+  - 'db/schema.rb'
+  DisabledByDefault: true
+  StyleGuideBaseURL: https://shopify.github.io/ruby-style-guide/
+
+Lint/AssignmentInCondition:
+  Enabled: true
+
+Layout/AccessModifierIndentation:
+  EnforcedStyle: indent
+  SupportedStyles:
+  - outdent
+  - indent
+  IndentationWidth:
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+  SupportedStyles:
+  - prefer_alias
+  - prefer_alias_method
+
+Layout/AlignHash:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+  EnforcedLastArgumentHashStyle: ignore_implicit
+  SupportedLastArgumentHashStyles:
+  - always_inspect
+  - always_ignore
+  - ignore_implicit
+  - ignore_explicit
+
+Layout/AlignParameters:
+  EnforcedStyle: with_fixed_indentation
+  SupportedStyles:
+  - with_first_parameter
+  - with_fixed_indentation
+  IndentationWidth:
+
+Style/AndOr:
+  EnforcedStyle: always
+  SupportedStyles:
+  - always
+  - conditionals
+
+Style/BarePercentLiterals:
+  EnforcedStyle: bare_percent
+  SupportedStyles:
+  - percent_q
+  - bare_percent
+
+Style/BlockDelimiters:
+  EnforcedStyle: line_count_based
+  SupportedStyles:
+  - line_count_based
+  - semantic
+  - braces_for_chaining
+  ProceduralMethods:
+  - benchmark
+  - bm
+  - bmbm
+  - create
+  - each_with_object
+  - measure
+  - new
+  - realtime
+  - tap
+  - with_object
+  FunctionalMethods:
+  - let
+  - let!
+  - subject
+  - watch
+  IgnoredMethods:
+  - lambda
+  - proc
+  - it
+
+Style/BracesAroundHashParameters:
+  EnforcedStyle: no_braces
+  SupportedStyles:
+  - braces
+  - no_braces
+  - context_dependent
+
+Layout/CaseIndentation:
+  EnforcedStyle: end
+  SupportedStyles:
+  - case
+  - end
+  IndentOneStep: false
+  IndentationWidth:
+
+Style/ClassAndModuleChildren:
+  EnforcedStyle: nested
+  SupportedStyles:
+  - nested
+  - compact
+
+Style/ClassCheck:
+  EnforcedStyle: is_a?
+  SupportedStyles:
+  - is_a?
+  - kind_of?
+
+Style/CommandLiteral:
+  EnforcedStyle: percent_x
+  SupportedStyles:
+  - backticks
+  - percent_x
+  - mixed
+  AllowInnerBackticks: false
+
+Style/CommentAnnotation:
+  Keywords:
+  - TODO
+  - FIXME
+  - OPTIMIZE
+  - HACK
+  - REVIEW
+
+Style/ConditionalAssignment:
+  EnforcedStyle: assign_to_condition
+  SupportedStyles:
+  - assign_to_condition
+  - assign_inside_condition
+  SingleLineConditionsOnly: true
+
+Layout/DotPosition:
+  EnforcedStyle: leading
+  SupportedStyles:
+  - leading
+  - trailing
+
+Style/EmptyElse:
+  EnforcedStyle: both
+  SupportedStyles:
+  - empty
+  - nil
+  - both
+
+Layout/EmptyLineBetweenDefs:
+  AllowAdjacentOneLineDefs: false
+
+Layout/EmptyLinesAroundBlockBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - no_empty_lines
+
+Layout/EmptyLinesAroundClassBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - no_empty_lines
+
+Layout/EmptyLinesAroundModuleBody:
+  EnforcedStyle: no_empty_lines
+  SupportedStyles:
+  - empty_lines
+  - empty_lines_except_namespace
+  - no_empty_lines
+
+Layout/ExtraSpacing:
+  AllowForAlignment: true
+  ForceEqualSignAlignment: false
+
+Naming/FileName:
+  Exclude: []
+  ExpectMatchingDefinition: false
+  Regex:
+  IgnoreExecutableScripts: true
+
+Layout/IndentFirstArgument:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - consistent
+  - special_for_inner_method_call
+  - special_for_inner_method_call_in_parentheses
+  IndentationWidth:
+
+Style/For:
+  EnforcedStyle: each
+  SupportedStyles:
+  - for
+  - each
+
+Style/FormatString:
+  EnforcedStyle: format
+  SupportedStyles:
+  - format
+  - sprintf
+  - percent
+
+Style/FrozenStringLiteralComment:
+  Details: >-
+    Add `# frozen_string_literal: true` to the top of the file. Frozen string
+    literals will become the default in a future Ruby version, and we want to
+    make sure we're ready.
+  EnforcedStyle: always
+  SupportedStyles:
+    - always
+    - never
+
+Style/GlobalVars:
+  AllowedVariables: []
+
+Style/HashSyntax:
+  EnforcedStyle: ruby19
+  SupportedStyles:
+  - ruby19
+  - hash_rockets
+  - no_mixed_keys
+  - ruby19_no_mixed_keys
+  UseHashRocketsWithSymbolValues: false
+  PreferHashRocketsForNonAlnumEndingSymbols: false
+
+Layout/IndentationConsistency:
+  EnforcedStyle: normal
+  SupportedStyles:
+  - normal
+  - rails
+
+Layout/IndentationWidth:
+  Width: 2
+
+Layout/IndentFirstArrayElement:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_brackets
+  IndentationWidth:
+
+Layout/IndentAssignment:
+  IndentationWidth:
+
+Layout/IndentFirstHashElement:
+  EnforcedStyle: consistent
+  SupportedStyles:
+  - special_inside_parentheses
+  - consistent
+  - align_braces
+  IndentationWidth:
+
+Style/LambdaCall:
+  EnforcedStyle: call
+  SupportedStyles:
+  - call
+  - braces
+
+Style/Next:
+  EnforcedStyle: skip_modifier_ifs
+  MinBodyLength: 3
+  SupportedStyles:
+  - skip_modifier_ifs
+  - always
+
+Style/NonNilCheck:
+  IncludeSemanticChanges: false
+
+Style/MethodCallWithArgsParentheses:
+  Enabled: true
+  IgnoreMacros: true
+  IgnoredMethods:
+  - require
+  - require_relative
+  - require_dependency
+  - yield
+  - raise
+  - puts
+  Exclude:
+  - Gemfile
+
+Style/MethodDefParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  - require_no_parentheses_except_multiline
+
+Naming/MethodName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Layout/MultilineArrayBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineHashBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineMethodCallBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+  SupportedStyles:
+  - aligned
+  - indented
+  - indented_relative_to_receiver
+  IndentationWidth: 2
+
+Layout/MultilineMethodDefinitionBraceLayout:
+  EnforcedStyle: symmetrical
+  SupportedStyles:
+  - symmetrical
+  - new_line
+  - same_line
+
+Style/NumericLiteralPrefix:
+  EnforcedOctalStyle: zero_only
+  SupportedOctalStyles:
+  - zero_with_o
+  - zero_only
+
+Style/ParenthesesAroundCondition:
+  AllowSafeAssignment: true
+
+Style/PercentQLiterals:
+  EnforcedStyle: lower_case_q
+  SupportedStyles:
+  - lower_case_q
+  - upper_case_q
+
+Naming/PredicateName:
+  NamePrefix:
+  - is_
+  NamePrefixBlacklist:
+  - is_
+  NameWhitelist:
+  - is_a?
+  Exclude:
+  - 'spec/**/*'
+
+Style/PreferredHashMethods:
+  EnforcedStyle: short
+  SupportedStyles:
+  - short
+  - verbose
+
+Style/RaiseArgs:
+  EnforcedStyle: exploded
+  SupportedStyles:
+  - compact
+  - exploded
+
+Style/RedundantReturn:
+  AllowMultipleReturnValues: false
+
+Style/RegexpLiteral:
+  EnforcedStyle: mixed
+  SupportedStyles:
+  - slashes
+  - percent_r
+  - mixed
+  AllowInnerSlashes: false
+
+Style/SafeNavigation:
+  ConvertCodeThatCanStartToReturnNil: false
+  Enabled: true
+
+Lint/SafeNavigationChain:
+  Enabled: true
+
+Style/Semicolon:
+  AllowAsExpressionSeparator: false
+
+Style/SignalException:
+  EnforcedStyle: only_raise
+  SupportedStyles:
+  - only_raise
+  - only_fail
+  - semantic
+
+Style/SingleLineMethods:
+  AllowIfMethodIsEmpty: true
+
+Layout/SpaceBeforeFirstArg:
+  AllowForAlignment: true
+
+Style/SpecialGlobalVars:
+  EnforcedStyle: use_english_names
+  SupportedStyles:
+  - use_perl_names
+  - use_english_names
+
+Style/StabbyLambdaParentheses:
+  EnforcedStyle: require_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+
+Style/StringLiteralsInInterpolation:
+  EnforcedStyle: single_quotes
+  SupportedStyles:
+  - single_quotes
+  - double_quotes
+
+Layout/SpaceAroundBlockParameters:
+  EnforcedStyleInsidePipes: no_space
+  SupportedStylesInsidePipes:
+  - space
+  - no_space
+
+Layout/SpaceAroundEqualsInParameterDefault:
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+
+Layout/SpaceAroundOperators:
+  AllowForAlignment: true
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: space
+  SupportedStyles:
+  - space
+  - no_space
+
+Layout/SpaceInsideBlockBraces:
+  EnforcedStyle: space
+  SupportedStyles:
+  - space
+  - no_space
+  EnforcedStyleForEmptyBraces: no_space
+  SpaceBeforeBlockParameters: true
+
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: no_space
+  SupportedStyles:
+  - space
+  - no_space
+  - compact
+
+Layout/SpaceInsideStringInterpolation:
+  EnforcedStyle: no_space
+  SupportedStyles:
+  - space
+  - no_space
+
+Style/SymbolProc:
+  IgnoredMethods:
+  - respond_to
+  - define_method
+
+Style/TernaryParentheses:
+  EnforcedStyle: require_no_parentheses
+  SupportedStyles:
+  - require_parentheses
+  - require_no_parentheses
+  AllowSafeAssignment: true
+
+Layout/TrailingBlankLines:
+  EnforcedStyle: final_newline
+  SupportedStyles:
+  - final_newline
+  - final_blank_line
+
+Style/TrivialAccessors:
+  ExactNameMatch: true
+  AllowPredicates: true
+  AllowDSLWriters: false
+  IgnoreClassMethods: false
+  Whitelist:
+  - to_ary
+  - to_a
+  - to_c
+  - to_enum
+  - to_h
+  - to_hash
+  - to_i
+  - to_int
+  - to_io
+  - to_open
+  - to_path
+  - to_proc
+  - to_r
+  - to_regexp
+  - to_str
+  - to_s
+  - to_sym
+
+Naming/VariableName:
+  EnforcedStyle: snake_case
+  SupportedStyles:
+  - snake_case
+  - camelCase
+
+Style/WhileUntilModifier:
+  Enabled: true
+
+Metrics/BlockNesting:
+  Max: 3
+
+Metrics/LineLength:
+  Max: 120
+  AllowHeredoc: true
+  AllowURI: true
+  URISchemes:
+  - http
+  - https
+  IgnoreCopDirectives: false
+  IgnoredPatterns:
+  - '\A\s*(remote_)?test(_\w+)?\s.*(do|->)(\s|\Z)'
+
+Metrics/ParameterLists:
+  Max: 5
+  CountKeywordArgs: false
+
+Layout/BlockAlignment:
+  EnforcedStyleAlignWith: either
+  SupportedStylesAlignWith:
+  - either
+  - start_of_block
+  - start_of_line
+
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+  SupportedStylesAlignWith:
+  - keyword
+  - variable
+  - start_of_line
+
+Layout/DefEndAlignment:
+  EnforcedStyleAlignWith: start_of_line
+  SupportedStylesAlignWith:
+  - start_of_line
+  - def
+
+Lint/InheritException:
+  EnforcedStyle: runtime_error
+  SupportedStyles:
+  - runtime_error
+  - standard_error
+
+Lint/UnusedBlockArgument:
+  IgnoreEmptyBlocks: true
+  AllowUnusedKeywordArguments: false
+
+Lint/UnusedMethodArgument:
+  AllowUnusedKeywordArguments: false
+  IgnoreEmptyMethods: true
+
+Naming/AccessorMethodName:
+  Enabled: true
+
+Layout/AlignArray:
+  Enabled: true
+
+Style/ArrayJoin:
+  Enabled: true
+
+Naming/AsciiIdentifiers:
+  Enabled: true
+
+Style/Attr:
+  Enabled: true
+
+Style/BeginBlock:
+  Enabled: true
+
+Style/BlockComments:
+  Enabled: true
+
+Layout/BlockEndNewline:
+  Enabled: true
+
+Style/CaseEquality:
+  Enabled: true
+
+Style/CharacterLiteral:
+  Enabled: true
+
+Naming/ClassAndModuleCamelCase:
+  Enabled: true
+
+Style/ClassMethods:
+  Enabled: true
+
+Style/ClassVars:
+  Enabled: true
+
+Layout/ClosingParenthesisIndentation:
+  Enabled: true
+
+Style/ColonMethodCall:
+  Enabled: true
+
+Layout/CommentIndentation:
+  Enabled: true
+
+Naming/ConstantName:
+  Enabled: true
+
+Style/DateTime:
+  Enabled: true
+
+Style/DefWithParentheses:
+  Enabled: true
+
+Style/EachForSimpleLoop:
+  Enabled: true
+
+Style/EachWithObject:
+  Enabled: true
+
+Layout/ElseAlignment:
+  Enabled: true
+
+Style/EmptyCaseCondition:
+  Enabled: true
+
+Layout/EmptyLines:
+  Enabled: true
+
+Layout/EmptyLinesAroundAccessModifier:
+  Enabled: true
+
+Layout/EmptyLinesAroundMethodBody:
+  Enabled: true
+
+Style/EmptyLiteral:
+  Enabled: true
+
+Style/EndBlock:
+  Enabled: true
+
+Layout/EndOfLine:
+  Enabled: true
+
+Style/EvenOdd:
+  Enabled: true
+
+Layout/InitialIndentation:
+  Enabled: true
+
+Lint/FlipFlop:
+  Enabled: true
+
+Style/IfInsideElse:
+  Enabled: true
+
+Style/IfUnlessModifierOfIfUnless:
+  Enabled: true
+
+Style/IfWithSemicolon:
+  Enabled: true
+
+Style/IdenticalConditionalBranches:
+  Enabled: true
+
+Style/InfiniteLoop:
+  Enabled: true
+
+Layout/LeadingCommentSpace:
+  Enabled: true
+
+Style/LineEndConcatenation:
+  Enabled: true
+
+Style/MethodCallWithoutArgsParentheses:
+  Enabled: true
+
+Style/MethodMissingSuper:
+  Enabled: true
+
+Style/MissingRespondToMissing:
+  Enabled: true
+
+Layout/MultilineBlockLayout:
+  Enabled: true
+
+Style/MultilineIfThen:
+  Enabled: true
+
+Style/MultilineMemoization:
+  Enabled: true
+
+Style/MultilineTernaryOperator:
+  Enabled: true
+
+Style/NegatedIf:
+  Enabled: true
+
+Style/NegatedWhile:
+  Enabled: true
+
+Style/NestedModifier:
+  Enabled: true
+
+Style/NestedParenthesizedCalls:
+  Enabled: true
+
+Style/NestedTernaryOperator:
+  Enabled: true
+
+Style/NilComparison:
+  Enabled: true
+
+Style/Not:
+  Enabled: true
+
+Style/OneLineConditional:
+  Enabled: true
+
+Naming/BinaryOperatorParameterName:
+  Enabled: true
+
+Style/OptionalArguments:
+  Enabled: true
+
+Style/ParallelAssignment:
+  Enabled: true
+
+Style/PerlBackrefs:
+  Enabled: true
+
+Style/Proc:
+  Enabled: true
+
+Style/RedundantBegin:
+  Enabled: true
+
+Style/RedundantException:
+  Enabled: true
+
+Style/RedundantFreeze:
+  Enabled: true
+
+Style/RedundantParentheses:
+  Enabled: true
+
+Style/RedundantSelf:
+  Enabled: true
+
+Style/RedundantSortBy:
+  Enabled: true
+
+Layout/RescueEnsureAlignment:
+  Enabled: true
+
+Style/RescueModifier:
+  Enabled: true
+
+Style/Sample:
+  Enabled: true
+
+Style/SelfAssignment:
+  Enabled: true
+
+Layout/SpaceAfterColon:
+  Enabled: true
+
+Layout/SpaceAfterComma:
+  Enabled: true
+
+Layout/SpaceAfterMethodName:
+  Enabled: true
+
+Layout/SpaceAfterNot:
+  Enabled: true
+
+Layout/SpaceAfterSemicolon:
+  Enabled: true
+
+Layout/SpaceBeforeComma:
+  Enabled: true
+
+Layout/SpaceBeforeComment:
+  Enabled: true
+
+Layout/SpaceBeforeSemicolon:
+  Enabled: true
+
+Layout/SpaceAroundKeyword:
+  Enabled: true
+
+Layout/SpaceInsideArrayPercentLiteral:
+  Enabled: true
+
+Layout/SpaceInsidePercentLiteralDelimiters:
+  Enabled: true
+
+Layout/SpaceInsideArrayLiteralBrackets:
+  Enabled: true
+
+Layout/SpaceInsideParens:
+  Enabled: true
+
+Layout/SpaceInsideRangeLiteral:
+  Enabled: true
+
+Style/SymbolLiteral:
+  Enabled: true
+
+Layout/Tab:
+  Enabled: true
+
+Layout/TrailingWhitespace:
+  Enabled: true
+
+Style/UnlessElse:
+  Enabled: true
+
+Style/UnneededCapitalW:
+  Enabled: true
+
+Style/UnneededInterpolation:
+  Enabled: true
+
+Style/UnneededPercentQ:
+  Enabled: true
+
+Style/VariableInterpolation:
+  Enabled: true
+
+Style/WhenThen:
+  Enabled: true
+
+Style/WhileUntilDo:
+  Enabled: true
+
+Style/ZeroLengthPredicate:
+  Enabled: true
+
+Layout/IndentHeredoc:
+  EnforcedStyle: squiggly
+
+Lint/AmbiguousOperator:
+  Enabled: true
+
+Lint/AmbiguousRegexpLiteral:
+  Enabled: true
+
+Lint/CircularArgumentReference:
+  Enabled: true
+
+Layout/ConditionPosition:
+  Enabled: true
+
+Lint/Debugger:
+  Enabled: true
+
+Lint/DeprecatedClassMethods:
+  Enabled: true
+
+Lint/DuplicateMethods:
+  Enabled: true
+
+Lint/DuplicatedKey:
+  Enabled: true
+
+Lint/EachWithObjectArgument:
+  Enabled: true
+
+Lint/ElseLayout:
+  Enabled: true
+
+Lint/EmptyEnsure:
+  Enabled: true
+
+Lint/EmptyInterpolation:
+  Enabled: true
+
+Lint/EndInMethod:
+  Enabled: true
+
+Lint/EnsureReturn:
+  Enabled: true
+
+Lint/FloatOutOfRange:
+  Enabled: true
+
+Lint/FormatParameterMismatch:
+  Enabled: true
+
+Lint/HandleExceptions:
+  Enabled: true
+
+Lint/ImplicitStringConcatenation:
+  Description: Checks for adjacent string literals on the same line, which could
+    better be represented as a single string literal.
+
+Lint/IneffectiveAccessModifier:
+  Description: Checks for attempts to use `private` or `protected` to set the visibility
+    of a class method, which does not work.
+
+Lint/LiteralAsCondition:
+  Enabled: true
+
+Lint/LiteralInInterpolation:
+  Enabled: true
+
+Lint/Loop:
+  Description: Use Kernel#loop with break rather than begin/end/until or begin/end/while
+    for post-loop tests.
+
+Lint/NestedMethodDefinition:
+  Enabled: true
+
+Lint/NextWithoutAccumulator:
+  Description: Do not omit the accumulator when calling `next` in a `reduce`/`inject`
+    block.
+
+Lint/NonLocalExitFromIterator:
+  Enabled: true
+
+Lint/ParenthesesAsGroupedExpression:
+  Enabled: true
+
+Lint/PercentStringArray:
+  Enabled: true
+
+Lint/PercentSymbolArray:
+  Enabled: true
+
+Lint/RandOne:
+  Description: Checks for `rand(1)` calls. Such calls always return `0` and most
+    likely a mistake.
+
+Lint/RequireParentheses:
+  Enabled: true
+
+Lint/RescueException:
+  Enabled: true
+
+Lint/ShadowedException:
+  Enabled: true
+
+Lint/ShadowingOuterLocalVariable:
+  Enabled: true
+
+Lint/StringConversionInInterpolation:
+  Enabled: true
+
+Lint/UnderscorePrefixedVariableName:
+  Enabled: true
+
+Lint/UnifiedInteger:
+  Enabled: true
+
+Lint/UnneededCopDisableDirective:
+  Enabled: true
+
+Lint/UnneededCopEnableDirective:
+  Enabled: true
+
+Lint/UnneededSplatExpansion:
+  Enabled: true
+
+Lint/UnreachableCode:
+  Enabled: true
+
+Lint/UselessAccessModifier:
+  ContextCreatingMethods: []
+
+Lint/UselessAssignment:
+  Enabled: true
+
+Lint/UselessComparison:
+  Enabled: true
+
+Lint/UselessElseWithoutRescue:
+  Enabled: true
+
+Lint/UselessSetterCall:
+  Enabled: true
+
+Lint/Void:
+  Enabled: true
+
+Security/Eval:
+  Enabled: true
+
+Security/JSONLoad:
+  Enabled: true
+
+Security/Open:
+  Enabled: true
+
+Lint/BigDecimalNew:
+  Enabled: true
+
+Style/Strip:
+  Enabled: true
+
+Style/TrailingBodyOnClass:
+  Enabled: true
+
+Style/TrailingBodyOnModule:
+  Enabled: true
+
+Style/TrailingCommaInArrayLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Style/TrailingCommaInHashLiteral:
+  EnforcedStyleForMultiline: comma
+  Enabled: true
+
+Layout/SpaceInsideReferenceBrackets:
+  EnforcedStyle: no_space
+  EnforcedStyleForEmptyBrackets: no_space
+  Enabled: true
+
+Style/ModuleFunction:
+  EnforcedStyle: extend_self
+
+Lint/OrderedMagicComments:
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -5,7 +5,7 @@ require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
   test.pattern = 'test/**/*_test.rb'
-  test.verbose = true
+  test.warning = false
 end
 
 begin

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -30,7 +30,8 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("graphql-client")
 
   s.add_development_dependency("mocha", ">= 0.9.8")
-  s.add_development_dependency("fakeweb")
+  # s.add_development_dependency("fakeweb")
+  s.add_development_dependency("webmock")
   s.add_development_dependency("minitest", ">= 4.0")
   s.add_development_dependency("rake")
   s.add_development_dependency("timecop")

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("graphql-client")
 
   s.add_development_dependency("mocha", ">= 0.9.8")
-  # s.add_development_dependency("fakeweb")
   s.add_development_dependency("webmock")
   s.add_development_dependency("minitest", ">= 4.0")
   s.add_development_dependency("rake")

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -33,9 +33,9 @@ class BaseTest < Test::Unit::TestCase
 
     ShopifyAPI::Base.clear_session
 
-    assert_equal nil, ShopifyAPI::Base.user
-    assert_equal nil, ShopifyAPI::Base.password
-    assert_equal nil, ShopifyAPI::Base.site
+    assert_nil ShopifyAPI::Base.user
+    assert_nil ShopifyAPI::Base.password
+    assert_nil ShopifyAPI::Base.site
   end
 
   test '#clear_session should clear site and headers from Base' do
@@ -92,8 +92,9 @@ class BaseTest < Test::Unit::TestCase
   test "prefix= will forward to resource when the value does not start with admin" do
     session = ShopifyAPI::Session.new(domain: 'shop1.myshopify.com', token: 'token1', api_version: '2019-01')
     ShopifyAPI::Base.activate_session(session)
-
-    TestResource.prefix = 'a/regular/path/'
+    silence_warnings do
+      TestResource.prefix = 'a/regular/path/'
+    end
 
     assert_equal('/admin/api/2019-01/a/regular/path/', TestResource.prefix)
   end

--- a/test/blog_test.rb
+++ b/test/blog_test.rb
@@ -3,6 +3,6 @@ class BlogTest < Test::Unit::TestCase
   test "blog creation" do
     fake "blogs", :method => :post, :status => 202, :body => load_fixture('blog')
     blog = ShopifyAPI::Blog.create(:title => "Test Blog")
-    assert_equal '{"blog":{"title":"Test Blog"}}', FakeWeb.last_request.body
+    assert_equal '{"blog":{"title":"Test Blog"}}', WebMock.last_request.body
   end
 end

--- a/test/collection_publication_test.rb
+++ b/test/collection_publication_test.rb
@@ -35,6 +35,6 @@ class CollectionPublicationTest < Test::Unit::TestCase
       },
     }.to_json
 
-    assert_equal expected_body, FakeWeb.last_request.body
+    assert_equal expected_body, WebMock.last_request.body
   end
 end

--- a/test/customer_test.rb
+++ b/test/customer_test.rb
@@ -30,7 +30,7 @@ class CustomerTest < Test::Unit::TestCase
 
     customer_invite_response = @customer.send_invite
 
-    assert_equal '{"customer_invite":{}}', FakeWeb.last_request.body
+    assert_equal '{"customer_invite":{}}', WebMock.last_request.body
     assert_kind_of ShopifyAPI::CustomerInvite, customer_invite_response
     assert_equal customer_invite['customer_invite']['to'], customer_invite_response.to
   end
@@ -43,7 +43,7 @@ class CustomerTest < Test::Unit::TestCase
 
     customer_invite_response = @customer.send_invite(ShopifyAPI::CustomerInvite.new(customer_invite['customer_invite']))
 
-    assert_equal customer_invite, ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_equal customer_invite, ActiveSupport::JSON.decode(WebMock.last_request.body)
     assert_kind_of ShopifyAPI::CustomerInvite, customer_invite_response
     assert_equal customer_invite['customer_invite']['to'], customer_invite_response.to
   end

--- a/test/discount_code_test.rb
+++ b/test/discount_code_test.rb
@@ -30,7 +30,7 @@ class DiscountCodeTest < Test::Unit::TestCase
     discount_code.code = "SUMMERSALE10"
     discount_code.save
 
-    assert_equal '{"discount_code":{"code":"SUMMERSALE10"}}', FakeWeb.last_request.body
+    assert_equal '{"discount_code":{"code":"SUMMERSALE10"}}', WebMock.last_request.body
   end
 
   def test_update_discount_code
@@ -41,7 +41,7 @@ class DiscountCodeTest < Test::Unit::TestCase
     fake 'price_rules/102586120/discount_codes/1002091923', method: :put, status: 200, body: ActiveSupport::JSON.encode(discount_code_response)
 
     @discount_code.save
-    
+
     assert_equal discount_code_response['discount_code']['code'], @discount_code.code
   end
 

--- a/test/draft_order_test.rb
+++ b/test/draft_order_test.rb
@@ -39,7 +39,7 @@ class DraftOrderTest < Test::Unit::TestCase
 
     draft_order = ShopifyAPI::DraftOrder.create(line_items: [{ quantity: 1, variant_id: 39072856 }])
 
-    assert_equal '{"draft_order":{"line_items":[{"quantity":1,"variant_id":39072856}]}}', FakeWeb.last_request.body
+    assert_equal '{"draft_order":{"line_items":[{"quantity":1,"variant_id":39072856}]}}', WebMock.last_request.body
     assert_equal 39072856, draft_order.line_items.first.variant_id
   end
 
@@ -69,7 +69,7 @@ class DraftOrderTest < Test::Unit::TestCase
 
     draft_order_invoice_response = @draft_order.send_invoice
 
-    assert_equal '{"draft_order_invoice":{}}', FakeWeb.last_request.body
+    assert_equal '{"draft_order_invoice":{}}', WebMock.last_request.body
     assert_kind_of ShopifyAPI::DraftOrderInvoice, draft_order_invoice_response
     assert_equal draft_order_invoice['draft_order_invoice']['to'], draft_order_invoice_response.to
   end
@@ -81,7 +81,7 @@ class DraftOrderTest < Test::Unit::TestCase
 
     draft_order_invoice_response = @draft_order.send_invoice(ShopifyAPI::DraftOrderInvoice.new(draft_order_invoice['draft_order_invoice']))
 
-    assert_equal draft_order_invoice, ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_equal draft_order_invoice, ActiveSupport::JSON.decode(WebMock.last_request.body)
     assert_kind_of ShopifyAPI::DraftOrderInvoice, draft_order_invoice_response
     assert_equal draft_order_invoice['draft_order_invoice']['to'], draft_order_invoice_response.to
   end
@@ -96,7 +96,7 @@ class DraftOrderTest < Test::Unit::TestCase
 
     field = @draft_order.add_metafield(ShopifyAPI::Metafield.new(namespace: 'contact', key: 'email', value: '123@example.com', value_type: 'string'))
 
-    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), ActiveSupport::JSON.decode(WebMock.last_request.body)
     assert !field.new_record?
     assert_equal 'contact', field.namespace
     assert_equal 'email', field.key

--- a/test/lib/webmock_extensions/last_request.rb
+++ b/test/lib/webmock_extensions/last_request.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module LastRequest
+  def last_request
+    @last_request
+  end
+
+  def last_request=(request_signature)
+    @last_request = request_signature
+  end
+end
+
+WebMock.extend(LastRequest)
+WebMock.after_request do |request_signature, response|
+  WebMock.last_request = request_signature
+end

--- a/test/metafield_test.rb
+++ b/test/metafield_test.rb
@@ -24,7 +24,7 @@ class MetafieldTest < Test::Unit::TestCase
     blog = ShopifyAPI::Blog.find(1008414260)
     metafield = blog.add_metafield(ShopifyAPI::Metafield.new(:namespace => "summaries", :key => "First Summary", :value => "Make commerce better", :value_type => "string"))
 
-    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"summaries","key":"First Summary","value":"Make commerce better","value_type":"string"}}'), ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"summaries","key":"First Summary","value":"Make commerce better","value_type":"string"}}'), ActiveSupport::JSON.decode(WebMock.last_request.body)
     assert !metafield.new_record?
   end
 

--- a/test/price_rule_test.rb
+++ b/test/price_rule_test.rb
@@ -42,7 +42,7 @@ class PriceRuleTest < Test::Unit::TestCase
       starts_at: "2017-01-19T00:00:00Z"
     )
 
-    assert_equal '{"price_rule":{"target_type":"line_item","allocation_method":"across","value_type":"fixed_amount","value":-10.0,"customer_selection":"all","starts_at":"2017-01-19T00:00:00Z"}}', FakeWeb.last_request.body
+    assert_equal '{"price_rule":{"target_type":"line_item","allocation_method":"across","value_type":"fixed_amount","value":-10.0,"customer_selection":"all","starts_at":"2017-01-19T00:00:00Z"}}', WebMock.last_request.body
     assert_equal -10, price_rule.value
   end
 

--- a/test/product_publication_test.rb
+++ b/test/product_publication_test.rb
@@ -35,6 +35,6 @@ class ProductPublicationTest < Test::Unit::TestCase
       },
     }.to_json
 
-    assert_equal expected_body, FakeWeb.last_request.body
+    assert_equal expected_body, WebMock.last_request.body
   end
 end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -12,7 +12,7 @@ class ProductTest < Test::Unit::TestCase
     fake "products/632910392/metafields", :method => :post, :status => 201, :body => load_fixture('metafield')
 
     field = @product.add_metafield(ShopifyAPI::Metafield.new(:namespace => "contact", :key => "email", :value => "123@example.com", :value_type => "string"))
-    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), ActiveSupport::JSON.decode(WebMock.last_request.body)
     assert !field.new_record?
     assert_equal "contact", field.namespace
     assert_equal "email", field.key

--- a/test/recurring_application_charge_test.rb
+++ b/test/recurring_application_charge_test.rb
@@ -129,15 +129,14 @@ class RecurringApplicationChargeTest < Test::Unit::TestCase
     fake "recurring_application_charges", body: {recurring_application_charges: []}.to_json
 
     assert_equal 0, ShopifyAPI::RecurringApplicationCharge.all.count
-    assert_equal nil, ShopifyAPI::RecurringApplicationCharge.current
+    assert_nil ShopifyAPI::RecurringApplicationCharge.current
     assert_equal [], ShopifyAPI::RecurringApplicationCharge.pending
   end
 
   def test_recurring_application_charge_not_found_error
     fake "recurring_application_charges", body: '{"errors":"Not Found"}', status: 404
-
-    assert_equal(nil, ShopifyAPI::RecurringApplicationCharge.all)
-    assert_equal(nil, ShopifyAPI::RecurringApplicationCharge.current)
+    assert_nil ShopifyAPI::RecurringApplicationCharge.all
+    assert_nil ShopifyAPI::RecurringApplicationCharge.current
     assert_equal([], ShopifyAPI::RecurringApplicationCharge.pending)
   end
 end

--- a/test/shop_test.rb
+++ b/test/shop_test.rb
@@ -50,7 +50,7 @@ class ShopTest < Test::Unit::TestCase
     fake "metafields", :method => :post, :status => 201, :body =>load_fixture('metafield')
 
     field = @shop.add_metafield(ShopifyAPI::Metafield.new(:namespace => "contact", :key => "email", :value => "123@example.com", :value_type => "string"))
-    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), ActiveSupport::JSON.decode(FakeWeb.last_request.body)
+    assert_equal ActiveSupport::JSON.decode('{"metafield":{"namespace":"contact","key":"email","value":"123@example.com","value_type":"string"}}'), ActiveSupport::JSON.decode(WebMock.last_request.body)
     assert !field.new_record?
     assert_equal "contact", field.namespace
     assert_equal "email", field.key

--- a/test/tax_service_test.rb
+++ b/test/tax_service_test.rb
@@ -3,6 +3,7 @@ class TaxServiceTest < Test::Unit::TestCase
   test "tax service creation" do
     fake "tax_services", :method => :post, :status => 202, :body => load_fixture('tax_service')
     tax_service = ShopifyAPI::TaxService.create(:name => "My Tax Service", :url => "https://mytaxservice.com")
-    assert_equal '{"tax_service":{"name":"My Tax Service","url":"https://mytaxservice.com"}}', FakeWeb.last_request.body
+    assert_equal '{"tax_service":{"name":"My Tax Service","url":"https://mytaxservice.com"}}', WebMock.last_request.body
+
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -14,102 +14,101 @@ WebMock.disable_net_connect!
 # setup ShopifyAPI with fake api_key and secret
 module Test
   module Unit
-  end
-end
+    class TestCase < Minitest::Test
+      def self.test(string, &block)
+        define_method("test_#{string}", &block)
+      end
 
-class Test::Unit::TestCase < Minitest::Unit::TestCase
-  def self.test(string, &block)
-    define_method("test_#{string}", &block)
-  end
+      def self.should(string, &block)
+        self.test("should_#{string}", &block)
+      end
 
-  def self.should(string, &block)
-    self.test("should_#{string}", &block)
-  end
+      def self.context(string)
+        yield
+      end
 
-  def self.context(string)
-    yield
-  end
+      def setup
+        ActiveResource::Base.format = :json
+        ShopifyAPI.constants.each do |const|
+          begin
+            const = mod.const_get(const)
+            const.format = :json if const.respond_to?(:format=)
+          rescue NameError
+          end
+        end
 
-  def setup
-    ActiveResource::Base.format = :json
-    ShopifyAPI.constants.each do |const|
-      begin
-        const = mod.const_get(const)
-        const.format = :json if const.respond_to?(:format=)
-      rescue NameError
+        ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2019-01'))
+
+        ShopifyAPI::Base.clear_session
+        session = ShopifyAPI::Session.new(
+          domain: "https://this-is-my-test-shop.myshopify.com",
+          token: "token_test_helper",
+          api_version: '2019-01',
+        )
+
+        ShopifyAPI::Base.activate_session(session)
+      end
+
+      def teardown
+        ShopifyAPI::Base.clear_session
+        ShopifyAPI::Base.site = nil
+        ShopifyAPI::Base.password = nil
+        ShopifyAPI::Base.user = nil
+
+        ShopifyAPI::ApiVersion.clear_defined_versions
+        ShopifyAPI::ApiVersion.define_known_versions
+      end
+
+      # Custom Assertions
+      def assert_not(expression)
+        refute expression, "Expected <#{expression}> to be false!"
+      end
+
+      def assert_nothing_raised
+        yield
+      end
+
+      def assert_not_includes(array, value)
+        refute array.include?(value)
+      end
+
+      def assert_includes(array, value)
+        assert array.include?(value)
+      end
+
+      def load_fixture(name, format=:json)
+        File.read(File.dirname(__FILE__) + "/fixtures/#{name}.#{format}")
+      end
+
+      def assert_request_body(expected)
+        assert_equal expected, WebMock.last_request.body
+      end
+
+      def fake(endpoint, options={})
+        body   = options.has_key?(:body) ? options.delete(:body) : load_fixture(endpoint)
+        format = options.delete(:format) || :json
+        method = options.delete(:method) || :get
+        api_version = options.delete(:api_version) || ShopifyAPI::ApiVersion.coerce_to_version('2019-01')
+        extension = ".#{options.delete(:extension)||'json'}" unless options[:extension]==false
+
+        url = if options.has_key?(:url)
+          options[:url]
+        else
+          "https://this-is-my-test-shop.myshopify.com#{api_version.construct_api_path("#{endpoint}#{extension}")}"
+        end
+
+        WebMock.stub_request(method, url).to_return(
+          body: body, status: 200, headers: { content_type: "text/#{format}", content_length: 1 }.merge(options)
+        )
+      end
+
+      def ar_version_before?(version_string)
+        Gem::Version.new(ActiveResource::VERSION::STRING) < Gem::Version.new(version_string)
+      end
+
+      def ar_version_after?(version_string)
+        Gem::Version.new(version_string) < Gem::Version.new(ActiveResource::VERSION::STRING)
       end
     end
-
-    ShopifyAPI::ApiVersion.define_version(ShopifyAPI::ApiVersion::Release.new('2019-01'))
-
-    ShopifyAPI::Base.clear_session
-    session = ShopifyAPI::Session.new(
-      domain: "https://this-is-my-test-shop.myshopify.com",
-      token: "token_test_helper",
-      api_version: '2019-01',
-    )
-
-    ShopifyAPI::Base.activate_session(session)
-  end
-
-  def teardown
-    ShopifyAPI::Base.clear_session
-    ShopifyAPI::Base.site = nil
-    ShopifyAPI::Base.password = nil
-    ShopifyAPI::Base.user = nil
-
-    ShopifyAPI::ApiVersion.clear_defined_versions
-    ShopifyAPI::ApiVersion.define_known_versions
-  end
-
-  # Custom Assertions
-  def assert_not(expression)
-    refute expression, "Expected <#{expression}> to be false!"
-  end
-
-  def assert_nothing_raised
-    yield
-  end
-
-  def assert_not_includes(array, value)
-    refute array.include?(value)
-  end
-
-  def assert_includes(array, value)
-    assert array.include?(value)
-  end
-
-  def load_fixture(name, format=:json)
-    File.read(File.dirname(__FILE__) + "/fixtures/#{name}.#{format}")
-  end
-
-  def assert_request_body(expected)
-    assert_equal expected, WebMock.last_request.body
-  end
-
-  def fake(endpoint, options={})
-    body   = options.has_key?(:body) ? options.delete(:body) : load_fixture(endpoint)
-    format = options.delete(:format) || :json
-    method = options.delete(:method) || :get
-    api_version = options.delete(:api_version) || ShopifyAPI::ApiVersion.coerce_to_version('2019-01')
-    extension = ".#{options.delete(:extension)||'json'}" unless options[:extension]==false
-
-    url = if options.has_key?(:url)
-      options[:url]
-    else
-      "https://this-is-my-test-shop.myshopify.com#{api_version.construct_api_path("#{endpoint}#{extension}")}"
-    end
-
-    WebMock.stub_request(method, url).to_return(
-      body: body, status: 200, headers: { content_type: "text/#{format}", content_length: 1 }.merge(options)
-    )
-  end
-
-  def ar_version_before?(version_string)
-    Gem::Version.new(ActiveResource::VERSION::STRING) < Gem::Version.new(version_string)
-  end
-
-  def ar_version_after?(version_string)
-    Gem::Version.new(version_string) < Gem::Version.new(ActiveResource::VERSION::STRING)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -90,7 +90,7 @@ module Test
         method = options.delete(:method) || :get
         api_version = options.delete(:api_version) || ShopifyAPI::ApiVersion.coerce_to_version('2019-01')
         extension = ".#{options.delete(:extension)||'json'}" unless options[:extension]==false
-
+        status = options.delete(:status) || 200
         url = if options.has_key?(:url)
           options[:url]
         else
@@ -98,7 +98,7 @@ module Test
         end
 
         WebMock.stub_request(method, url).to_return(
-          body: body, status: 200, headers: { content_type: "text/#{format}", content_length: 1 }.merge(options)
+          body: body, status: status, headers: { content_type: "text/#{format}", content_length: 1 }.merge(options)
         )
       end
 


### PR DESCRIPTION
running tests is . bit of a nightmare these days with the sheer number or warnings. This PR cleans up a bunch of easy wins and turns down the warnings level to something more manageable. 

### Changes
- Move from FakeWeb to WebMock
    - FakeWeb seems to be dead and hasn't had a version release since  August 23, 2010 (thats almost 9 years!! :O ) and WebMock seems to be the spiritual successor to it and is largely based on FakeWeb
- Update TestCase to inherit from `Minitest::Test`instead of `Minitest::Unit::TestCase`
- replace all calls to `assert_equal nil, :something` with `assert_nil`
- set Rake TestTask to be verbose = false (the default) and warning = false
    - I can't see a reason to be verbose by default, it just clutters the test output
    - Most of the warning output is coming from the graphql gems. Setting warning to false removes the `-w` flag when rake runs ruby. The full set of warnings can be viewed by running `RUBYOPT=W2 bundle exec rake test` or _totally_ silenced with `RUBYOPT=W0 bundle exec rake test`


### Unchanged Warnings
- There are still warnings for `URI.escape` being obsolete, but I'm not 100% sure what it should be changed to since theres no drop in replacement.
- There are still warnings about various methods being redefined in `lib/active_resource/` but these seem intentional redefinitions. Maybe theres a better way extend AR to meet our needs?
- graphql gem warnings
-  few unused variable warnings. 