### PR TITLE
Add versioning for Fulfillment Platform APIs

### DIFF
--- a/lib/shopify_api/resources/assigned_fulfillment_order.rb
+++ b/lib/shopify_api/resources/assigned_fulfillment_order.rb
@@ -1,6 +1,14 @@
 module ShopifyAPI
   class AssignedFulfillmentOrder < Base
+
+    def initialize(attributes = {}, persisted = false)
+      ShopifyAPI::Base.version_validation!(FulfillmentOrder::MINIMUM_VERSION)
+      super(attributes, persisted)
+    end
+
     def self.find(scope, *args)
+      ShopifyAPI::Base.version_validation!(FulfillmentOrder::MINIMUM_VERSION)
+
       assigned_fulfillment_orders = super(scope, *args)
       assigned_fulfillment_orders.map { |afo| FulfillmentOrder.new(afo.attributes) }
     end

--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -132,6 +132,14 @@ module ShopifyAPI
         !!early_july_pagination
       end
 
+      def version_validation!(minimum_version)
+        available_in_version = ShopifyAPI::ApiVersion.find_version(minimum_version)
+
+        unless ShopifyAPI::Base.api_version >= available_in_version
+          raise NotImplementedError, "The minimum supported version is #{minimum_version}."
+        end
+      end
+
       private
 
       attr_accessor :early_july_pagination

--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -1,6 +1,15 @@
 module ShopifyAPI
   class FulfillmentOrder < Base
+    MINIMUM_VERSION = '2020-01'
+
+    def initialize(attributes = {}, persisted = false)
+      ShopifyAPI::Base.version_validation!(MINIMUM_VERSION)
+      super(attributes, persisted)
+    end
+
     def self.find(scope, *args)
+      ShopifyAPI::Base.version_validation!(MINIMUM_VERSION)
+
       if scope == :all
         order_id = args.first&.dig(:params, :order_id)
         raise ShopifyAPI::ValidationException, "'order_id' is required" if order_id.blank?

--- a/lib/shopify_api/resources/fulfillment_v2.rb
+++ b/lib/shopify_api/resources/fulfillment_v2.rb
@@ -2,6 +2,11 @@ module ShopifyAPI
   class FulfillmentV2 < Base
     self.element_name = 'fulfillment'
 
