### PR TITLE
Add validation and tests for deprecation of product and variant inventory-related fields

### DIFF
--- a/lib/shopify_api/resources/product.rb
+++ b/lib/shopify_api/resources/product.rb
@@ -16,6 +16,15 @@ module ShopifyAPI
       end
     end
 
+    def total_inventory=(new_value)
+      raise_deprecated_inventory_call('total_inventory') unless allow_inventory_params?
+      super
+    end
+
+    def serializable_hash(options = {})
+      allow_inventory_params? ? super(options) : super(options).except('total_inventory')
+    end
+
     def collections
       CustomCollection.find(:all, :params => {:product_id => self.id})
     end
@@ -30,6 +39,18 @@ module ShopifyAPI
 
     def remove_from_collection(collection)
       collection.remove_product(self)
+    end
+
+    private
+
+    def raise_deprecated_inventory_call(parameter)
+      raise(ShopifyAPI::ValidationException,
+        "'#{parameter}' is deprecated - see https://help.shopify.com/en/api/guides/inventory-migration-guide",
+        )
+    end
+
+    def allow_inventory_params?
+      Base.api_version < ApiVersion.find_version('2019-10')
     end
   end
 end

--- a/lib/shopify_api/resources/variant.rb
+++ b/lib/shopify_api/resources/variant.rb
@@ -4,5 +4,36 @@ module ShopifyAPI
     include DisablePrefixCheck
 
     conditional_prefix :product
+
+    def inventory_quantity_adjustment=(new_value)
+      raise_deprecated_inventory_call('inventory_quantity_adjustment') unless allow_inventory_params?
+      super
+    end
+
+    def inventory_quantity=(new_value)
+      raise_deprecated_inventory_call('inventory_quantity') unless allow_inventory_params?
+      super
+    end
+
+    def old_inventory_quantity=(new_value)
+      raise_deprecated_inventory_call('old_inventory_quantity') unless allow_inventory_params?
+      super
+    end
+
+    def serializable_hash(options = {})
+      allow_inventory_params? ? super(options) : super(options).except('inventory_quantity', 'old_inventory_quantity')
+    end
+
+    private
+
+    def raise_deprecated_inventory_call(parameter)
+      raise(ShopifyAPI::ValidationException,
+        "'#{parameter}' is deprecated - see https://help.shopify.com/en/api/guides/inventory-migration-guide",
+        )
+    end
+
+    def allow_inventory_params?
+      Base.api_version < ApiVersion.find_version('2019-10')
+    end
   end
 end

--- a/test/product_test.rb
+++ b/test/product_test.rb
@@ -57,4 +57,43 @@ class ProductTest < Test::Unit::TestCase
 
     assert_equal('100.00 - 199.00', @product.price_range)
   end
+
+  def test_deprecated_variant_inventory_fields_are_included_in_2019_07
+    ShopifyAPI::Base.api_version = '2019-07'
+    variant = @product.variants.first
+    assert variant.as_json.include?('inventory_quantity')
+  end
+
+  def test_deprecated_variant_inventory_fields_are_removed_in_2020_01
+    ShopifyAPI::Base.api_version = '2020-01'
+    variant = @product.variants.first
+    refute variant.as_json.include?('inventory_quantity')
+  end
+
+  def test_deprecated_inventory_fields_are_removed_in_2020_01
+    ShopifyAPI::Base.api_version = '2020-01'
+    refute @product.as_json.include?('total_inventory')
+  end
+
+  def test_setting_product_total_inventory_passes_in_api_before_2019_10
+    ShopifyAPI::Base.api_version = '2019-07'
+    fake("products/632910392", {:body => load_fixture('product')})
+    @product.total_inventory = 8
+  end
+
+  def test_setting_product_total_inventory_fails_in_2019_10_api
+    ShopifyAPI::Base.api_version = '2019-10'
+    fake("products/632910392", {:body => load_fixture('product')})
+    assert_raises(ShopifyAPI::ValidationException) do
+      @product.total_inventory = 8
+    end
+  end
+
+  def test_setting_product_total_inventory_fails_in_the_unstable_api
+    ShopifyAPI::Base.api_version = :unstable
+    fake("products/632910392", {:body => load_fixture('product')})
+    assert_raises(ShopifyAPI::ValidationException) do
+      @product.total_inventory = 8
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -96,7 +96,7 @@ module Test
         body   = options.has_key?(:body) ? options.delete(:body) : load_fixture(endpoint)
         format = options.delete(:format) || :json
         method = options.delete(:method) || :get
