### PR TITLE
Fix `mocha/setup` deprecation warning

### DIFF
--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("rack")
   s.add_runtime_dependency("graphql-client")
 
-  s.add_development_dependency("mocha", ">= 0.9.8")
+  s.add_development_dependency("mocha", ">= 1.4.0")
   s.add_development_dependency("webmock")
   s.add_development_dependency("minitest", ">= 4.0")
   s.add_development_dependency("rake")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require 'rubygems'
 require 'minitest/autorun'
 require 'webmock/minitest'
 require_relative 'lib/webmock_extensions/last_request'
-require 'mocha/setup'
+require 'mocha/minitest'
 require 'pry'
 
 $LOAD_PATH.unshift(File.dirname(__FILE__))


### PR DESCRIPTION
Prevents this warning when running the tests:

    Mocha deprecation warning at ... test/test_helper.rb:5:in `require':
    Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.

Requiring `mocha/setup` was deprecated in 1.10.0:

https://github.com/freerange/mocha/blob/master/RELEASE.md#1100