### PR TITLE
Add fulfillment order related read requests

### DIFF
--- a/lib/shopify_api/resources/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/resources/assigned_fulfillment_order.rb
@@ -1,0 +1,8 @@
+module ShopifyAPI
+  class AssignedFulfillmentOrder < Base
+    def self.all(options = {})
+      assigned_fulfillment_orders = super(options)
+      assigned_fulfillment_orders.map { |afo| FulfillmentOrder.new(afo.attributes) }
+    end
+  end
+end

--- a/lib/shopify_api/resources/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/resources/assigned_fulfillment_order.rb
@@ -1,7 +1,7 @@
 module ShopifyAPI
   class AssignedFulfillmentOrder < Base
-    def self.all(options = {})
-      assigned_fulfillment_orders = super(options)
+    def self.find(scope, *args)
+      assigned_fulfillment_orders = super(scope, *args)
       assigned_fulfillment_orders.map { |afo| FulfillmentOrder.new(afo.attributes) }
     end
   end

--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -1,0 +1,16 @@
+module ShopifyAPI
+  class FulfillmentOrder < Base
+    def self.all(options = {})
+      order_id = options.dig(:params, :order_id)
+      raise ShopifyAPI::ValidationException, "'order_id' is required" if order_id.nil? || order_id == ''
+
+      order = ::ShopifyAPI::Order.new(id: order_id)
+      order.fulfillment_orders
+    end
+
+    def fulfillments(options = {})
+      fulfillment_hashes = get(:fulfillments, options)
+      fulfillment_hashes.map { |fulfillment_hash| Fulfillment.new(fulfillment_hash) }
+    end
+  end
+end

--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -1,11 +1,15 @@
 module ShopifyAPI
   class FulfillmentOrder < Base
-    def self.all(options = {})
-      order_id = options.dig(:params, :order_id)
-      raise ShopifyAPI::ValidationException, "'order_id' is required" if order_id.nil? || order_id == ''
+    def self.find(scope, *args)
+      if scope == :all
+        order_id = args.first&.dig(:params, :order_id)
+        raise ShopifyAPI::ValidationException, "'order_id' is required" if order_id.blank?
 
-      order = ::ShopifyAPI::Order.new(id: order_id)
-      order.fulfillment_orders
+        order = ::ShopifyAPI::Order.new(id: order_id)
+        order.fulfillment_orders(args.first[:params].except(:order_id))
+      else
+        super(scope, *args)
+      end
     end
 
     def fulfillments(options = {})

--- a/lib/shopify_api/resources/order.rb
+++ b/lib/shopify_api/resources/order.rb
@@ -30,6 +30,11 @@ module ShopifyAPI
       Transaction.create(capture_transaction)
     end
 
+    def fulfillment_orders(options = {})
+      fulfillment_order_hashes = get(:fulfillment_orders, options)
+      fulfillment_order_hashes.map { |fulfillment_order_hash| FulfillmentOrder.new(fulfillment_order_hash) }
+    end
+
     class ClientDetails < Base
     end
   end

--- a/test/assigned_fulfillment_order_test.rb
+++ b/test/assigned_fulfillment_order_test.rb
@@ -1,0 +1,41 @@
+require 'test_helper'
+
+class AssignedFulFillmentOrderTest < Test::Unit::TestCase
+  context "AssignedFulfillmentOrder" do
+    context "#all" do
+      should "list assigned fulfillment orders by assigned_status" do
+        fulfillment_order_fixture = load_fixture('assigned_fulfillment_orders')
+        fake 'assigned_fulfillment_orders.json?assigned_status=cancellation_requested', method: :get,
+             body: fulfillment_order_fixture, extension: false
+
+        assigned_fulfillment_orders = ShopifyAPI::AssignedFulfillmentOrder.all(
+            params: { assigned_status: 'cancellation_requested' }
+        )
+
+        assert_equal 2, assigned_fulfillment_orders.count
+        assigned_fulfillment_orders.each do |fulfillment_order|
+          assert fulfillment_order.is_a?(ShopifyAPI::FulfillmentOrder)
+          assert_equal 'in_progress', fulfillment_order.status
+          assert_equal 'cancellation_accepted', fulfillment_order.request_status
+        end
+      end
+
+      should "be able to list assigned fulfillment orders by location_ids" do
+        fulfillment_order_fixture = load_fixture('assigned_fulfillment_orders')
+        assigned_location_id = 905684977
+        fake "assigned_fulfillment_orders.json?location_ids%5B%5D=#{assigned_location_id}", method: :get,
+             body: fulfillment_order_fixture, extension: false
+
+        assigned_fulfillment_orders = ShopifyAPI::AssignedFulfillmentOrder.all(
+            params: { location_ids: [assigned_location_id] }
+        )
+
+        assert_equal 2, assigned_fulfillment_orders.count
+        assigned_fulfillment_orders.each do |fulfillment_order|
+          assert fulfillment_order.is_a?(ShopifyAPI::FulfillmentOrder)
+          assert_equal assigned_location_id, fulfillment_order.assigned_location_id
+        end
+      end
+    end
+  end
+end

