### PR TITLE
[WIP] Adding FulfillmentOrder, FulfillmentRequest, CancellationRequest, AssignedFulfillmentOrder resources/filters

### DIFF
--- a/lib/shopify_api/resources/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/resources/assigned_fulfillment_order.rb
@@ -1,0 +1,9 @@
+module ShopifyAPI
+  class AssignedFulfillmentOrder < Base
+    init_prefix :order
+
+    def order_id
+      @prefix_options[:order_id]
+    end
+  end
+end

--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -1,0 +1,17 @@
+module ShopifyAPI
+  class FulfillmentOrder < Base
+    init_prefix :order
+
+    def order_id
+      @prefix_options[:order_id]
+    end
+
+    def cancel; load_attributes_from_response(post(:cancel, {}, only_id)); end
+    def close; load_attributes_from_response(post(:close, {}, only_id)); end
+
+    def move(new_location_id:)
+      body = { new_location_id: new_location_id }
+      load_attributes_from_response(post(:move, {}, body))
+    end
+  end
+end

--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -6,12 +6,48 @@ module ShopifyAPI
       @prefix_options[:order_id]
     end
 
-    def cancel; load_attributes_from_response(post(:cancel, {}, only_id)); end
-    def close; load_attributes_from_response(post(:close, {}, only_id)); end
+    def self.with_assigned_status(assigned_status: nil, location_ids: nil)
+      options = { assigned_status: assigned_status, location_ids: location_ids }.compact
+      load_attributes_from_response(get("../assigned_fulfillment_orders", options))
+    end
+
+    def cancel
+      load_attributes_from_response(post(:cancel, {}, only_id))
+    end
+
+    def close
+      load_attributes_from_response(post(:close, {}, only_id))
+    end
 
     def move(new_location_id:)
       body = { new_location_id: new_location_id }
       load_attributes_from_response(post(:move, {}, body))
+    end
+
+    def new_fulfillment_request(message:, fulfillment_order_line_items:)
+      body = { message: message, fulfillment_order_line_items: fulfillment_order_line_items }
+      load_attributes_from_response(post('fulfillment_request', {}, body))
+    end
+
+    def accept_fulfillment_request
+      load_attributes_from_response(post('fulfillment_request/accept', {}, only_id))
+    end
+
+    def reject_fulfillment_request
+      load_attributes_from_response(post('fulfillment_request/reject', {}, only_id))
+    end
+
+    def new_cancellation_request(message:)
+      body = { message: message }
+      load_attributes_from_response(post('cancellation_request', {}, body))
+    end
+
+    def accept_cancellation_request
+      load_attributes_from_response(post('cancellation_request/accept', {}, only_id))
+    end
+
+    def reject_cancellation_request
+      load_attributes_from_response(post('cancellation_request/reject', {}, only_id))
     end
   end
 end

--- a/lib/shopify_api/resources/fulfillment_order_cancellation_request.rb
+++ b/lib/shopify_api/resources/fulfillment_order_cancellation_request.rb
@@ -1,0 +1,22 @@
+module ShopifyAPI
+  class FulfillmentOrderCancellationRequest < Base
+    self.resource_prefix = "orders/:order_id/fulfillments/:fulfillment_id/"
+    self.collection_name = 'cancellation_request'
+
+    def order_id
+      @prefix_options[:order_id]
+    end
+
+    def fulfillment_id
+      @prefix_options[:fulfillment_id]
+    end
+
+    def accept
+      load_attributes_from_response(post(:accept, {}, only_id))
+    end
+
+    def reject
+      load_attributes_from_response(post(:reject, {}, only_id))
+    end
+  end
+end