-        api_version = options.delete(:api_version) || ShopifyAPI::ApiVersion.find_version('2019-01')
+        api_version = options.delete(:api_version) || ShopifyAPI::Base.api_version
         extension = ".#{options.delete(:extension)||'json'}" unless options[:extension]==false
         status = options.delete(:status) || 200
         url = if options.has_key?(:url)

--- a/test/variant_test.rb
+++ b/test/variant_test.rb
@@ -43,4 +43,93 @@ class VariantTest < Test::Unit::TestCase
     v = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
     assert v.destroy
   end
+
+  def test_deprecated_inventory_fields_are_included_in_2019_07
+    ShopifyAPI::Base.api_version = '2019-07'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert variant.as_json.include?('inventory_quantity')
+  end
+
+  def test_deprecated_inventory_fields_are_removed_in_2020_01
+    ShopifyAPI::Base.api_version = '2020-01'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    refute variant.as_json.include?('inventory_quantity')
+  end
+
+  def test_setting_variant_inventory_quantity_adjustment_passes_in_api_before_2019_10
+    ShopifyAPI::Base.api_version = '2019-07'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    variant.inventory_quantity_adjustment = 8
+  end
+
+  def test_setting_variant_inventory_quantity_adjustment_fails_in_2019_10_api
+    ShopifyAPI::Base.api_version = '2019-10'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert_raises(ShopifyAPI::ValidationException) do
+      variant.inventory_quantity_adjustment = 8
+    end
+  end
+
+  def test_setting_variant_inventory_quantity_adjustment_fails_in_the_unstable_api
+    ShopifyAPI::Base.api_version = :unstable
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert_raises(ShopifyAPI::ValidationException) do
+      variant.inventory_quantity_adjustment = 8
+    end
+  end
+
+  def test_setting_variant_inventory_quantity_passes_in_api_before_2019_10
+    ShopifyAPI::Base.api_version = '2019-07'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    variant.inventory_quantity = 8
+  end
+
+  def test_setting_variant_inventory_quantity_fails_in_2019_10_api
+    ShopifyAPI::Base.api_version = '2019-10'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert_raises(ShopifyAPI::ValidationException) do
+      variant.inventory_quantity = 8
+    end
+  end
+
+  def test_setting_variant_inventory_quantity_fails_in_the_unstable_api
+    ShopifyAPI::Base.api_version = :unstable
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert_raises(ShopifyAPI::ValidationException) do
+      variant.inventory_quantity = 8
+    end
+  end
+
+  def test_setting_variant_old_inventory_quantity_passes_in_api_before_2019_10
+    ShopifyAPI::Base.api_version = '2019-07'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    variant.old_inventory_quantity = 8
+  end
+
+  def test_setting_variant_old_inventory_quantity_fails_in_2019_10_api
+    ShopifyAPI::Base.api_version = '2019-10'
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert_raises(ShopifyAPI::ValidationException) do
+      variant.old_inventory_quantity = 8
+    end
+  end
+
+  def test_setting_variant_old_inventory_quantity_fails_in_the_unstable_api
+    ShopifyAPI::Base.api_version = :unstable
+    fake "products/632910392/variants/808950810", :method => :get, :body => load_fixture('variant')
+    variant = ShopifyAPI::Variant.find(808950810, :params => {:product_id => 632910392})
+    assert_raises(ShopifyAPI::ValidationException) do
+      variant.old_inventory_quantity = 8
+    end
+  end
 end


### PR DESCRIPTION
fixes #632

The following fields on Product (`total_inventory`) and Variant (`inventory_quantity_adjustment`, `inventory_quantity`, `old_inventory_quantity`) were deprecated earlier this year and were removed in the 2019-10 api version.

This PR updates the code and adds tests to ensure the behaviour is correct. 

Reviewer's note: In `test/test_helper.rb` I changed the code to return the current API version if none was specified. The old code returned the Jan 2019 version. I believe this new behaviour is correct but would like confirmation.