+    def initialize(attributes = {}, persisted = false)
+      ShopifyAPI::Base.version_validation!(FulfillmentOrder::MINIMUM_VERSION)
+      super(attributes, persisted)
+    end
+
     def update_tracking(tracking_info:, notify_customer:)
       body = {
         fulfillment: {

--- a/lib/shopify_api/resources/order.rb
+++ b/lib/shopify_api/resources/order.rb
@@ -31,6 +31,8 @@ module ShopifyAPI
     end
 
     def fulfillment_orders(options = {})
+      ShopifyAPI::Base.version_validation!(FulfillmentOrder::MINIMUM_VERSION)
+
       fulfillment_order_hashes = get(:fulfillment_orders, options)
       fulfillment_order_hashes.map { |fulfillment_order_hash| FulfillmentOrder.new(fulfillment_order_hash) }
     end

--- a/test/assigned_fulfillment_order_test.rb
+++ b/test/assigned_fulfillment_order_test.rb
@@ -1,12 +1,47 @@
 require 'test_helper'
+require 'fulfillment_order_test_helper'
 
 class AssignedFulFillmentOrderTest < Test::Unit::TestCase
+  include FulfillmentOrderTestHelper
+
+  def setup
+    super
+    @url_prefix = url_prefix_for_activated_session_for('2020-01')
+    @fulfillment_order_fixture = load_fixture('assigned_fulfillment_orders')
+  end
+
   context "AssignedFulfillmentOrder" do
+    context ".new" do
+      should "raise NotImplementedError when api_version is older than 2020-01" do
+        url_prefix_for_activated_session_for('2019-10')
+
+        assert_raises NotImplementedError do
+          ShopifyAPI::AssignedFulfillmentOrder.new(ActiveSupport::JSON.decode(@fulfillment_order_fixture))
+        end
+      end
+    end
+
     context "#all" do
+      should "raise NotImplementedError when api_version is older than 2020-01" do
+        @url_prefix = url_prefix_for_activated_session_for('2019-10')
+
+        fake 'assigned_fulfillment_orders',
+          url: "#{@url_prefix}/assigned_fulfillment_orders.json",
+          method: :get,
+          body: @fulfillment_order_fixture,
+          extension: false
+
+        assert_raises NotImplementedError do
+          ShopifyAPI::AssignedFulfillmentOrder.all(params: { assigned_status: 'cancellation_requested' })
+        end
+      end
+
       should "list assigned fulfillment orders by assigned_status" do
-        fulfillment_order_fixture = load_fixture('assigned_fulfillment_orders')
-        fake 'assigned_fulfillment_orders.json?assigned_status=cancellation_requested', method: :get,
-             body: fulfillment_order_fixture, extension: false
+        fake 'assigned_fulfillment_orders',
+          url: "#{@url_prefix}/assigned_fulfillment_orders.json?assigned_status=cancellation_requested",
+          method: :get,
+          body: @fulfillment_order_fixture,
+          extension: false
 
         assigned_fulfillment_orders = ShopifyAPI::AssignedFulfillmentOrder.all(
             params: { assigned_status: 'cancellation_requested' }
@@ -21,10 +56,11 @@ class AssignedFulFillmentOrderTest < Test::Unit::TestCase
       end
 
       should "be able to list assigned fulfillment orders by location_ids" do
-        fulfillment_order_fixture = load_fixture('assigned_fulfillment_orders')
         assigned_location_id = 905684977
-        fake "assigned_fulfillment_orders.json?location_ids%5B%5D=#{assigned_location_id}", method: :get,
-             body: fulfillment_order_fixture, extension: false
+        fake 'assigned_fulfillment_orders',
+          url: "#{@url_prefix}/assigned_fulfillment_orders.json?location_ids%5B%5D=#{assigned_location_id}",
+          method: :get,
+          body: @fulfillment_order_fixture, extension: false
 
         assigned_fulfillment_orders = ShopifyAPI::AssignedFulfillmentOrder.all(
             params: { location_ids: [assigned_location_id] }

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -173,6 +173,20 @@ class BaseTest < Test::Unit::TestCase
     assert_equal ShopifyAPI::ApiVersion::NullVersion, ShopifyAPI::Base.api_version
   end
 
+  test "#version_validation! does not raise is api_version is newer or equal to minimum supported version" do
+    ShopifyAPI::Base.api_version = '2020-01'
+    assert_nil ShopifyAPI::Base::version_validation!('2020-01')
+  end
+
+  test "#version_validation! raises NotImplemetedError if api_version is older than minimum supported version" do
+    ShopifyAPI::Base.api_version = '2019-10'
+    exception = assert_raises NotImplementedError do
+      ShopifyAPI::Base::version_validation!('2020-01')
+    end
+    assert_equal 'The minimum supported version is 2020-01.', exception.message
+  end
+
+
   def clear_header(header)
     [ActiveResource::Base, ShopifyAPI::Base, ShopifyAPI::Product].each do |klass|
       klass.headers.delete(header)

--- a/test/fulfillment_order_test_helper.rb
+++ b/test/fulfillment_order_test_helper.rb
@@ -1,0 +1,7 @@
+module FulfillmentOrderTestHelper
+  def url_prefix_for_activated_session_for(version)
+    available_version = ShopifyAPI::Session.new(domain: 'shop2.myshopify.com', token: 'token2', api_version: version)
+    ShopifyAPI::Base.activate_session(available_version)
+    "https://shop2.myshopify.com/admin/api/#{version}"
+  end
+end

--- a/test/fulfillment_v2_test.rb
+++ b/test/fulfillment_v2_test.rb
@@ -1,39 +1,61 @@
 require 'test_helper'
+require 'fulfillment_order_test_helper'
 
 class FulfillmentV2Test < Test::Unit::TestCase
+  include FulfillmentOrderTestHelper
+
+  def setup
+    super
+    @tracking_info = {
+      number: 'JSDHFHAG',
+      url: 'https://example.com/fulfillment_tracking/JSDHFHAG',
+      company: 'ACME co',
+    }
+    @fake_fulfillment = ActiveSupport::JSON.decode(load_fixture('fulfillment'))['fulfillment']
+    @fake_fulfillment['tracking_number'] = @tracking_info[:number]
+    @fake_fulfillment['tracking_numbers'] = [@tracking_info[:number]]
+    @fake_fulfillment['tracking_url'] = @tracking_info[:url]
+    @fake_fulfillment['tracking_urls'] = [@tracking_info[:url]]
+    @fake_fulfillment['tracking_company'] = @tracking_info[:company]
+
+    @request_body = {
+      fulfillment: {
+        tracking_info: @tracking_info,
+        notify_customer: true
+      }
+    }
+    @url_prefix = url_prefix_for_activated_session_for('2020-01')
+    fake 'fulfillments',
+      url: "#{@url_prefix}/fulfillments/#{@fake_fulfillment['id']}/update_tracking.json",
+      method: :post,
+      request_body: ActiveSupport::JSON.encode(@request_body),
+      body: ActiveSupport::JSON.encode(fulfillment: @fake_fulfillment)
+  end
+
   context "FulfillmentV2" do
     context "#update_tracking" do
       should "be able to update tracking info for a fulfillment" do
-        tracking_info = {
-          number: 'JSDHFHAG',
-          url: 'https://example.com/fulfillment_tracking/JSDHFHAG',
-          company: 'ACME co',
-        }
-        fake_fulfillment = ActiveSupport::JSON.decode(load_fixture('fulfillment'))['fulfillment']
-        fake_fulfillment['tracking_number'] = tracking_info[:number]
-        fake_fulfillment['tracking_numbers'] = [tracking_info[:number]]
-        fake_fulfillment['tracking_url'] = tracking_info[:url]
-        fake_fulfillment['tracking_urls'] = [tracking_info[:url]]
-        fake_fulfillment['tracking_company'] = tracking_info[:company]
+        fulfillment = ShopifyAPI::FulfillmentV2.new(id: @fake_fulfillment['id'])
+        assert fulfillment.update_tracking(tracking_info: @tracking_info, notify_customer: true)
 
-        request_body = {
-          fulfillment: {
-            tracking_info: tracking_info,
-            notify_customer: true
-          }
-        }
-        fake "fulfillments/#{fake_fulfillment['id']}/update_tracking", method: :post,
-          request_body: ActiveSupport::JSON.encode(request_body),
-          body: ActiveSupport::JSON.encode(fulfillment: fake_fulfillment)
+        assert_equal @tracking_info[:number], fulfillment.tracking_number
+        assert_equal [@tracking_info[:number]], fulfillment.tracking_numbers
+        assert_equal @tracking_info[:url], fulfillment.tracking_url
+        assert_equal [@tracking_info[:url]], fulfillment.tracking_urls
+        assert_equal @tracking_info[:company], fulfillment.tracking_company
+      end
 
-        fulfillment = ShopifyAPI::FulfillmentV2.new(id: fake_fulfillment['id'])
-        assert fulfillment.update_tracking(tracking_info: tracking_info, notify_customer: true)
+      should "raise NotImplementedError when api_version is older than 2020-01" do
+        @url_prefix = url_prefix_for_activated_session_for('2019-10')
+        fake 'fulfillments',
+          url: "#{@url_prefix}/fulfillments/#{@fake_fulfillment['id']}/update_tracking.json",
+          method: :post,
+          request_body: ActiveSupport::JSON.encode(@request_body),
+          body: ActiveSupport::JSON.encode(fulfillment: @fake_fulfillment)
 
-        assert_equal tracking_info[:number], fulfillment.tracking_number
-        assert_equal [tracking_info[:number]], fulfillment.tracking_numbers
-        assert_equal tracking_info[:url], fulfillment.tracking_url
-        assert_equal [tracking_info[:url]], fulfillment.tracking_urls
-        assert_equal tracking_info[:company], fulfillment.tracking_company
+        assert_raises NotImplementedError do
+          ShopifyAPI::FulfillmentV2.new(id: @fake_fulfillment['id'])
+        end
       end
     end
   end


### PR DESCRIPTION
Closes: https://github.com/Shopify/shopify/issues/230988

Added version check for all Fulfillment Order related APIs. `NotImplementedError` is returned if the `api_version` is older than `2020-01`. 

Tests are updated to activate the session with different versions (i.e., `2020-01` or `2019-10`).

The PR is bit big, but most changes are in `fake`. For example:
Before
```ruby
fake 'assigned_fulfillment_orders.json?assigned_status=cancellation_requested', 
    method: :get,
    body: fulfillment_order_fixture, 
    extension: false
```
After
```ruby
fake 'assigned_fulfillment_orders',
    url: "#{@url_prefix}/assigned_fulfillment_orders.json?assigned_status=cancellation_requested",
    method: :get,
    body: fulfillment_order_fixture,
    extension: false
```

Also, append `?w=1` in url would make it a bit easy to review.