--- a/lib/shopify_api/resources/fulfillment_order_fulfillment_request.rb
+++ b/lib/shopify_api/resources/fulfillment_order_fulfillment_request.rb
@@ -1,0 +1,22 @@
+module ShopifyAPI
+  class FulfillmentOrderFulfillmentRequest < Base
+    self.resource_prefix = "orders/:order_id/fulfillments/:fulfillment_id/"
+    self.collection_name = 'fulfillment_request'
+
+    def order_id
+      @prefix_options[:order_id]
+    end
+
+    def fulfillment_id
+      @prefix_options[:fulfillment_id]
+    end
+
+    def accept
+      load_attributes_from_response(post(:accept, {}, only_id))
+    end
+
+    def reject
+      load_attributes_from_response(post(:reject, {}, only_id))
+    end
+  end
+end

--- a/test/assigned_fulfillment_order_test.rb
+++ b/test/assigned_fulfillment_order_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class AssignedFulFillmentOrderTest < Test::Unit::TestCase
+  context "AssignedFulfillmentOrder" do
+    context "#all" do
+      should "be able to list assigned fulfillment orders for an order by assigned_status" do
+        fake 'orders/450789469/assigned_fulfillment_orders.json?assigned_status=cancellation_requested', method: :get,
+             body: "[#{load_fixture('fulfillment_order')}]", extension: false
+
+        fulfillment_orders = ShopifyAPI::AssignedFulfillmentOrder.all(
+            params: { order_id: 450789469, assigned_status: 'cancellation_requested' }
+        )
+
+        assert_equal 1, fulfillment_orders.count
+        fulfillment_order = fulfillment_orders.first
+        assert_equal 450789469, fulfillment_order.order_id
+      end
+
+      should "be able to list assigned fulfillment orders for an order by location_ids" do
+        fo_fixture = load_fixture('fulfillment_order')
+        assigned_location_id = 361872256
+        fo_fixture = fo_fixture.gsub(/("assigned_location_id" *:) *[0-9]+/, "\\1 #{assigned_location_id}")
+        fake "orders/450789469/assigned_fulfillment_orders.json?location_ids%5B%5D=#{assigned_location_id}", method: :get,
+             body: "[#{fo_fixture}]", extension: false
+
+        fulfillment_orders = ShopifyAPI::AssignedFulfillmentOrder.all(
+            params: { order_id: 450789469, location_ids: [assigned_location_id] }
+        )
+
+        assert_equal 1, fulfillment_orders.count
+        fulfillment_order = fulfillment_orders.first.fulfillment_order
+        assert_equal 450789469, fulfillment_order.order_id
+        assert_equal assigned_location_id, fulfillment_order.assigned_location_id
+      end
+    end
+  end
+end

--- a/test/fixtures/fulfillment_order.json
+++ b/test/fixtures/fulfillment_order.json
@@ -1,0 +1,41 @@
+{
+   "fulfillment_order": {
+      "id": 519788021,
+      "shop_id": 690933842,
+      "order_id": 450789469,
+      "fulfillment_service_handle": "shipwire",
+      "status": "open",
+      "requires_shipping": true,
+      "is_not_deleted": true,
+      "deleted_at": null,
+      "created_at": "2016-07-12T11:23:42-04:00",
+      "updated_at": "2016-07-12T11:23:42-04:00",
+      "happened_at": "2016-07-12T11:23:42-04:00",
+      "assigned_location_id": 905684977,
+      "request_status": "unsubmitted",
+      "delivery_category": null,
+      "fulfillment_order_line_items": [
+         {
+            "id": 519788021,
+            "shop_id": 690933842,
+            "fulfillment_order_id": 519788021,
+            "line_item_id": 466157049,
+            "variant_id": 43729076,
+            "inventory_item_id": 808950810,
+            "inventory_commitment_id": 273471403,
+            "quantity": 1,
+            "sku": "draft-151",
+            "vendor": "Snowdevil",
+            "variant_title": "151cm",
+            "product_title": "Draft",
+            "pre_tax_price": 123.45,
+            "currency": "CAD",
+            "properties": null,
+            "is_not_deleted": true,
+            "deleted_at": null,
+            "created_at": "2016-07-12T11:23:54-04:00",
+            "updated_at": "2016-07-12T11:23:54-04:00"
+         }
+      ]
+   }
+}

