### PR TITLE
Add locations_for_move API

### DIFF
--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -17,6 +17,14 @@ module ShopifyAPI
       fulfillment_hashes.map { |fulfillment_hash| Fulfillment.new(fulfillment_hash) }
     end
 
+    def locations_for_move
+      locations_for_move_hashes = get(:locations_for_move, {})
+
+      locations_for_move_hashes.map do |locations_for_move_hash|
+        FulfillmentOrderLocationsForMove.new(locations_for_move_hash)
+      end
+    end
+
     def move(new_location_id:)
       body = {
         fulfillment_order: {

--- a/lib/shopify_api/resources/fulfillment_order_locations_for_move.rb
+++ b/lib/shopify_api/resources/fulfillment_order_locations_for_move.rb
@@ -1,0 +1,4 @@
+module ShopifyAPI
+  class FulfillmentOrderLocationsForMove < Base
+  end
+end

--- a/test/fixtures/fulfillment_order_locations_for_move.json
+++ b/test/fixtures/fulfillment_order_locations_for_move.json
@@ -1,0 +1,18 @@
+[
+  {
+    "location": {
+      "id": 1059367776,
+      "name": "Alpha Location"
+    },
+    "message": "Current location.",
+    "movable": false
+  },
+  {
+    "location": {
+      "id": 1059367777,
+      "name": "Bravo Location"
+    },
+    "message": "No items are stocked at this location.",
+    "movable": false
+  }
+]

--- a/test/fulfillment_order_test.rb
+++ b/test/fulfillment_order_test.rb
@@ -57,6 +57,24 @@ class FulFillmentOrderTest < Test::Unit::TestCase
       end
     end
 
+    context "#locations_for_move" do
+      should "be able to list locations for a fulfillment order" do
+        fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021)
+        fake "fulfillment_orders/#{fulfillment_order.id}/locations_for_move", method: :get,
+          body: load_fixture('fulfillment_order_locations_for_move')
+
+        locations_for_move = fulfillment_order.locations_for_move
+
+        assert_equal 2, locations_for_move.count
+        location_for_move = locations_for_move.first
+        assert location_for_move.is_a?(ShopifyAPI::FulfillmentOrderLocationsForMove)
+
+        location = location_for_move.location
+        assert location.is_a?(ShopifyAPI::Location)
+        assert_equal 1059367776,location.id
+      end
+    end
+
     context "#move" do
       should "move a fulfillment order to a new_location_id" do
         fulfillment_order = ShopifyAPI::FulfillmentOrder.find(519788021)


### PR DESCRIPTION
Closes: https://github.com/Shopify/shopify/issues/211513

This PR is to implement the API for REST API:
_GET fulfillment_orders/:fulfillment_order_id/locations_for_move_
