### PR TITLE
Change cursor pagination API version to 2019-10

### DIFF
--- a/lib/shopify_api/collection_pagination.rb
+++ b/lib/shopify_api/collection_pagination.rb
@@ -27,7 +27,7 @@ module ShopifyAPI
 
     private
 
-    AVAILABLE_IN_VERSION = ShopifyAPI::ApiVersion::Unstable.new
+    AVAILABLE_IN_VERSION = ShopifyAPI::ApiVersion::Release.new('2019-10')
 
     def fetch_page(url_params)
       ensure_available

--- a/test/pagination_test.rb
+++ b/test/pagination_test.rb
@@ -4,13 +4,13 @@ class PaginationTest < Test::Unit::TestCase
   def setup
     super
 
-    @version = ShopifyAPI::ApiVersion::Unstable.new
+    @version = ShopifyAPI::ApiVersion::Release.new('2019-10')
     ShopifyAPI::Base.api_version = @version.to_s
     @next_page_info = "eyJkaXJlY3Rpb24iOiJuZXh0IiwibGFzdF9pZCI6NDQwMDg5NDIzLCJsYXN0X3ZhbHVlIjoiNDQwMDg5NDIzIn0%3D"
     @previous_page_info = "eyJsYXN0X2lkIjoxMDg4MjgzMDksImxhc3RfdmFsdWUiOiIxMDg4MjgzMDkiLCJkaXJlY3Rpb24iOiJuZXh0In0%3D"
 
-    @next_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@next_page_info}>; rel=\"next\""
-    @previous_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@previous_page_info}>; rel=\"previous\""
+    @next_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?page_info=#{@next_page_info}>; rel=\"next\""
+    @previous_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?page_info=#{@previous_page_info}>; rel=\"previous\""
   end
 
   test "navigates using next and previous link headers with no original params" do
@@ -21,7 +21,7 @@ class PaginationTest < Test::Unit::TestCase
 
     fake(
       'orders',
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@next_page_info}",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?page_info=#{@next_page_info}",
       method: :get,
       status: 200,
       body: load_fixture('orders')
@@ -31,7 +31,7 @@ class PaginationTest < Test::Unit::TestCase
 
     fake(
       'orders',
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@previous_page_info}",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?page_info=#{@previous_page_info}",
       method: :get,
       status: 200,
       body: load_fixture('orders').gsub("450789469", "1122334455")
@@ -43,13 +43,13 @@ class PaginationTest < Test::Unit::TestCase
 
   test "uses all passed in querystring parameters" do
     params = "page_info=#{@next_page_info}&limit=50&fields=#{CGI.escape('id,created_at')}"
-    @next_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?#{params}>; rel=\"next\""
+    @next_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?#{params}>; rel=\"next\""
     fake(
       'orders',
       method: :get,
       status: 200,
       api_version: @version,
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?fields=id%2Cupdated_at&limit=100",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?fields=id%2Cupdated_at&limit=100",
       body: load_fixture('orders'),
       link: @next_link_header
     )
@@ -60,7 +60,7 @@ class PaginationTest < Test::Unit::TestCase
       method: :get,
       status: 200,
       api_version: @version,
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?fields=id%2Ccreated_at&limit=50&page_info=#{@next_page_info}",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?fields=id%2Ccreated_at&limit=50&page_info=#{@next_page_info}",
       body: load_fixture('orders')
     )
     next_page = orders.fetch_next_page
@@ -122,7 +122,7 @@ class PaginationTest < Test::Unit::TestCase
   end
 
   test "raises on invalid pagination links" do
-    link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@next_page_info}>;"
+    link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?page_info=#{@next_page_info}>;"
     fake 'orders', :method => :get, :status => 200, api_version: @version, :body => load_fixture('orders'), :link => link_header
 
     assert_raises ShopifyAPI::InvalidPaginationLinksError do
@@ -142,6 +142,29 @@ class PaginationTest < Test::Unit::TestCase
     end
   end
 
+  test "does not raise on the unstable version" do
+    version = ShopifyAPI::ApiVersion::Unstable.new
+    ShopifyAPI::Base.api_version = version.to_s
+    @next_link_header = "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@next_page_info}>; rel=\"next\""
+
+    link_header ="#{@previous_link_header}, #{@next_link_header}"
+
+    fake 'orders', :method => :get, :status => 200, api_version: version, :body => load_fixture('orders'), :link => link_header
+    orders = ShopifyAPI::Order.all
+
+    fake(
+      'orders',
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?page_info=#{@next_page_info}",
+      method: :get,
+      status: 200,
+      body: load_fixture('orders')
+    )
+    assert_nothing_raised do
+      next_page = orders.fetch_next_page
+      assert_equal 450789469, next_page.first.id
+    end
+  end
+
   test "allows for multiple concurrent API collection objects" do
     first_request_params = "page_info=#{@next_page_info}&limit=5"
     fake(
@@ -149,9 +172,9 @@ class PaginationTest < Test::Unit::TestCase
       method: :get,
       status: 200,
       api_version: @version,
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?limit=5",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?limit=5",
       body: load_fixture('orders'),
-      link: "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?#{first_request_params}>; rel=\"next\""
+      link: "<https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?#{first_request_params}>; rel=\"next\""
     )
     orders = ShopifyAPI::Order.where(limit: 5)
 
@@ -161,9 +184,9 @@ class PaginationTest < Test::Unit::TestCase
       method: :get,
       status: 200,
       api_version: @version,
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?limit=10",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?limit=10",
       body: load_fixture('orders'),
-      link: "<https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?#{second_request_params}>; rel=\"next\""
+      link: "<https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?#{second_request_params}>; rel=\"next\""
     )
 
     orders2 = ShopifyAPI::Order.where(limit: 10)
@@ -173,7 +196,7 @@ class PaginationTest < Test::Unit::TestCase
       method: :get,
       status: 200,
       api_version: @version,
-      url: "https://this-is-my-test-shop.myshopify.com/admin/api/unstable/orders.json?limit=5&page_info=#{@next_page_info}",
+      url: "https://this-is-my-test-shop.myshopify.com/admin/api/2019-10/orders.json?limit=5&page_info=#{@next_page_info}",
       body: load_fixture('orders')
     )
     next_page = orders.fetch_next_page


### PR DESCRIPTION
Changes support for relative cursor pagination to `2019-10`. This feature was added in https://github.com/Shopify/shopify_api/pull/594 under `unstable`, but is now generally available in the `2019-10` pre-release and later versions.