--- a/test/fixtures/assigned_fulfillment_orders.json
+++ b/test/fixtures/assigned_fulfillment_orders.json
@@ -1,0 +1,78 @@
+[
+   {
+      "id": 519788021,
+      "order_id": 450789469,
+      "fulfillment_service_handle": "shipwire",
+      "status": "in_progress",
+      "requires_shipping": true,
+      "is_not_deleted": true,
+      "deleted_at": null,
+      "created_at": "2016-07-12T11:23:42-04:00",
+      "updated_at": "2016-07-12T11:23:42-04:00",
+      "happened_at": "2016-07-12T11:23:42-04:00",
+      "assigned_location_id": 905684977,
+      "request_status": "cancellation_accepted",
+      "delivery_category": null,
+      "fulfillment_order_line_items": [
+         {
+            "id": 519788021,
+            "shop_id": 690933842,
+            "fulfillment_order_id": 519788021,
+            "line_item_id": 466157049,
+            "variant_id": 43729076,
+            "inventory_item_id": 808950810,
+            "inventory_commitment_id": 273471403,
+            "quantity": 1,
+            "sku": "IPOD2008GREEN",
+            "vendor": null,
+            "variant_title": "green",
+            "product_title": "IPod Nano - 8gb",
+            "pre_tax_price": 398.00,
+            "currency": "USD",
+            "properties": null,
+            "is_not_deleted": true,
+            "deleted_at": null,
+            "created_at": "2016-07-12T11:23:54-04:00",
+            "updated_at": "2016-07-12T11:23:54-04:00"
+         }
+      ]
+   },
+   {
+      "id": 519788022,
+      "order_id": 450789469,
+      "fulfillment_service_handle": "manual",
+      "status": "in_progress",
+      "requires_shipping": true,
+      "is_not_deleted": true,
+      "deleted_at": null,
+      "created_at": "2016-07-12T11:23:42-04:00",
+      "updated_at": "2016-07-12T11:23:42-04:00",
+      "happened_at": "2016-07-12T11:23:42-04:00",
+      "assigned_location_id": 905684977,
+      "request_status": "cancellation_accepted",
+      "delivery_category": null,
+      "fulfillment_order_line_items": [
+         {
+            "id": 519788021,
+            "shop_id": 690933842,
+            "fulfillment_order_id": 519788021,
+            "line_item_id": 466157049,
+            "variant_id": 43729076,
+            "inventory_item_id": 808950810,
+            "inventory_commitment_id": 273471403,
+            "quantity": 1,
+            "sku": "IPOD2008RED",
+            "vendor": null,
+            "variant_title": "red",
+            "product_title": "IPod Nano - 8gb",
+            "pre_tax_price": 398.00,
+            "currency": "USD",
+            "properties": null,
+            "is_not_deleted": true,
+            "deleted_at": null,
+            "created_at": "2016-07-12T11:23:54-04:00",
+            "updated_at": "2016-07-12T11:23:54-04:00"
+         }
+      ]
+   }
+]

--- a/test/fixtures/fulfillment_order.json
+++ b/test/fixtures/fulfillment_order.json
@@ -1,0 +1,38 @@
+{
+   "id": 519788021,
+   "order_id": 450789469,
+   "fulfillment_service_handle": "shipwire",
+   "status": "open",
+   "requires_shipping": true,
+   "is_not_deleted": true,
+   "deleted_at": null,
+   "created_at": "2016-07-12T11:23:42-04:00",
+   "updated_at": "2016-07-12T11:23:42-04:00",
+   "happened_at": "2016-07-12T11:23:42-04:00",
+   "assigned_location_id": 905684977,
+   "request_status": "unsubmitted",
+   "delivery_category": null,
+   "fulfillment_order_line_items": [
+      {
+         "id": 519788021,
+         "shop_id": 690933842,
+         "fulfillment_order_id": 519788021,
+         "line_item_id": 466157049,
+         "variant_id": 43729076,
+         "inventory_item_id": 808950810,
+         "inventory_commitment_id": 273471403,
+         "quantity": 1,
+         "sku": "IPOD2008GREEN",
+         "vendor": null,
+         "variant_title": "green",
+         "product_title": "IPod Nano - 8gb",
+         "pre_tax_price": 398.00,
+         "currency": "USD",
+         "properties": null,
+         "is_not_deleted": true,
+         "deleted_at": null,
+         "created_at": "2016-07-12T11:23:54-04:00",
+         "updated_at": "2016-07-12T11:23:54-04:00"
+      }
+   ]
+}

