### PR TITLE
Update clear_session not to clear the api-version

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -53,7 +53,6 @@ module ShopifyAPI
         self.site = nil
         self.password = nil
         self.user = nil
-        self.api_version = nil
         self.headers.delete('X-Shopify-Access-Token')
       end
 

--- a/test/base_test.rb
+++ b/test/base_test.rb
@@ -38,6 +38,22 @@ class BaseTest < Test::Unit::TestCase
     assert_nil ShopifyAPI::Base.site
   end
 
+  # test to  check session reset api version remains the same after session reset
+  test '#clear_session should not change the api_version' do
+    ShopifyAPI::Base.site = "https://zoo:lion@www.zoo.com"
+
+
+    assert_equal "zoo", ShopifyAPI::Base.user
+    assert_equal "lion", ShopifyAPI::Base.password
+
+    ShopifyAPI::Base.clear_session
+
+    assert_nil ShopifyAPI::Base.user
+    assert_nil ShopifyAPI::Base.password
+    assert_nil ShopifyAPI::Base.site
+    assert_equal ShopifyAPI::Base.api_version,@session1.api_version
+  end
+
   test '#clear_session should clear site and headers from Base' do
     ShopifyAPI::Base.activate_session @session1
     ShopifyAPI::Base.clear_session


### PR DESCRIPTION
resolves #640 

Removes resetting the api_version when clearing the session. In the `test\base_test.rb` there is no logic the shows the session clearing should also clear the api_version.
@tanema 