### PR TITLE
Add support for Discount Code batch endpoints

### DIFF
--- a/lib/shopify_api/resources/discount_code_batch.rb
+++ b/lib/shopify_api/resources/discount_code_batch.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+module ShopifyAPI
+  class DiscountCodeBatch < Base
+    init_prefix :price_rule
+
+    self.collection_name = 'batch'
+
+    def price_rule_id
+      @prefix_options[:price_rule_id]
+    end
+
+    def discount_code_job
+      @discount_codes ||= begin
+        if id
+          path = self.class.api_version.construct_api_path("price_rules/#{price_rule_id}/batch/#{id}/discount_codes.json")
+          discount_codes = ShopifyAPI::DiscountCode.find :all, from: path
+          discount_codes.each do |code|
+            errors = code.attributes['errors']
+            errors.attributes.each do |key, values|
+              values.each { |message| code.errors.add(key, message) }
+            end
+          end
+          discount_codes
+        end
+      end
+    end
+
+    def encode(options = {})
+      send("to_#{self.class.format.extension}", options)
+    end
+  end
+end

--- a/test/discount_code_batch_test.rb
+++ b/test/discount_code_batch_test.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+class DiscountCodeBatchTest < Test::Unit::TestCase
+  def setup
+    super
+    fake 'price_rules/102586120/batch/989355119', body: load_fixture('discount_code_batch')
+  end
+
+  def test_get_batch
+    batch = ShopifyAPI::DiscountCodeBatch.find 989355119, params: { price_rule_id: 102586120 }
+
+    assert_equal 989355119, batch.id
+  end
+
+  def test_get_batch_discount_codes
+    fake 'price_rules/102586120/batch/989355119/discount_codes',
+      method: :get,
+      status: 200,
+      body: load_fixture('discount_code_batch_discount_codes')
+
+    batch = ShopifyAPI::DiscountCodeBatch.find 989355119, params: { price_rule_id: 102586120 }
+    discount_code_job = batch.discount_code_job
+
+    assert_equal 3, discount_code_job.count
+    assert discount_code_job[2].errors.present?
+  end
+
+  def test_create_batch
+    fake 'price_rules/102586120/batch', method: :post, status: 201, body: load_fixture('discount_code_batch')
+    batch = ShopifyAPI::DiscountCodeBatch.new
+    batch.prefix_options[:price_rule_id] = 102586120
+    discount_codes = [{ "code": "SUMMER1" }, { "code": "SUMMER2" }, { "code": "SUMMER3" }]
+    batch.discount_codes = discount_codes
+    batch.save
+
+    expected_body = { discount_codes: discount_codes }.to_json
+    assert_equal expected_body, WebMock.last_request.body
+  end
+end

--- a/test/fixtures/discount_code_batch.json
+++ b/test/fixtures/discount_code_batch.json
@@ -1,0 +1,14 @@
+{
+  "discount_code_creation": {
+    "id": 989355119,
+    "price_rule_id": 102586120,
+    "started_at": null,
+    "completed_at": null,
+    "created_at": "2018-07-05T13:04:29-04:00",
+    "updated_at": "2018-07-05T13:04:29-04:00",
+    "status": "queued",
+    "codes_count": 3,
+    "imported_count": 0,
+    "failed_count": 0
+  }
+}

--- a/test/fixtures/discount_code_batch_discount_codes.json
+++ b/test/fixtures/discount_code_batch_discount_codes.json
@@ -1,0 +1,21 @@
+{
+  "discount_codes": [
+    {
+      "id": null,
+      "code": "SUMMER1",
+      "errors": {}
+    },
+    {
+      "id": null,
+      "code": "SUMMER2",
+      "errors": {}
+    },
+    {
+      "id": null,
+      "code": "SUMMER2",
+      "errors": {
+        "code": ["must be unique"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Support the API batch endpoints.

https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#batch_create-2020-01
https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#batch_show-2020-01
https://shopify.dev/docs/admin-api/rest/reference/discounts/discountcode#batch_discount_codes_index-2020-01

Tests shows some usage examples for the 3 endpoints.