### PR TITLE
Add save, update_tracking, and cancel actions to FulfillmentOrderFulfillment resource

### DIFF
--- a/lib/shopify_api/resources/fulfillment.rb
+++ b/lib/shopify_api/resources/fulfillment.rb
@@ -9,5 +9,39 @@ module ShopifyAPI
     def cancel; load_attributes_from_response(post(:cancel, {}, only_id)); end
     def complete; load_attributes_from_response(post(:complete, {}, only_id)); end
     def open; load_attributes_from_response(post(:open, {}, only_id)); end
+
+    def order_id=(order_id)
+      prefix_options[:order_id] = order_id
+    end
+
+    def load(attributes, remove_root = false, persisted = false)
+      order_id = attributes['order_id']
+      prefix_options[:order_id] = order_id if order_id
+      super(attributes, remove_root, persisted)
+    end
+
+    def save
+      if prefix_options[:order_id].present?
+        super
+      else
+        line_items = attributes['line_items_by_fulfillment_order'] || attributes[:line_items_by_fulfillment_order]
+        if line_items.blank?
+          raise ShopifyAPI::ValidationException,
+                "either 'line_items_by_fulfillment_order' or prefix_options[:order_id] is required"
+        end
+
+        fulfillmentV2 = FulfillmentV2.new(attributes)
+        result = fulfillmentV2.save
+        load(fulfillmentV2.attributes, false, true)
+        result
+      end
+    end
+
+    def update_tracking(tracking_info:, notify_customer:)
+      fulfillmentV2 = FulfillmentV2.new(attributes)
+      result = fulfillmentV2.update_tracking(tracking_info: tracking_info, notify_customer: notify_customer)
+      load(fulfillmentV2.attributes, false, true)
+      result
+    end
   end
 end

--- a/lib/shopify_api/resources/fulfillment_v2.rb
+++ b/lib/shopify_api/resources/fulfillment_v2.rb
@@ -1,0 +1,15 @@
+module ShopifyAPI
+  class FulfillmentV2 < Base
+    self.element_name = 'fulfillment'
+
+    def update_tracking(tracking_info:, notify_customer:)
+      body = {
+        fulfillment: {
+          tracking_info: tracking_info,
+          notify_customer: notify_customer
+        }
+      }
+      load_attributes_from_response(post(:update_tracking, {}, body.to_json))
+    end
+  end
+end

--- a/test/fulfillment_test.rb
+++ b/test/fulfillment_test.rb
@@ -56,6 +56,127 @@ class FulFillmentTest < Test::Unit::TestCase
         assert_equal 450789469, fulfillment.order_id
       end
     end
-  end
 
+    context "#create" do
+      should "create a fulfillment with line_items_by_fulfillment_order" do
+        create_fulfillment_attributes = {
+          message: "The message for this FO fulfillment",
+          notify_customer: true,
+          tracking_info: {
+            number: "XSDFHYR23475",
+            url: "https://tracking.example.com/XSDFHYR23475",
+            company: "TFTC - the fulfillment/tracking company"
+          },
+          line_items_by_fulfillment_order: [
+            {
+              fulfillment_order_id: 3,
+              fulfillment_order_line_items: [{ id: 2, quantity: 1 }]
+            }
+          ]
+        }
+        request_body = { fulfillment: create_fulfillment_attributes }
+        response_body = { fulfillment: create_fulfillment_attributes.merge(id: 346743624) }
+        fake "fulfillments", :method => :post,
+          request_body: ActiveSupport::JSON.encode(request_body),
+          body: ActiveSupport::JSON.encode(response_body)
+
+        fulfillment = ShopifyAPI::Fulfillment.create(create_fulfillment_attributes)
+        assert fulfillment.is_a?(ShopifyAPI::Fulfillment)
+        assert fulfillment.persisted?
+        assert_equal 346743624, fulfillment.id
+      end
+    end
+
+    context "#save" do
+      should "save a fulfillment with line_items_by_fulfillment_order" do
+        create_fulfillment_attributes = {
+          message: "The message for this FO fulfillment",
+          notify_customer: true,
+          tracking_info: {
+            number: "XSDFHYR23475",
+            url: "https://tracking.example.com/XSDFHYR23475",
+            company: "TFTC - the fulfillment/tracking company"
+          },
+          line_items_by_fulfillment_order: [
+            {
+              fulfillment_order_id: 3,
+              fulfillment_order_line_items: [{ id: 2, quantity: 1 }]
+            }
+          ]
+        }
+        request_body = { fulfillment: create_fulfillment_attributes }
+        response_body = { fulfillment: create_fulfillment_attributes.merge(id: 346743624) }
+        fake "fulfillments", :method => :post,
+          request_body: ActiveSupport::JSON.encode(request_body),
+          body: ActiveSupport::JSON.encode(response_body)
+
+        fulfillment = ShopifyAPI::Fulfillment.new(create_fulfillment_attributes)
+        assert fulfillment.save
+        assert fulfillment.is_a?(ShopifyAPI::Fulfillment)
+        assert fulfillment.persisted?
+        assert_equal 346743624, fulfillment.id
+      end
+
+      should "save a fulfillment without line_items_by_fulfillment_order" do
+        order_id = 8
+        create_fulfillment_attributes = {
+          message: "The message for this FO fulfillment",
+          notify_customer: true,
+          tracking_info: {
+            number: "XSDFHYR23475",
+            url: "https://tracking.example.com/XSDFHYR23475",
+            company: "TFTC - the fulfillment/tracking company"
+          }
+        }
+        request_body = { fulfillment: create_fulfillment_attributes }
+        response_body = { fulfillment: create_fulfillment_attributes.merge(id: 346743624) }
+        fake "orders/#{order_id}/fulfillments", :method => :post,
+          request_body: ActiveSupport::JSON.encode(request_body),
+          body: ActiveSupport::JSON.encode(response_body)
+
+        fulfillment = ShopifyAPI::Fulfillment.new(create_fulfillment_attributes)
+        fulfillment.prefix_options[:order_id] = order_id
+
+        assert fulfillment.save
+        assert fulfillment.is_a?(ShopifyAPI::Fulfillment)
+        assert fulfillment.persisted?
+        assert_equal 346743624, fulfillment.id
+      end
+    end
+
+    context "#update_tracking" do
+      should "be able to update tracking info for a fulfillment" do
+        tracking_info = {
+          number: 'JSDHFHAG',
+          url: 'https://example.com/fulfillment_tracking/JSDHFHAG',
+          company: 'ACME co',
+        }
+        fake_fulfillment = ActiveSupport::JSON.decode(load_fixture('fulfillment'))['fulfillment']
+        fake_fulfillment['tracking_number'] = tracking_info[:number]
+        fake_fulfillment['tracking_numbers'] = [tracking_info[:number]]
+        fake_fulfillment['tracking_url'] = tracking_info[:url]
+        fake_fulfillment['tracking_urls'] = [tracking_info[:url]]
+        fake_fulfillment['tracking_company'] = tracking_info[:company]
+
+        request_body = {
+          fulfillment: {
+            tracking_info: tracking_info,
+            notify_customer: true
+          }
+        }
+        fake "fulfillments/#{fake_fulfillment['id']}/update_tracking", method: :post,
+          request_body: ActiveSupport::JSON.encode(request_body),
+          body: ActiveSupport::JSON.encode(fulfillment: fake_fulfillment)
+
+        fulfillment = ShopifyAPI::Fulfillment.new(id: fake_fulfillment['id'])
+        assert fulfillment.update_tracking(tracking_info: tracking_info, notify_customer: true)
+
+        assert_equal tracking_info[:number], fulfillment.tracking_number
+        assert_equal [tracking_info[:number]], fulfillment.tracking_numbers
+        assert_equal tracking_info[:url], fulfillment.tracking_url
+        assert_equal [tracking_info[:url]], fulfillment.tracking_urls
+        assert_equal tracking_info[:company], fulfillment.tracking_company
+      end
+    end
+  end
 end