--- a/test/fixtures/fulfillment_orders.json
+++ b/test/fixtures/fulfillment_orders.json
@@ -1,0 +1,78 @@
+[
+   {
+      "id": 519788021,
+      "order_id": 450789469,
+      "fulfillment_service_handle": "shipwire",
+      "status": "open",
+      "requires_shipping": true,
+      "is_not_deleted": true,
+      "deleted_at": null,
+      "created_at": "2016-07-12T11:23:42-04:00",
+      "updated_at": "2016-07-12T11:23:42-04:00",
+      "happened_at": "2016-07-12T11:23:42-04:00",
+      "assigned_location_id": 905684977,
+      "request_status": "unsubmitted",
+      "delivery_category": null,
+      "fulfillment_order_line_items": [
+         {
+            "id": 519788021,
+            "shop_id": 690933842,
+            "fulfillment_order_id": 519788021,
+            "line_item_id": 466157049,
+            "variant_id": 43729076,
+            "inventory_item_id": 808950810,
+            "inventory_commitment_id": 273471403,
+            "quantity": 1,
+            "sku": "IPOD2008GREEN",
+            "vendor": null,
+            "variant_title": "green",
+            "product_title": "IPod Nano - 8gb",
+            "pre_tax_price": 398.00,
+            "currency": "USD",
+            "properties": null,
+            "is_not_deleted": true,
+            "deleted_at": null,
+            "created_at": "2016-07-12T11:23:54-04:00",
+            "updated_at": "2016-07-12T11:23:54-04:00"
+         }
+      ]
+   },
+   {
+      "id": 519788022,
+      "order_id": 450789469,
+      "fulfillment_service_handle": "manual",
+      "status": "open",
+      "requires_shipping": true,
+      "is_not_deleted": true,
+      "deleted_at": null,
+      "created_at": "2016-07-12T11:23:42-04:00",
+      "updated_at": "2016-07-12T11:23:42-04:00",
+      "happened_at": "2016-07-12T11:23:42-04:00",
+      "assigned_location_id": 905684977,
+      "request_status": "unsubmitted",
+      "delivery_category": null,
+      "fulfillment_order_line_items": [
+         {
+            "id": 519788021,
+            "shop_id": 690933842,
+            "fulfillment_order_id": 519788021,
+            "line_item_id": 466157049,
+            "variant_id": 43729076,
+            "inventory_item_id": 808950810,
+            "inventory_commitment_id": 273471403,
+            "quantity": 1,
+            "sku": "IPOD2008RED",
+            "vendor": null,
+            "variant_title": "red",
+            "product_title": "IPod Nano - 8gb",
+            "pre_tax_price": 398.00,
+            "currency": "USD",
+            "properties": null,
+            "is_not_deleted": true,
+            "deleted_at": null,
+            "created_at": "2016-07-12T11:23:54-04:00",
+            "updated_at": "2016-07-12T11:23:54-04:00"
+         }
+      ]
+   }
+]

--- a/test/fixtures/fulfillments.json
+++ b/test/fixtures/fulfillments.json
@@ -1,0 +1,53 @@
+[
+  {
+    "created_at": "2014-03-07T16:14:08-05:00",
+    "id": 255858046,
+    "order_id": 450789469,
+    "service": "manual",
+    "status": "failure",
+    "tracking_company": null,
+    "updated_at": "2014-03-07T16:14:08-05:00",
+    "tracking_number": "1Z2345",
+    "tracking_numbers": [
+      "1Z2345"
+    ],
+    "tracking_url": "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track",
+    "tracking_urls": [
+      "http://wwwapps.ups.com/etracking/tracking.cgi?InquiryNumber1=1Z2345&TypeOfInquiryNumber=T&AcceptUPSLicenseAgreement=yes&submit=Track"
+    ],
+    "receipt": {
+      "testcase": true,
+      "authorization": "123456"
+    },
+    "line_items": [
+      {
+        "fulfillment_service": "manual",
+        "fulfillment_status": null,
+        "grams": 200,
+        "id": 466157049,
+        "price": "199.00",
+        "product_id": 632910392,
+        "quantity": 1,
+        "requires_shipping": true,
+        "sku": "IPOD2008GREEN",
+        "taxable": true,
+        "title": "IPod Nano - 8gb",
+        "variant_id": 39072856,
+        "variant_title": "green",
+        "vendor": null,
+        "name": "IPod Nano - 8gb - green",
+        "variant_inventory_management": "shopify",
+        "properties": [
+          {
+            "name": "Custom Engraving",
+            "value": "Happy Birthday"
+          }
+        ],
+        "product_exists": true,
+        "tax_lines": [
+
+        ]
+      }
+    ]
+  }
+]

