### PR TITLE
Make cursor based pagination return relative uri's when fetching next and previous pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 9.1.1
+
+* Make cursor based pagination return relative uri's when fetching next and previous pages. [#726](https://github.com/Shopify/shopify_api/pull/726)
+
 ## Version 9.1.0
 
 * Implements equality operator on `Session` [#714](https://github.com/Shopify/shopify_api/pull/714)

--- a/lib/shopify_api/pagination_link_headers.rb
+++ b/lib/shopify_api/pagination_link_headers.rb
@@ -25,7 +25,7 @@ module ShopifyAPI
         url = parts[0][/<(.*)>/, 1]
         rel = parts[1][/rel="(.*)"/, 1]&.to_sym
 
-        url = URI.parse(url)
+        url = URI.parse(url).request_uri
         LinkHeader.new(url, rel)
       end
     end

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "9.1.0"
+  VERSION = "9.1.1"
 end


### PR DESCRIPTION
Fixes #713 

Currently, when using REST based collection pagination, the request made using `.fetch_next_page` and `fetch_previous_page` actually includes the base site twice.

Normal request is fine:
```
prods = ShopifyAPI::Product.find(:all, params: {limit: 5})
GET https://myshop.myshopify.com:443/admin/api/2020-01/products.json?limit=5
```

but then fetching next or previous page results in the following request:

```
=> GET https://myshop.myshopify.com:443https://myshop.myshopify.com/admin/api/2020-01/products.json?limit=5&page_info=eyJkaXJlY3Rpb24iOiJuZXh0IiwibGFzdF9pZCI6MjA3MDE5MjE2MDgzMywibGFzdF92YWx1ZSI6IlByaW1lIHRpbWUifQ
```

Strangely, Shopify works when calling the api like that most of the time.. but sometimes it randomly fails with a "522 - Bad Gateway" error.

This happens because the absolute url is passed from the pagination link headers, through to ActiveResource, which then merges the 'site' into the url again internally before making the request.

This pull request ensures we return a relative path (request_uri) instead of the absolute path when parsing the pagination link headers.

This ensures correctly formatted requests each time.

```
prods = ShopifyAPI::Product.find(:all, params: {limit: 5})

=> GET https://myshop.myshopify.com:443/admin/api/2020-01/products.json?limit=5

prods.fetch_next_page

=> GET https://myshop.myshopify.com/admin/api/2020-01/products.json?limit=5&page_info=eyJkaXJlY3Rpb24iOiJuZXh0IiwibGFzdF9pZCI6MjA3MDE5MjE2MDgzMywibGFzdF92YWx1ZSI6IlByaW1lIHRpbWUifQ
```