### PR TITLE
warning raised for version eol

### DIFF
--- a/lib/active_resource/detailed_log_subscriber.rb
+++ b/lib/active_resource/detailed_log_subscriber.rb
@@ -3,6 +3,7 @@ module ActiveResource
     def request(event)
       log_request_response_details(event)
       warn_on_deprecated_header(event)
+      warn_on_version_eol_warning_header(event)
     end
 
     def logger
@@ -30,6 +31,22 @@ module ActiveResource
           warning_message = <<-MSG
           [DEPRECATED] ShopifyAPI made a call to #{payload[:method].upcase} #{payload[:path]}, and this call made
           use of a deprecated endpoint, behaviour, or parameter. See #{header_value} for more details.
+          MSG
+
+          warn warning_message
+        end
+      end
+    end
+
+    def warn_on_version_eol_warning_header(event)
+      payload = event.payload
+
+      payload[:response].each do |header_name, header_value|
+        case header_name.downcase
+        when 'x-shopify-api-version-warning'
+          warning_message = <<-MSG
+          [Version EOL Warning] ShopifyAPI made a call to #{payload[:method].upcase} #{payload[:path]}, and this call made
+          use of an API version that is expired or will expire within 30 days. See #{header_value} for more details.
           MSG
 
           warn warning_message

--- a/lib/active_resource/detailed_log_subscriber.rb
+++ b/lib/active_resource/detailed_log_subscriber.rb
@@ -38,8 +38,8 @@ module ActiveResource
 
         when VERSION_EOL_WARNING_HEADER
           warning_message = <<-MSG
-          [Version EOL Warning] ShopifyAPI made a call to #{payload[:method].upcase} #{payload[:path]}, and this call made
-          use of an API version that is expired or will expire within 30 days. See #{header_value} for more details.
+          [API Version Warning] ShopifyAPI made a call to #{payload[:method].upcase} #{payload[:path]}, and this call used
+          an API version that is unsupported or will become unsupported within 30 days. See #{header_value} for more details.
           MSG
 
           warn warning_message

--- a/lib/active_resource/detailed_log_subscriber.rb
+++ b/lib/active_resource/detailed_log_subscriber.rb
@@ -1,9 +1,10 @@
 module ActiveResource
   class DetailedLogSubscriber < ActiveSupport::LogSubscriber
+    VERSION_EOL_WARNING_HEADER = 'x-shopify-api-version-warning'
+    VERSION_DEPRECATION_HEADER = 'x-shopify-api-deprecated-reason'
     def request(event)
       log_request_response_details(event)
-      warn_on_deprecated_header(event)
-      warn_on_version_eol_warning_header(event)
+      warn_on_deprecated_header_or_version_eol_header(event)
     end
 
     def logger
@@ -22,28 +23,20 @@ module ActiveResource
       info "Response:\n#{event.payload[:response].body}"
     end
 
-    def warn_on_deprecated_header(event)
+    def warn_on_deprecated_header_or_version_eol_header(event)
       payload = event.payload
 
       payload[:response].each do |header_name, header_value|
         case header_name.downcase
-        when 'x-shopify-api-deprecated-reason'
+        when VERSION_DEPRECATION_HEADER
           warning_message = <<-MSG
           [DEPRECATED] ShopifyAPI made a call to #{payload[:method].upcase} #{payload[:path]}, and this call made
           use of a deprecated endpoint, behaviour, or parameter. See #{header_value} for more details.
           MSG
 
           warn warning_message
-        end
-      end
-    end
 
-    def warn_on_version_eol_warning_header(event)
-      payload = event.payload
-
-      payload[:response].each do |header_name, header_value|
-        case header_name.downcase
-        when 'x-shopify-api-version-warning'
+        when VERSION_EOL_WARNING_HEADER
           warning_message = <<-MSG
           [Version EOL Warning] ShopifyAPI made a call to #{payload[:method].upcase} #{payload[:path]}, and this call made
           use of an API version that is expired or will expire within 30 days. See #{header_value} for more details.

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -115,7 +115,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     )
   end
 
-  test "warns when the server responds with a x-shopify-api-version-warning" do
+  test "warns when the server responds with a x-shopify-api-version-warning header" do
     fake(
       "pages/1",
       method: :get,
@@ -128,7 +128,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     assert_equal 1, @logger.logged(:warn).size
 
     assert_match(
-      %r{\[Version EOL Warning\] ShopifyAPI made a call to GET /admin/api/2019-01/pages/1.json},
+      %r{\[API Version Warning\] ShopifyAPI made a call to GET /admin/api/2019-01/pages/1.json},
       @logger.logged(:warn).first
     )
     assert_match(

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -114,4 +114,26 @@ class LogSubscriberTest < Test::Unit::TestCase
       @logger.logged(:warn).first
     )
   end
+
+  test "warns when the server responds with a x-shopify-api-version-warning" do
+    fake(
+      "pages/1",
+      method: :get,
+      body: @page,
+      x_shopify_api_version_warning: 'https://shopify.dev/concepts/about-apis/versioning'
+    )
+
+    ShopifyAPI::Page.find(1)
+
+    assert_equal 1, @logger.logged(:warn).size
+
+    assert_match(
+      %r{\[Version EOL Warning\] ShopifyAPI made a call to GET /admin/api/2019-01/pages/1.json},
+      @logger.logged(:warn).first
+    )
+    assert_match(
+      %r{See https:\/\/shopify.dev\/concepts\/about-apis\/versioning for more details.},
+      @logger.logged(:warn).first
+    )
+  end
 end


### PR DESCRIPTION
Closes https://github.com/Shopify/shopify/issues/233879

TL;DR  This pull request is raised to add a warning message case of API Version being used to make a call is expired or will expire within 30 days

**Background:**

Currently, a warning header is added to the responses of all admin and storefront APIs that are using a version that expires within 30 days or is expired already. This was done through https://github.com/Shopify/shopify/pull/232580

Now, we want to raise warning messages through the Shopify API gem as well if API calls are made using expired or EOL versions. 

**Solution**

The response headers of the API responses are checked for the presence of the version EOL warning header. If present, a warning message is raised.