--- a/test/fulfillment_order_test.rb
+++ b/test/fulfillment_order_test.rb
@@ -1,0 +1,87 @@
+require 'test_helper'
+
+class FulFillmentOrderTest < Test::Unit::TestCase
+  def setup
+    super
+    fake "orders/450789469/fulfillment_orders/519788021", method: :get,
+         body: load_fixture('fulfillment_order')
+  end
+
+  context "FulfillmentOrder" do
+    context "#find" do
+      should "be able to find fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, params: { order_id: 450789469 })
+        assert_equal 519788021, fulfillment_order.id
+        assert_equal 450789469, fulfillment_order.order_id
+      end
+    end
+
+    context "#all" do
+      should "be able to list fulfillment orders for an order" do
+        fake 'orders/450789469/fulfillment_orders', method: :get, body: "[#{load_fixture('fulfillment_order')}]"
+
+        fulfillment_orders = ShopifyAPI::FulfillmentOrder.all(
+            params: { order_id: 450789469 }
+        )
+
+        assert_equal 1, fulfillment_orders.count
+        fulfillment_order = fulfillment_orders.first
+        assert_equal 519788021, fulfillment_order.id
+        assert_equal 450789469, fulfillment_order.order_id
+      end
+    end
+
+    context "#cancel" do
+      should "be able to cancel fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, :params => {:order_id => 450789469})
+
+        cancelled = ActiveSupport::JSON.decode(load_fixture('fulfillment_order'))
+        cancelled['fulfillment_order']['status'] = 'cancelled'
+        fake "orders/450789469/fulfillment_orders/519788021/cancel", :method => :post, :body => ActiveSupport::JSON.encode(cancelled)
+
+        assert_equal 'open', fulfillment_order.status
+        assert fulfillment_order.cancel
+        assert_equal 'cancelled', fulfillment_order.status
+      end
+    end
+
+    context "#close" do
+      should "be able to close fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, :params => {:order_id => 450789469})
+
+        closed = ActiveSupport::JSON.decode(load_fixture('fulfillment_order'))
+        closed['fulfillment_order']['status'] = 'closed'
+        fake "orders/450789469/fulfillment_orders/519788021/close", :method => :post, :body => ActiveSupport::JSON.encode(closed)
+
+        assert_equal 'open', fulfillment_order.status
+        assert fulfillment_order.close
+        assert_equal 'closed', fulfillment_order.status
+      end
+    end
+
+    context "#move" do
+      should "be able to move fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, :params => {:order_id => 450789469})
+        new_location_id = 5
+
+        moved = ActiveSupport::JSON.decode(load_fixture('fulfillment_order'))
+        moved['fulfillment_order']['assigned_location_id'] = new_location_id
+        fulfillment_order.status = 'closed'
+
+        body = {
+            original_fulfillment_order: fulfillment_order,
+            moved_fulfillment_order: moved['fulfillment_order'],
+        }
+        fake "orders/450789469/fulfillment_orders/519788021/move", :method => :post, :body => ActiveSupport::JSON.encode(body)
+
+        assert_equal true, fulfillment_order.move(new_location_id: new_location_id)
+        refute_nil fulfillment_order.original_fulfillment_order
+        refute_nil fulfillment_order.moved_fulfillment_order
+
+        assert_equal 'closed', fulfillment_order.original_fulfillment_order.status
+        assert_equal 'open', fulfillment_order.moved_fulfillment_order.status
+        assert_equal new_location_id, fulfillment_order.moved_fulfillment_order.assigned_location_id
+      end
+    end
+  end
+end

--- a/test/fulfillment_order_test.rb
+++ b/test/fulfillment_order_test.rb
@@ -4,7 +4,7 @@ class FulFillmentOrderTest < Test::Unit::TestCase
   def setup
     super
     fake "orders/450789469/fulfillment_orders/519788021", method: :get,
-         body: load_fixture('fulfillment_order')
+      body: load_fixture('fulfillment_order')
   end
 
   context "FulfillmentOrder" do
