### PR TITLE
Fulfillment orders fulfillment cancellation request

### DIFF
--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -43,6 +43,63 @@ module ShopifyAPI
       load_attributes_from_response(post(:close, {}, body.to_json))
     end
 
+    def request_fulfillment(fulfillment_order_line_items: nil, message: nil)
+      body = {
+        fulfillment_request: {
+          fulfillment_order_line_items: fulfillment_order_line_items,
+          message: message
+        }
+      }
+      keyed_fulfillment_orders = keyed_fulfillment_orders_from_response(post(:fulfillment_request, {}, body.to_json))
+      load_keyed_fulfillment_order(keyed_fulfillment_orders, 'original_fulfillment_order')
+      keyed_fulfillment_orders
+    end
+
+    def accept_fulfillment_request(message: nil)
+      body = {
+        fulfillment_request: {
+          message: message
+        }
+      }
+      load_attributes_from_response(post('fulfillment_request/accept', {}, body.to_json))
+    end
+
+    def reject_fulfillment_request(message: nil)
+      body = {
+        fulfillment_request: {
+          message: message
+        }
+      }
+      load_attributes_from_response(post('fulfillment_request/reject', {}, body.to_json))
+    end
+
+    def request_cancellation(message: nil)
+      body = {
+        cancellation_request: {
+          message: message
+        }
+      }
+      load_attributes_from_response(post(:cancellation_request, {}, body.to_json))
+    end
+
+    def accept_cancellation_request(message: nil)
+      body = {
+        cancellation_request: {
+          message: message
+        }
+      }
+      load_attributes_from_response(post('cancellation_request/accept', {}, body.to_json))
+    end
+
+    def reject_cancellation_request(message: nil)
+      body = {
+        cancellation_request: {
+          message: message
+        }
+      }
+      load_attributes_from_response(post('cancellation_request/reject', {}, body.to_json))
+    end
+
     private
 
     def load_keyed_fulfillment_order(keyed_fulfillment_orders, key)


### PR DESCRIPTION
This PR adds the following POST requests:

POST fulfillment_orders/:fulfillment_order_id/fulfillment_request
POST fulfillment_orders/:fulfillment_order_id/fulfillment_request/accept
POST fulfillment_orders/:fulfillment_order_id/fulfillment_request/reject

POST fulfillment_orders/:fulfillment_order_id/cancellation_request
POST fulfillment_orders/:fulfillment_order_id/cancellation_request/accept
POST fulfillment_orders/:fulfillment_order_id/cancellation_request/reject

GET requests are in PR #633
Actions move, cancel, close for fulfillment orders are in PR #635
Subsequent PRs will add other fulfillment order related POST requests to relevant resources.

Since all that's really needed is the `fulfillment_order_id`, if it's known you can do (rather than querying it first):
```
  FulfillmentOrder.new(id: <the-fo-id>).fulfillment_request(<params>)
```

Note to reviewer:

- when the endpoint returns a single resource, it is loaded into the current resource and `true` is returned if the request is ok
- when the endpoint returns multiple keyed resources (e.g. original_fulfillment_order, submitted_fulfillment_order, unsubmitted_fulfillment_order) the return value is a hash of the multiple resources keyed by the names. Is it conventional to reload the current resource with one of these as well?