### PR TITLE
Packaging for release 9.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+== Version 9.0.1
+
+* Added warning message if API version used is unsupported or soon to be unsupported  [#685](https://github.com/Shopify/shopify_api/pull/685)
 * Take into account "errors" messages from response body [#677](https://github.com/Shopify/shopify_api/pull/677)
 
 == Version 9.0.0

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "9.0.0"
+  VERSION = "9.0.1"
 end


### PR DESCRIPTION
We had rolled out a warning header to all admin and storefront APIs (REST and Graphql) if an unsupported or soon to be unsupported version pf the API was used in Shopify Core. 
Shopify/shopify#232580

Now we have added a warning message within the Shopify API gem as well.
https://github.com/Shopify/shopify_api/pull/685

This version bump is done to release the changes in shopify api gem