### PR TITLE
Remove old shopify binary from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## Version 9.1.2
+
+* Removes the `shopify` binary which will be used by the Shopify CLI
+
 ## Version 9.1.1
 
 * Make cursor based pagination return relative uri's when fetching next and previous pages. [#726](https://github.com/Shopify/shopify_api/pull/726)

--- a/bin/shopify
+++ b/bin/shopify
@@ -1,3 +1,0 @@
-#!/usr/bin/env ruby
-puts "shopify command is no longer bundled with shopify_api."
-puts "if you need these tools, install the shopify_cli gem"

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,3 +1,3 @@
 module ShopifyAPI
-  VERSION = "9.1.1"
+  VERSION = "9.1.2"
 end

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -19,7 +19,6 @@ Gem::Specification.new do |s|
   ]
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test}/*`.split("\n")
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
 
   s.rdoc_options = ["--charset=UTF-8"]
   s.summary = %q{ShopifyAPI is a lightweight gem for accessing the Shopify admin REST web services}


### PR DESCRIPTION
With the upcoming CLI v2 changes, a new `shopify` executable will be generated and distributed, which will overwrite the current binary from this repo.

This is what happens when the current binary is executed:
```
% shopify
shopify command is no longer bundled with shopify_api.
if you need these tools, install the shopify_cli gem
```

Therefore, what this change does is simply fully remove the binary which no longer belongs to this gem so it doesn't accidentally overwrite the new CLI binary.

The version was bumped (patch bump since no function actually changed) so future installs don't bring the binary in over the new one.