### PR TITLE
Make relative cursor based pagination work across page loads

### DIFF
--- a/lib/shopify_api/paginated_collection.rb
+++ b/lib/shopify_api/paginated_collection.rb
@@ -27,6 +27,14 @@ module ShopifyAPI
         fetch_page(@previous_url)
       end
 
+      def next_page_info
+        extract_page_info(@next_url)
+      end
+
+      def previous_page_info
+        extract_page_info(@previous_url)
+      end
+
       private
 
       AVAILABLE_IN_VERSION = ShopifyAPI::ApiVersion.find_version('2019-10')
@@ -49,6 +57,10 @@ module ShopifyAPI
         return if ShopifyAPI::Base.api_version >= AVAILABLE_IN_VERSION
         return if ShopifyAPI::Base.api_version >= AVAILABLE_IN_VERSION_EARLY && resource_class.early_july_pagination?
         raise NotImplementedError
+      end
+
+      def extract_page_info(url)
+        CGI.escape(Rack::Utils.parse_query(URI(url).query)['page_info']) if url.present?
       end
     end
 

--- a/test/pagination_test.rb
+++ b/test/pagination_test.rb
@@ -97,6 +97,20 @@ class PaginationTest < Test::Unit::TestCase
     refute orders.next_page?
   end
 
+  test "#next_page_info returns next_page_info if next page is present" do
+    fake 'orders', :method => :get, :status => 200, api_version: @version, :body => load_fixture('orders'), :link => @next_link_header
+    orders = ShopifyAPI::Order.all
+
+    assert_equal @next_page_info, orders.next_page_info
+  end
+
+  test "#next_page_info returns nil if next page is not present" do
+    fake 'orders', :method => :get, :status => 200, api_version: @version, :body => load_fixture('orders'), :link => @previous_link_header
+    orders = ShopifyAPI::Order.all
+
+    assert_nil orders.next_page_info
+  end
+
   test "#previous_page? returns true if previous page is present" do
     fake 'orders', :method => :get, :status => 200, api_version: @version, :body => load_fixture('orders'), :link => @previous_link_header
     orders = ShopifyAPI::Order.all
@@ -109,6 +123,20 @@ class PaginationTest < Test::Unit::TestCase
     orders = ShopifyAPI::Order.all
 
     refute orders.previous_page?
+  end
+
+  test "#previous_page_info returns previous_page_info if next page is present" do
+    fake 'orders', :method => :get, :status => 200, api_version: @version, :body => load_fixture('orders'), :link => @previous_link_header
+    orders = ShopifyAPI::Order.all
+
+    assert_equal @previous_page_info, orders.previous_page_info
+  end
+
+  test "#previous_page_info returns nil if next page is not present" do
+    fake 'orders', :method => :get, :status => 200, api_version: @version, :body => load_fixture('orders'), :link => @next_link_header
+    orders = ShopifyAPI::Order.all
+
+    assert_nil orders.previous_page_info
   end
 
   test "pagination handles no link headers" do


### PR DESCRIPTION
Extract `page_info` from `next_url` and `previous_url` to make cross relative cursor based pagination work across page loads.

Solving issue https://github.com/Shopify/shopify_api/issues/624