### PR TITLE
Default sessions to Base api_version

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
         params.each { |k,value| public_send("#{k}=", value) }
       end
 
-      def temp(domain:, token:, api_version: nil, &block)
+      def temp(domain:, token:, api_version: ShopifyAPI::Base.api_version, &block)
         session = new(domain: domain, token: token, api_version: api_version)
 
         with_session(session, &block)
@@ -84,9 +84,9 @@ module ShopifyAPI
       end
     end
 
-    def initialize(domain:, token:, api_version: nil, extra: {})
+    def initialize(domain:, token:, api_version: ShopifyAPI::Base.api_version, extra: {})
       self.domain = self.class.prepare_domain(domain)
-      self.api_version = api_version || ShopifyAPI::Base.api_version
+      self.api_version = api_version
       self.token = token
       self.extra = extra
     end

--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -20,7 +20,7 @@ module ShopifyAPI
         params.each { |k,value| public_send("#{k}=", value) }
       end
 
-      def temp(domain:, token:, api_version:, &block)
+      def temp(domain:, token:, api_version: nil, &block)
         session = new(domain: domain, token: token, api_version: api_version)
 
         with_session(session, &block)
@@ -84,9 +84,9 @@ module ShopifyAPI
       end
     end
 
-    def initialize(domain:, token:, api_version:, extra: {})
+    def initialize(domain:, token:, api_version: nil, extra: {})
       self.domain = self.class.prepare_domain(domain)
-      self.api_version = api_version
+      self.api_version = api_version || ShopifyAPI::Base.api_version
       self.token = token
       self.extra = extra
     end

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -18,18 +18,21 @@ class SessionTest < Test::Unit::TestCase
     assert_not session.valid?
   end
 
-  test "not be valid without an api version" do
+  test "not be valid without an API version" do
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: nil)
+    assert_not session.valid?
+
     session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: ShopifyAPI::ApiVersion::NullVersion)
     assert_not session.valid?
   end
 
-  test "default to base api version" do
-    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: nil)
+  test "default to base API version" do
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token")
     assert session.valid?
     assert_equal session.api_version, ShopifyAPI::Base.api_version
   end
 
-  test "can override the base api version" do
+  test "can override the base API version" do
     different_api_version = '2020-01'
     session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: different_api_version)
     assert session.valid?

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -19,11 +19,21 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "not be valid without an api version" do
-    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: nil)
-    assert_not session.valid?
-
     session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: ShopifyAPI::ApiVersion::NullVersion)
     assert_not session.valid?
+  end
+
+  test "default to base api version" do
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: nil)
+    assert session.valid?
+    assert_equal session.api_version, ShopifyAPI::Base.api_version
+  end
+
+  test "can override the base api version" do
+    different_api_version = '2020-01'
+    session = ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: different_api_version)
+    assert session.valid?
+    assert_equal session.api_version, ShopifyAPI::ApiVersion.find_version(different_api_version)
   end
 
   test "be valid with any token, any url and version" do


### PR DESCRIPTION
Paired with @carmelal for this one, to fix #743. We changed the way sessions (and temp sessions) are created so that they default to `Base.api_version` if no `api_version` is given, so that developers don't need to pass in the version every time they need a session.