### PR TITLE
Rename collection with CollectionParser

### DIFF
--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -8,7 +8,7 @@ require 'shopify_api/limits'
 require 'shopify_api/defined_versions'
 require 'shopify_api/api_version'
 require 'active_resource/json_errors'
-require 'shopify_api/collection_parser'
+require 'shopify_api/paginated_collection'
 require 'shopify_api/disable_prefix_check'
 
 module ShopifyAPI

--- a/lib/shopify_api/paginated_collection.rb
+++ b/lib/shopify_api/paginated_collection.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module ShopifyAPI
-  class CollectionParser < ActiveResource::Collection
+  class PaginatedCollection < ActiveResource::Collection
     module CollectionPagination
       def initialize(args)
         @previous_url_params = extract_url_params(pagination_link_headers.previous_link)

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -11,7 +11,7 @@ module ShopifyAPI
                                   "ActiveResource/#{ActiveResource::VERSION::STRING}",
                                   "Ruby/#{RUBY_VERSION}"].join(' ')
 
-    self.collection_parser = ShopifyAPI::CollectionParser
+    self.collection_parser = ShopifyAPI::PaginatedCollection
 
     def encode(options = {})
       same = dup


### PR DESCRIPTION
Rename `collection` class added in https://github.com/Shopify/shopify_api/pull/602 with `collectionParser` so as to avoid overriding with `resources/collection` which we plan to add in this PR #609 Add support Collection#products endpoint.