### PR TITLE
raise ApiVersionNotSetError if Base.api_version is nil

### DIFF
--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 module ShopifyAPI
   class ApiVersion
+    class ApiVersionNotSetError < StandardError; end
     class UnknownVersion < StandardError; end
     class InvalidVersion < StandardError; end
 
@@ -107,6 +108,24 @@ module ShopifyAPI
 
       def construct_graphql_path
         construct_api_path('graphql.json')
+      end
+    end
+
+    class NullVersion
+      def self.nil?
+        true
+      end
+
+      def self.present?
+        false
+      end
+
+      def self.empty?
+        true
+      end
+
+      def self.method_missing(method_name, *args, &block)
+        raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request."
       end
     end
   end

--- a/lib/shopify_api/api_version.rb
+++ b/lib/shopify_api/api_version.rb
@@ -112,20 +112,18 @@ module ShopifyAPI
     end
 
     class NullVersion
-      def self.nil?
-        true
-      end
+      class << self
+        def stable?
+          raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request."
+        end
 
-      def self.present?
-        false
-      end
+        def construct_api_path(*_path)
+          raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request."
+        end
 
-      def self.empty?
-        true
-      end
-
-      def self.method_missing(method_name, *args, &block)
-        raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request."
+        def construct_graphql_path
+          raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request."
+        end
       end
     end
   end

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -3,7 +3,6 @@ require 'shopify_api/version'
 module ShopifyAPI
   class Base < ActiveResource::Base
     class InvalidSessionError < StandardError; end
-    class ApiVersionNotSetError < StandardError; end
     extend Countable
 
     self.timeout = 90
@@ -59,17 +58,17 @@ module ShopifyAPI
       end
 
       def api_version
-        api_version = if _api_version_defined?
+        if _api_version_defined?
           _api_version
         elsif superclass != Object && superclass.site
           superclass.api_version.dup.freeze
+        else
+          ApiVersion::NullVersion
         end
-        raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request." unless api_version
-        api_version
       end
 
       def api_version=(version)
-        self._api_version = version.nil? ? nil : ApiVersion.coerce_to_version(version)
+        self._api_version = version.nil? ? ApiVersion::NullVersion : ApiVersion.coerce_to_version(version)
       end
 
       def prefix(options = {})

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -3,6 +3,7 @@ require 'shopify_api/version'
 module ShopifyAPI
   class Base < ActiveResource::Base
     class InvalidSessionError < StandardError; end
+    class ApiVersionNotSetError < StandardError; end
     extend Countable
 
     self.timeout = 90
@@ -58,11 +59,13 @@ module ShopifyAPI
       end
 
       def api_version
-        if _api_version_defined?
+        api_version = if _api_version_defined?
           _api_version
         elsif superclass != Object && superclass.site
           superclass.api_version.dup.freeze
         end
+        raise ApiVersionNotSetError, "You must set ShopifyAPI::Base.api_version before making a request." unless api_version
+        api_version
       end
 
       def api_version=(version)

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -136,9 +136,17 @@ class ApiVersionTest < Test::Unit::TestCase
     )
   end
 
-  test "NullVersion raises ApiVersionNotSetError for any method call" do
+  test "NullVersion raises ApiVersionNotSetError" do
     assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
-      ShopifyAPI::ApiVersion::NullVersion.anything
+      ShopifyAPI::ApiVersion::NullVersion.construct_api_path(:string)
+    end
+
+    assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
+      ShopifyAPI::ApiVersion::NullVersion.construct_graphql_path
+    end
+
+    assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
+      ShopifyAPI::ApiVersion::NullVersion.stable?
     end
   end
 

--- a/test/api_version_test.rb
+++ b/test/api_version_test.rb
@@ -136,6 +136,12 @@ class ApiVersionTest < Test::Unit::TestCase
     )
   end
 
+  test "NullVersion raises ApiVersionNotSetError for any method call" do
+    assert_raises(ShopifyAPI::ApiVersion::ApiVersionNotSetError) do
+      ShopifyAPI::ApiVersion::NullVersion.anything
+    end
+  end
+
   class TestApiVersion < ShopifyAPI::ApiVersion
     def initialize(name)
       @version_name = name

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -163,11 +163,9 @@ class BaseTest < Test::Unit::TestCase
     assert_equal '2019-04', ShopifyAPI::Base.api_version.to_s
   end
 
-  test "#api_version raises ApiVersionNotSetError if no version is set." do
+  test "#api_version= nil should set ApiVersion to ShopifyAPI::ApiVersion::NullVersion" do
     ShopifyAPI::Base.api_version = nil
-    assert_raises(ShopifyAPI::Base::ApiVersionNotSetError) do
-      ShopifyAPI::Base.api_version
-    end
+    assert_equal ShopifyAPI::ApiVersion::NullVersion, ShopifyAPI::Base.api_version
   end
 
   def clear_header(header)

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -158,9 +158,16 @@ class BaseTest < Test::Unit::TestCase
     assert_equal 2, ShopifyAPI::Shop.current.id
   end
 
-  test "#api_version should set ApiVersion" do
+  test "#api_version= should set ApiVersion" do
     ShopifyAPI::Base.api_version = '2019-04'
     assert_equal '2019-04', ShopifyAPI::Base.api_version.to_s
+  end
+
+  test "#api_version raises ApiVersionNotSetError if no version is set." do
+    ShopifyAPI::Base.api_version = nil
+    assert_raises(ShopifyAPI::Base::ApiVersionNotSetError) do
+      ShopifyAPI::Base.api_version
+    end
   end
 
   def clear_header(header)


### PR DESCRIPTION
Currently if you try to access a resource without setting an api_version first, you raise an exception:

```
NoMethodError: undefined method `construct_api_path' for nil:NilClass`
from .../shopify_api/lib/shopify_api/resources/base.rb:73:in `prefix'
```

Its not a super clear error. Instead, lets raise an error if the api_version hasn't been set (aka `ShopifyAPI::Base.api_version` would return nil) to let developers know they need to set the api version. This error is super easy to run into if you spin up the shopify_api_console and forget you need to set a version first. 