--- a/test/fulfillment_order_test.rb
+++ b/test/fulfillment_order_test.rb
@@ -5,6 +5,9 @@ class FulFillmentOrderTest < Test::Unit::TestCase
     super
     fake "fulfillment_orders/519788021", method: :get,
       body: load_fixture('fulfillment_order')
+
+    fake "orders/450789469/fulfillment_orders", method: :get,
+      body: load_fixture('fulfillment_orders')
   end
 
   context "FulfillmentOrder" do

--- a/test/fulfillment_order_test.rb
+++ b/test/fulfillment_order_test.rb
@@ -1,0 +1,58 @@
+require 'test_helper'
+
+class FulFillmentOrderTest < Test::Unit::TestCase
+  def setup
+    super
+    fake "fulfillment_orders/519788021", method: :get,
+      body: load_fixture('fulfillment_order')
+  end
+
+  context "FulfillmentOrder" do
+    context "#find" do
+      should "be able to find fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021)
+        assert fulfillment_order.is_a?(ShopifyAPI::FulfillmentOrder)
+        assert_equal 519788021, fulfillment_order.id
+        assert_equal 450789469, fulfillment_order.order_id
+      end
+    end
+
+    context "#all" do
+      should "be able to list fulfillment orders for an order" do
+        fake 'orders/450789469/fulfillment_orders', method: :get, body: load_fixture('fulfillment_orders')
+
+        fulfillment_orders = ShopifyAPI::FulfillmentOrder.all(
+          params: { order_id: 450789469 }
+        )
+
+        assert_equal [519788021, 519788022], fulfillment_orders.map(&:id).sort
+        fulfillment_orders.each do |fulfillment_order|
+          assert fulfillment_order.is_a?(ShopifyAPI::FulfillmentOrder)
+          assert_equal 450789469, fulfillment_order.order_id
+        end
+      end
+
+      should "require order_id" do
+        assert_raises ShopifyAPI::ValidationException do
+          ShopifyAPI::FulfillmentOrder.all
+        end
+      end
+    end
+
+    context "#fulfillments" do
+      should "be able to list fulfillments for a fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021)
+
+        fake "fulfillment_orders/#{fulfillment_order.id}/fulfillments", method: :get,
+             body: load_fixture('fulfillments')
+
+        fulfillments = fulfillment_order.fulfillments
+
+        assert_equal 1, fulfillments.count
+        fulfillment = fulfillments.first
+        assert fulfillment.is_a?(ShopifyAPI::Fulfillment)
+        assert_equal 450789469, fulfillment.order_id
+      end
+    end
+  end
+end

--- a/test/order_test.rb
+++ b/test/order_test.rb
@@ -72,4 +72,18 @@ class OrderTest < Test::Unit::TestCase
       },
     }.to_json)
   end
+
+  test "fulfillment_orders should get fulfillment orders for an order" do
+    fake 'orders/450789469', body: load_fixture('order')
+    order = ShopifyAPI::Order.find(450789469)
+
+    fake 'orders/450789469/fulfillment_orders', method: :get, body: load_fixture('fulfillment_orders')
+    fulfillment_orders = order.fulfillment_orders
+
+    assert_equal [519788021, 519788022], fulfillment_orders.map(&:id).sort
+    fulfillment_orders.each do |fulfillment_order|
+      assert fulfillment_order.is_a?(ShopifyAPI::FulfillmentOrder)
+      assert_equal 450789469, fulfillment_order.order_id
+    end
+  end
 end


### PR DESCRIPTION
This PR adds the following read requests:
- GET orders/:order_id/fulfillment_orders
- GET assigned_fulfillment_orders
- GET fulfillment_orders/:fulfillment_order_id
- GET fulfillment_orders/:fulfillment_order_id/fulfillments

Subsequent PRs will add fulfillment order related write requests to relevant resources.

The approach I took was pretty straight forward with the following notable choices:
- the resources returned via `AssignedFulfillmentOrder` are converted to `FulfillmentOrder` type so that subsequent actions defined on FulfillmentOrder may be used
- the `fulfillments` method on FulfillmentOrder will get the related fulfillments