--- a/test/fulfillment_v2_test.rb
+++ b/test/fulfillment_v2_test.rb
@@ -1,0 +1,40 @@
+require 'test_helper'
+
+class FulfillmentV2Test < Test::Unit::TestCase
+  context "FulfillmentV2" do
+    context "#update_tracking" do
+      should "be able to update tracking info for a fulfillment" do
+        tracking_info = {
+          number: 'JSDHFHAG',
+          url: 'https://example.com/fulfillment_tracking/JSDHFHAG',
+          company: 'ACME co',
+        }
+        fake_fulfillment = ActiveSupport::JSON.decode(load_fixture('fulfillment'))['fulfillment']
+        fake_fulfillment['tracking_number'] = tracking_info[:number]
+        fake_fulfillment['tracking_numbers'] = [tracking_info[:number]]
+        fake_fulfillment['tracking_url'] = tracking_info[:url]
+        fake_fulfillment['tracking_urls'] = [tracking_info[:url]]
+        fake_fulfillment['tracking_company'] = tracking_info[:company]
+
+        request_body = {
+          fulfillment: {
+            tracking_info: tracking_info,
+            notify_customer: true
+          }
+        }
+        fake "fulfillments/#{fake_fulfillment['id']}/update_tracking", method: :post,
+          request_body: ActiveSupport::JSON.encode(request_body),
+          body: ActiveSupport::JSON.encode(fulfillment: fake_fulfillment)
+
+        fulfillment = ShopifyAPI::FulfillmentV2.new(id: fake_fulfillment['id'])
+        assert fulfillment.update_tracking(tracking_info: tracking_info, notify_customer: true)
+
+        assert_equal tracking_info[:number], fulfillment.tracking_number
+        assert_equal [tracking_info[:number]], fulfillment.tracking_numbers
+        assert_equal tracking_info[:url], fulfillment.tracking_url
+        assert_equal [tracking_info[:url]], fulfillment.tracking_urls
+        assert_equal tracking_info[:company], fulfillment.tracking_company
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR adds the following POST requests:

POST fulfillments (via FulfillmentOrderFulfillment.save)
POST fulfillments/:fulfillment_id/update_tracking
POST fulfillments/:fulfillment_id/cancel

GET requests are in PR #633
FulfillmentOrder actions move, cancel, close are in PR #635
FulfillmentOrder actions fulfillment_request (+ accept/reject), cancellation_request (+ accept/reject) are in PR #637
Subsequent PRs will add other fulfillment order related requests to relevant resources.

Since all that's really needed is the `fulfillment_id`, if it's known you can do (rather than querying it first):
```
  FulfillmentOrderFulfillment.new(id: <the-fulfillment-id>).update_tracking(<params>)
```

Notes to reviewer:

- there's already a `Fulfillment` resource which I haven't yet determined is the same/compatible with FO fulfillments so created a new resource FulfillmentOrderFulfillment
- the specific statuses used in the tests may not make logical sense in terms of fulfillment order/fulfillment lifecycle. the tests do verify proper request dispatching and serialization