### PR TITLE
Package release for 8.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+== Version 8.1.0
+
+* Release 2020-01 REST ADMIN API VERSION [#656](https://github.com/Shopify/shopify_api/pull/656)
+* Release new Endpoint `collection.products` and `collection.find()` in 2020-01 REST API version [#657](https://github.com/Shopify/shopify_api/pull/657)
 * Enrich 4xx errors with error message from response body [#647](https://github.com/Shopify/shopify_api/pull/647)
 
 == Version 8.0.0

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "8.0.0"
+  VERSION = "8.1.0"
 end


### PR DESCRIPTION
Packaging for release 8.1.0:

- Release 2020-01 Collections#products #657
https://github.com/Shopify/shopify_api/pull/657
- Release 2020-01 REST ADMIN API VERSION https://github.com/Shopify/shopify_api/pull/656
- Enrich 4xx error message with error text from response.body #647 https://github.com/Shopify/shopify_api/pull/647

