### PR TITLE
Allow for executing client to be set dynamically

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -147,6 +147,32 @@ during your boot process.
 The goal is to have all clients created at boot so there's no schema loading,
 parsing, or client instantiation done during runtime when your app serves a request.
 
+## Using a custom client
+`ShopifyAPI::GraphQL::HTTPClient` inherits from `::GraphQL::Client::HTTP` and instruments
+the headers, url and api version for you. However, you may find that you wish to add
+additional functionality to the client responsible for executing and parsing queries.
+For instance, you may wish to create a client which loads responses from a file for your
+tests, or you may want to implement a client which raises errors instead of passing them
+back through the results object.
+
+To set a custom client set `ShopifyAPI::GraphQL.client_klass` to your client:
+```ruby
+class RaisingHTTPClient < ShopifyAPI::GraphQL::HTTPClient
+  def execute(document:, operation_name: nil, variables: {}, context: {})
+    result = super
+    do_work(result)
+  end
+
+  private
+
+  def do_work(result)
+    result
+  end
+end
+
+ShopifyAPI::GraphQL.client_klass = RaisingHTTPClient
+```
+
 ## Migration guide
 Prior to shopify_api v9.0 the GraphQL client implementation was limited and almost
 unusable due to the client making dynamic introspection queries to Shopify's API.

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -147,15 +147,16 @@ during your boot process.
 The goal is to have all clients created at boot so there's no schema loading,
 parsing, or client instantiation done during runtime when your app serves a request.
 
-## Using a custom client
-`ShopifyAPI::GraphQL::HTTPClient` inherits from `::GraphQL::Client::HTTP` and instruments
-the headers, url and api version for you. However, you may find that you wish to add
-additional functionality to the client responsible for executing and parsing queries.
-For instance, you may wish to create a client which loads responses from a file for your
-tests, or you may want to implement a client which raises errors instead of passing them
-back through the results object.
+## Using a custom query execution adapter
+Github's GraphQL Client uses an adapter pattern so that you can define how you interact
+with GraphQL API's. Shopify provides a minimal implementation in `ShopifyAPI::GraphQL::HTTPClient`.
+If you need to add additional functionality pre, during or post query execution you can
+consider implementing these within a custom query execution adapter, inheriting from
+`ShopifyAPI::GraphQL::HTTPClient` which provides the necessary implementation for
+headers, url, and api versions
 
-To set a custom client set `ShopifyAPI::GraphQL.client_klass` to your client:
+
+To set a custom query executiona dapter set `ShopifyAPI::GraphQL.execution_adapter` to your client:
 ```ruby
 class RaisingHTTPClient < ShopifyAPI::GraphQL::HTTPClient
   def execute(document:, operation_name: nil, variables: {}, context: {})
@@ -170,8 +171,11 @@ class RaisingHTTPClient < ShopifyAPI::GraphQL::HTTPClient
   end
 end
 
-ShopifyAPI::GraphQL.client_klass = RaisingHTTPClient
+ShopifyAPI::GraphQL.execution_adapter = RaisingHTTPClient
 ```
+
+Note, the execution adapter has `client` in the name. This is to remain consistent with
+the naming conventions within the Github GraphQL Client library.
 
 ## Migration guide
 Prior to shopify_api v9.0 the GraphQL client implementation was limited and almost

--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -147,6 +147,21 @@ during your boot process.
 The goal is to have all clients created at boot so there's no schema loading,
 parsing, or client instantiation done during runtime when your app serves a request.
 
+
+## Using a custom GraphQL Client
+By default `ShopifyAPI::GraphQL` wraps the Github GraphQL Client library. However, this client
+may not suitable for various reasons. If you wish to expand on the interface of the client or
+improve the required functions for your use case you can implement a client of your own.
+
+To use a custom GraphQL Client:
+```
+class CustomGraphQLClient < ::GraphQL::Client
+end
+
+ShopifyAPI::GraphQL.graphql_client = CustomGraphQLClient
+```
+
+
 ## Using a custom query execution adapter
 Github's GraphQL Client uses an adapter pattern so that you can define how you interact
 with GraphQL API's. Shopify provides a minimal implementation in `ShopifyAPI::GraphQL::HTTPClient`.

