### PR TITLE
Implement Session#==

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -149,6 +149,14 @@ module ShopifyAPI
       expires_in <= 0
     end
 
+    def ==(other)
+      self.class == other.class &&
+        domain == other.domain &&
+        token == other.token &&
+        api_version == other.api_version &&
+        extra == other.extra
+    end
+
     private
 
     def parameterize(params)

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -346,6 +346,88 @@ class SessionTest < Test::Unit::TestCase
     assert_equal('testshop.myshopify.com', session.url)
   end
 
+  test "equality verifies domain" do
+    session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    other_session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    different_session = ShopifyAPI::Session.new(
+      domain: "http://another_testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    assert_equal(session, other_session)
+    refute_equal(session, different_session)
+  end
+
+  test "equality verifies token" do
+    session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    different_session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "very-different-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    refute_equal(session, different_session)
+  end
+
+  test "equality verifies api_version" do
+    session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    different_session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: :unstable,
+      extra: { foo: "bar" }
+    )
+    refute_equal(session, different_session)
+  end
+
+  test "equality verifies extra" do
+    session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    different_session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { bar: "other-bar" }
+    )
+    refute_equal(session, different_session)
+  end
+
+  test "equality verifies other is a Session" do
+    session = ShopifyAPI::Session.new(
+      domain: "http://testshop.myshopify.com",
+      token: "any-token",
+      api_version: '2019-01',
+      extra: { foo: "bar" }
+    )
+    different_session = nil
+    refute_equal(session, different_session)
+  end
+
   private
 
   def make_sorted_params(params)


### PR DESCRIPTION
It's convenient to be able to compare `Session` objects (when testing, for example).

Co-authored with @gbossh 

For: https://github.com/Shopify/shopify_app/pull/951