### PR TITLE
Small consistency change

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -104,7 +104,7 @@ module ShopifyAPI
         raise ShopifyAPI::ValidationException, "Invalid Signature: Possible malicious login"
       end
 
-      response = access_token_request(params['code'])
+      response = access_token_request(params[:code])
       if response.code == "200"
         self.extra = JSON.parse(response.body)
         self.token = extra.delete('access_token')


### PR DESCRIPTION
fixes #620 

This fixes a small consistency issue in code style. As far as the tests are concerned they are all accessing this hash with indifferent access, and I believe at this point the parameters are coming from a controller so it should already have indifferent access.

I tried to look for usage in our ShopifyApp gem but it seems like that part is taken care of by the omniauth gem and does not use this functionality.