### PR TITLE
Add option to not raise if non-matching schema name

### DIFF
--- a/lib/shopify_api/graphql.rb
+++ b/lib/shopify_api/graphql.rb
@@ -39,7 +39,7 @@ module ShopifyAPI
         @_client_cache = {}
       end
 
-      def initialize_clients
+      def initialize_clients(raise_on_invalid_schema: true)
         initialize_client_cache
 
         Dir.glob(schema_location.join("*.json")).each do |schema_file|
@@ -49,7 +49,11 @@ module ShopifyAPI
           if matches
             api_version = ShopifyAPI::ApiVersion.new(handle: matches[1])
           else
-            raise InvalidSchema, "Invalid schema file name `#{schema_file}`. Does not match format of: `<version>.json`."
+            if raise_on_invalid_schema
+              raise InvalidSchema, "Invalid schema file name `#{schema_file}`. Does not match format of: `<version>.json`."
+            else
+              next
+            end
           end
 
           schema = ::GraphQL::Client.load_schema(schema_file.to_s)

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -53,6 +53,17 @@ class GraphQLTest < Test::Unit::TestCase
     end
   end
 
+  test '#initialize_clients does not raise if raise_on_invalid_schema is set to false' do
+    version_fixtures('unstable') do |dir|
+      ShopifyAPI::GraphQL.schema_location = dir
+      FileUtils.touch(ShopifyAPI::GraphQL.schema_location.join('nope.json'))
+
+      ShopifyAPI::GraphQL.initialize_clients(raise_on_invalid_schema: false)
+
+      assert ShopifyAPI::GraphQL.client('unstable')
+    end
+  end
+
   test '#client returns default schema if only one exists' do
     version_fixtures('unstable') do |dir|
       ShopifyAPI::Base.api_version = 'unstable'


### PR DESCRIPTION
ApolloClient is generating, in the same directory as my schemas, a `shopify-schema-unions-and-interfaces.json` file. This makes `initialize_clients` raise an exception when it encounters it.

Unfortunately, ApolloClient does not allow to disable the creation of that file, or to give it a different name.

After talking to @swalkinshaw on Slack, we decided that putting an option to not raise on `initialize_clients` was the best approach for now.