--- a/lib/shopify_api/graphql.rb
+++ b/lib/shopify_api/graphql.rb
@@ -5,6 +5,7 @@ require 'shopify_api/graphql/http_client'
 module ShopifyAPI
   module GraphQL
     DEFAULT_SCHEMA_LOCATION_PATH = Pathname('shopify_graphql_schemas')
+    DEFAULT_CLIENT_KLASS = HTTPClient
 
     InvalidSchema = Class.new(StandardError)
     InvalidClient = Class.new(StandardError)
@@ -57,7 +58,7 @@ module ShopifyAPI
           end
 
           schema = ::GraphQL::Client.load_schema(schema_file.to_s)
-          client = ::GraphQL::Client.new(schema: schema, execute: HTTPClient.new(api_version)).tap do |c|
+          client = ::GraphQL::Client.new(schema: schema, execute: client_klass.new(api_version)).tap do |c|
             c.allow_dynamic_queries = true
           end
 
@@ -71,6 +72,14 @@ module ShopifyAPI
 
       def schema_location=(path)
         @schema_location = Pathname(path)
+      end
+
+      def client_klass
+        @client_klass || DEFAULT_CLIENT_KLASS
+      end
+
+      def client_klass=(client)
+        @client_klass = client
       end
 
       private

--- a/lib/shopify_api/graphql.rb
+++ b/lib/shopify_api/graphql.rb
@@ -5,7 +5,7 @@ require 'shopify_api/graphql/http_client'
 module ShopifyAPI
   module GraphQL
     DEFAULT_SCHEMA_LOCATION_PATH = Pathname('shopify_graphql_schemas')
-    DEFAULT_CLIENT_KLASS = HTTPClient
+    DEFAULT_EXECUTION_ADAPTER = HTTPClient
 
     InvalidSchema = Class.new(StandardError)
     InvalidClient = Class.new(StandardError)
@@ -58,7 +58,7 @@ module ShopifyAPI
           end
 
           schema = ::GraphQL::Client.load_schema(schema_file.to_s)
-          client = ::GraphQL::Client.new(schema: schema, execute: client_klass.new(api_version)).tap do |c|
+          client = ::GraphQL::Client.new(schema: schema, execute: execution_adapter.new(api_version)).tap do |c|
             c.allow_dynamic_queries = true
           end
 
@@ -74,12 +74,12 @@ module ShopifyAPI
         @schema_location = Pathname(path)
       end
 
-      def client_klass
-        @client_klass || DEFAULT_CLIENT_KLASS
+      def execution_adapter
+        @execution_adapter || DEFAULT_EXECUTION_ADAPTER
       end
 
-      def client_klass=(client)
-        @client_klass = client
+      def execution_adapter=(executor)
+        @execution_adapter = executor
       end
 
       private

--- a/lib/shopify_api/graphql.rb
+++ b/lib/shopify_api/graphql.rb
@@ -6,6 +6,7 @@ module ShopifyAPI
   module GraphQL
     DEFAULT_SCHEMA_LOCATION_PATH = Pathname('shopify_graphql_schemas')
     DEFAULT_EXECUTION_ADAPTER = HTTPClient
+    DEFAULT_GRAPHQL_CLIENT = ::GraphQL::Client
 
     InvalidSchema = Class.new(StandardError)
     InvalidClient = Class.new(StandardError)
@@ -57,8 +58,8 @@ module ShopifyAPI
             end
           end
 
-          schema = ::GraphQL::Client.load_schema(schema_file.to_s)
-          client = ::GraphQL::Client.new(schema: schema, execute: execution_adapter.new(api_version)).tap do |c|
+          schema = graphql_client.load_schema(schema_file.to_s)
+          client = graphql_client.new(schema: schema, execute: execution_adapter.new(api_version)).tap do |c|
             c.allow_dynamic_queries = true
           end
 
@@ -80,6 +81,14 @@ module ShopifyAPI
 
       def execution_adapter=(executor)
         @execution_adapter = executor
