### PR TITLE
Release 2020-01 Collections#products

### DIFF
--- a/lib/shopify_api/resources/collection.rb
+++ b/lib/shopify_api/resources/collection.rb
@@ -6,7 +6,7 @@ module ShopifyAPI
     include Metafields
 
     def products(options = {})
-      available_in_version = ShopifyAPI::ApiVersion.find_version(:unstable)
+      available_in_version = ShopifyAPI::ApiVersion.find_version('2020-01')
       raise NotImplementedError unless ShopifyAPI::Base.api_version >= available_in_version
       Product.find(:all, from: "#{self.class.prefix}collections/#{id}/products.json", params: options)
     end

--- a/test/collection_test.rb
+++ b/test/collection_test.rb
@@ -1,13 +1,13 @@
 require 'test_helper'
 
 class CollectionTest < Test::Unit::TestCase
-  test "Collection get products gets all products in a collection on unstable version" do
-    unstable_version = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: :unstable)
-    ShopifyAPI::Base.activate_session(unstable_version)
+  test "Collection get products gets all products in a collection on 2020-01 version" do
+    available_version = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: '2020-01')
+    ShopifyAPI::Base.activate_session(available_version)
 
     fake(
         'collections',
-        url: 'https://shop2.myshopify.com/admin/api/unstable/collections/1.json',
+        url: 'https://shop2.myshopify.com/admin/api/2020-01/collections/1.json',
         method: :get,
         status: 200,
         body: load_fixture('collection'),
@@ -18,7 +18,7 @@ class CollectionTest < Test::Unit::TestCase
 
     fake(
         'products',
-        url: 'https://shop2.myshopify.com/admin/api/unstable/collections/1/products.json',
+        url: 'https://shop2.myshopify.com/admin/api/2020-01/collections/1/products.json',
         method: :get,
         status: 200,
         body: load_fixture('collection_products'),
@@ -28,12 +28,12 @@ class CollectionTest < Test::Unit::TestCase
   end
 
   test "Collection get products fails on older api version" do
-    unstable_version = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: '2019-07')
-    ShopifyAPI::Base.activate_session(unstable_version)
+    old_version = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: '2019-10')
+    ShopifyAPI::Base.activate_session(old_version)
 
     fake(
         'collections',
-        url: 'https://shop2.myshopify.com/admin/api/2019-07/collections/1.json',
+        url: 'https://shop2.myshopify.com/admin/api/2019-10/collections/1.json',
         method: :get,
         status: 200,
         body: load_fixture('collection'),


### PR DESCRIPTION
Release the endpoint `Collections#products` in the 2020-01 REST ADMIN API version.

https://help.shopify.com/en/api/reference/products/collection?api[version]=2020-01

Depends on https://github.com/Shopify/shopify_api/pull/656