### PR TITLE
removed unused smartcollection.products endpoint

### DIFF
--- a/lib/shopify_api/resources/smart_collection.rb
+++ b/lib/shopify_api/resources/smart_collection.rb
@@ -3,12 +3,8 @@ module ShopifyAPI
     include Events
     include Metafields
 
-    def products(options = {})
-      if options.present?
-        Product.find(:all, from: "#{self.class.prefix}smart_collections/#{id}/products.json", params: options)
-      else
-        Product.find(:all, params: { collection_id: id })
-      end
+    def products
+      Product.find(:all, params: { collection_id: id })
     end
 
     def order(options={})

--- a/test/smart_collection_test.rb
+++ b/test/smart_collection_test.rb
@@ -7,29 +7,4 @@ class SmartCollectionTest < Test::Unit::TestCase
     smart_collection = ShopifyAPI::SmartCollection.create(:title => "Macbooks", :rules => rules)
     assert_equal 1063001432, smart_collection.id
   end
-
-  test "Smart Collection get products gets all products in a smart collection" do
-    fake "smart_collections/1063001432", method: :get, status: 200, body: load_fixture('smart_collection')
-    smart_collection = ShopifyAPI::SmartCollection.find(1063001432)
-
-    fake "products.json?collection_id=1063001432",
-      method: :get,
-      status: 200,
-      body:
-      load_fixture('smart_collection_products'),
-      extension: false
-    assert_equal [632910392, 921728736], smart_collection.products.map(&:id)
-  end
-
-  test "Smart Collection get products with only_sorted=only_manual gets only manually sorted products" do
-    fake "smart_collections/1063001432", method: :get, status: 200, body: load_fixture('smart_collection')
-    smart_collection = ShopifyAPI::SmartCollection.find(1063001432)
-
-    fake "smart_collections/1063001432/products.json?only_sorted=only_manual",
-      method: :get,
-      status: 200,
-      body: load_fixture('smart_collection_products'),
-      extension: false
-    assert_equal [632910392, 921728736], smart_collection.products(only_sorted: "only_manual").map(&:id)
-  end
 end


### PR DESCRIPTION
The `SmartCollection#products` endpoint was behind a beta flag, which was never enabled. Sitting at 0% since 2018. The REST API documentation was never added. All calls to this endpoint would result in a 401. Since we're removing the endpoint from the controller, I'm first removing it from the API.
I checked with #api-patterns and they confirmed this is safe to remove.