+      end
+
+      def graphql_client
+        @graphql_client || DEFAULT_GRAPHQL_CLIENT
+      end
+
+      def graphql_client=(client)
+        @graphql_client = client
       end
 
       private

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -152,11 +152,27 @@ class GraphQLTest < Test::Unit::TestCase
       ShopifyAPI::Base.api_version = 'unstable'
 
       ShopifyAPI::GraphQL.initialize_clients
-
       assert_instance_of SuperDuperExecutionAdapter, ShopifyAPI::GraphQL.client('unstable').execute
     end
 
     ShopifyAPI::GraphQL.execution_adapter = nil
+  end
+
+  test '#client creates client based off configured class' do
+    class SuperDuperClient < ::GraphQL::Client
+    end
+
+    ShopifyAPI::GraphQL.graphql_client = SuperDuperClient
+    version_fixtures('unstable') do |dir|
+      ShopifyAPI::Base.api_version = 'unstable'
+
+      ShopifyAPI::GraphQL.initialize_clients
+
+      assert_instance_of SuperDuperClient, ShopifyAPI::GraphQL.client('unstable')
+    end
+
+    ShopifyAPI::GraphQL.clear_clients
+    ShopifyAPI::GraphQL.graphql_client = nil
   end
 
   private

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -143,6 +143,22 @@ class GraphQLTest < Test::Unit::TestCase
     end
   end
 
+  test '#client creates client based off configured class' do
+    class SuperDuperClient < ShopifyAPI::GraphQL::HTTPClient
+    end
+
+    ShopifyAPI::GraphQL.client_klass = SuperDuperClient
+    version_fixtures('unstable') do |dir|
+      ShopifyAPI::Base.api_version = 'unstable'
+
+      ShopifyAPI::GraphQL.initialize_clients
+
+      assert_instance_of SuperDuperClient, ShopifyAPI::GraphQL.client('unstable').execute
+    end
+
+    ShopifyAPI::GraphQL.client_klass = nil
+  end
+
   private
 
   def version_fixtures(*versions)

--- a/test/graphql_test.rb
+++ b/test/graphql_test.rb
@@ -143,20 +143,20 @@ class GraphQLTest < Test::Unit::TestCase
     end
   end
 
-  test '#client creates client based off configured class' do
-    class SuperDuperClient < ShopifyAPI::GraphQL::HTTPClient
+  test '#client creates execution adapter based off configured class' do
+    class SuperDuperExecutionAdapter < ShopifyAPI::GraphQL::HTTPClient
     end
 
-    ShopifyAPI::GraphQL.client_klass = SuperDuperClient
+    ShopifyAPI::GraphQL.execution_adapter = SuperDuperExecutionAdapter
     version_fixtures('unstable') do |dir|
       ShopifyAPI::Base.api_version = 'unstable'
 
       ShopifyAPI::GraphQL.initialize_clients
 
-      assert_instance_of SuperDuperClient, ShopifyAPI::GraphQL.client('unstable').execute
+      assert_instance_of SuperDuperExecutionAdapter, ShopifyAPI::GraphQL.client('unstable').execute
     end
 
-    ShopifyAPI::GraphQL.client_klass = nil
+    ShopifyAPI::GraphQL.execution_adapter = nil
   end
 
   private


### PR DESCRIPTION
### Preface

First I want to thank you all for implementing a more memory efficient GraphQL client. We are really excited to delete ours. I also really appreciate the light wrapper approach.

### Problem

Throughout our application we use the graphql api and one of the first things we noticed was that we needed to check the result object returned from the graphql client to determine if an error occurred. This wasn't something we liked scattered throughout our code and as a result we enhanced the client to parse errors and raise exceptions instead.

However, we appreciate this may not be the approach everyone wants to take. We also really like the lightweight approach. It better enables developers to instrument heuristics they prefer.

### Solution

In order to maintain flexibility, respect the light wrapper approach, and enable cleaner code I'd like to propose the ability to set a custom client implementation. As much as this will allow us to easily handle errors without monkey patching, I'm far more excited to use this in our tests. 