@@ -21,7 +21,7 @@ class FulFillmentOrderTest < Test::Unit::TestCase
         fake 'orders/450789469/fulfillment_orders', method: :get, body: "[#{load_fixture('fulfillment_order')}]"
 
         fulfillment_orders = ShopifyAPI::FulfillmentOrder.all(
-            params: { order_id: 450789469 }
+          params: { order_id: 450789469 }
         )
 
         assert_equal 1, fulfillment_orders.count
@@ -30,6 +30,32 @@ class FulFillmentOrderTest < Test::Unit::TestCase
         assert_equal 450789469, fulfillment_order.order_id
       end
     end
+
+    # context "#with_assigned_status" do
+    #   should "be able to list fulfillment orders for an order with given assigned status" do
+    #     fake 'orders/450789469/assigned_fulfillment_orders?assigned_status=cancellation_requested', method: :get, body: "[#{load_fixture('fulfillment_order')}]"
+    #
+    #     fulfillment_orders = ShopifyAPI::FulfillmentOrder.with_assigned_status(assigned_status: 'cancellation_requested')
+    #
+    #     assert_equal 1, fulfillment_orders.count
+    #     fulfillment_order = fulfillment_orders.first
+    #     assert_equal 519788021, fulfillment_order.id
+    #     assert_equal 450789469, fulfillment_order.order_id
+    #   end
+    #
+    #   should "be able to list fulfillment orders for an order with given location_id" do
+    #     fake 'orders/450789469/assigned_fulfillment_orders?status=...', method: :get, body: "[#{load_fixture('fulfillment_order')}]"
+    #
+    #     fulfillment_orders = ShopifyAPI::FulfillmentOrder.all(
+    #         params: { order_id: 450789469 }
+    #     )
+    #
+    #     assert_equal 1, fulfillment_orders.count
+    #     fulfillment_order = fulfillment_orders.first
+    #     assert_equal 519788021, fulfillment_order.id
+    #     assert_equal 450789469, fulfillment_order.order_id
+    #   end
+    # end
 
     context "#cancel" do
       should "be able to cancel fulfillment order" do
@@ -69,8 +95,8 @@ class FulFillmentOrderTest < Test::Unit::TestCase
         fulfillment_order.status = 'closed'
 
         body = {
-            original_fulfillment_order: fulfillment_order,
-            moved_fulfillment_order: moved['fulfillment_order'],
+          original_fulfillment_order: fulfillment_order,
+          moved_fulfillment_order: moved['fulfillment_order'],
         }
         fake "orders/450789469/fulfillment_orders/519788021/move", :method => :post, :body => ActiveSupport::JSON.encode(body)
 
@@ -81,6 +107,111 @@ class FulFillmentOrderTest < Test::Unit::TestCase
         assert_equal 'closed', fulfillment_order.original_fulfillment_order.status
         assert_equal 'open', fulfillment_order.moved_fulfillment_order.status
         assert_equal new_location_id, fulfillment_order.moved_fulfillment_order.assigned_location_id
