### PR TITLE
Added options hash to create_permission_url and makes redirect_uri required

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,17 +192,16 @@ ShopifyAPI uses ActiveResource to communicate with the REST web service. ActiveR
    shopify_session = ShopifyAPI::Session.new(domain: "SHOP_NAME.myshopify.com", api_version: api_version, token: nil)
    ```
 
-   Then call:
-
-   ```ruby
-   scope = ["write_products"]
-   permission_url = shopify_session.create_permission_url(scope)
-   ```
-
-   or if you want a custom redirect_uri:
+   Then call `create_permission_url` with the redirect_uri you've registered for your application:
 
    ```ruby
    permission_url = shopify_session.create_permission_url(scope, "https://my_redirect_uri.com")
+   ```
+
+   You can also pass a state parameter in the options hash as a last argument:
+
+   ```ruby
+   permission_url = shopify_session.create_permission_url(scope, "https://my_redirect_uri.com", { state: "My Nonce" })
    ```
 
 4. Once authorized, the shop redirects the owner to the return URL of your application with a parameter named 'code'. This is a temporary token that the app can exchange for a permanent access token.

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -91,9 +91,9 @@ module ShopifyAPI
       self.extra = extra
     end
 
-    def create_permission_url(scope, redirect_uri = nil)
-      params = {:client_id => api_key, :scope => scope.join(',')}
-      params[:redirect_uri] = redirect_uri if redirect_uri
+    def create_permission_url(scope, redirect_uri, options = {})
+      params = { client_id: api_key, scope: scope.join(','), redirect_uri: redirect_uri }
+      params[:state] = options[:state] if options[:state]
       construct_oauth_url("authorize", params)
     end
 


### PR DESCRIPTION
Fixes https://github.com/Shopify/shopify_api/issues/466

A re-attempt at the solution first investigated in https://github.com/Shopify/shopify_api/pull/467

- Makes a **breaking change** in requiring `redirect_uri` to `create_permissions_url`, since this is actually required today
- Adds an options hash so that we don't break the interface again, which for now supports passing `state`
- Updates readme

cc @jamiemtdwyer @richter-alex let me know your thoughts