+      end
+    end
+
+    context "FulfillmentRequest" do
+      context "#new_fulfillment_request" do
+        test 'be able to create a fulfillment order fulfillment request' do
+          fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, :params => {:order_id => 450789469})
+          original_fulfillment_order = fulfillment_order.clone
+          submitted_fulfillment_order = fulfillment_order.clone
+          unsubmitted_fulfillment_order = fulfillment_order.clone
+
+          fake "orders/450789469/fulfillment_orders/519788021/fulfillment_request", method: :post,
+               body: ActiveSupport::JSON.encode({
+                 original_fulfillment_order: original_fulfillment_order,
+                 submitted_fulfillment_order: submitted_fulfillment_order,
+                 unsubmitted_fulfillment_order: unsubmitted_fulfillment_order,
+                 status: :ok,
+               })
+
+          assert fulfillment_order.new_fulfillment_request(message: 'the message',
+                   fulfillment_order_line_items: [{ id: 29284237, quantity: 1 }])
+
+          assert_equal 'ok', fulfillment_order.status
+          assert_equal original_fulfillment_order.attributes,
+                       fulfillment_order.original_fulfillment_order.attributes
+          refute_nil fulfillment_order.submitted_fulfillment_order
+          refute_nil fulfillment_order.unsubmitted_fulfillment_order
+        end
+      end
+
+      context "#accept_fulfillment_request" do
+        should "be able to accept a fulfillment order fulfillment request" do
+          fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, params: { order_id: 450789469 })
+
+          fake "orders/450789469/fulfillment_orders/519788021/fulfillment_request/accept", method: :post,
+               body: ActiveSupport::JSON.encode({ fulfillment_order: fulfillment_order, status: :ok })
+
+          assert fulfillment_order.accept_fulfillment_request
+
+          assert_equal 'ok', fulfillment_order.status
+          refute_nil fulfillment_order.fulfillment_order
+          assert_equal fulfillment_order.id, fulfillment_order.fulfillment_order.id
+        end
+      end
+
+      context "#reject_fulfillment_request" do
+        should "be able to reject a fulfillment order fulfillment request" do
+          fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, params: { order_id: 450789469 })
+
+          fake "orders/450789469/fulfillment_orders/519788021/fulfillment_request/reject", method: :post,
+               body: ActiveSupport::JSON.encode({ fulfillment_order: fulfillment_order, status: :ok })
+
+          assert fulfillment_order.reject_fulfillment_request
+
+          assert_equal 'ok', fulfillment_order.status
+          refute_nil fulfillment_order.fulfillment_order
+          assert_equal fulfillment_order.id, fulfillment_order.fulfillment_order.id
+        end
+      end
+    end
+
+    context "CancellationRequest" do
+      context "#new_cancellation_request" do
+        test 'be able to create a fulfillment order cancellation request' do
+          fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, :params => {:order_id => 450789469})
+
+          fake "orders/450789469/fulfillment_orders/519788021/cancellation_request", method: :post,
+            body: ActiveSupport::JSON.encode({ fulfillment_order: fulfillment_order, status: :ok })
+
+          assert fulfillment_order.new_cancellation_request(message: 'the message')
+
+          assert_equal 'ok', fulfillment_order.status
+          refute_nil fulfillment_order.fulfillment_order
+          assert_equal fulfillment_order.id, fulfillment_order.fulfillment_order.id
+        end
+      end
+
+      context "#accept_cancellation_request" do
+        should "be able to accept a fulfillment order cancellation request" do
+          fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, params: { order_id: 450789469 })
+
+          fake "orders/450789469/fulfillment_orders/519788021/cancellation_request/accept", method: :post,
+            body: ActiveSupport::JSON.encode({ fulfillment_order: fulfillment_order, status: :ok })
+
+          assert fulfillment_order.accept_cancellation_request
+
+          assert_equal 'ok', fulfillment_order.status
+          refute_nil fulfillment_order.fulfillment_order
+          assert_equal fulfillment_order.id, fulfillment_order.fulfillment_order.id
+        end
+      end
+
+      context "#reject_cancellation_request" do
+        should "be able to reject a fulfillment order cancellation request" do
+          fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021, params: { order_id: 450789469 })
+
+          fake "orders/450789469/fulfillment_orders/519788021/cancellation_request/reject", method: :post,
+            body: ActiveSupport::JSON.encode({ fulfillment_order: fulfillment_order, status: :ok })
+
+          assert fulfillment_order.reject_cancellation_request
+
+          assert_equal 'ok', fulfillment_order.status
+          refute_nil fulfillment_order.fulfillment_order
+          assert_equal fulfillment_order.id, fulfillment_order.fulfillment_order.id
+        end
       end
     end
   end


### PR DESCRIPTION
Issue [#211513](https://github.com/Shopify/shopify/issues/211513) make shopify_api FO compatible

Add `/orders/:order_id/fulfillment_orders` resource

Reviewers please carefully check the `move` endpoint test in particular for form of request query/body and response.