### PR TITLE
Clean up Base user / password on temp sessions

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -28,12 +28,17 @@ module ShopifyAPI
 
       def with_session(session, &_block)
         original_session = extract_current_session
+        original_user = ShopifyAPI::Base.user
+        original_password = ShopifyAPI::Base.password
 
         begin
+          ShopifyAPI::Base.clear_session
           ShopifyAPI::Base.activate_session(session)
           yield
         ensure
           ShopifyAPI::Base.activate_session(original_session)
+          ShopifyAPI::Base.user = original_user
+          ShopifyAPI::Base.password = original_password
         end
       end
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -78,13 +78,17 @@ class SessionTest < Test::Unit::TestCase
     assert_equal "My test secret", ShopifyAPI::Session.secret
   end
 
-  test "#temp reset ShopifyAPI::Base.site to original value" do
+  test "#temp reset ShopifyAPI::Base values to original value" do
     session1 = ShopifyAPI::Session.new(domain: 'fakeshop.myshopify.com', token: 'token1', api_version: '2019-01')
+    ShopifyAPI::Base.user = 'foo'
+    ShopifyAPI::Base.password = 'bar'
     ShopifyAPI::Base.activate_session(session1)
 
     ShopifyAPI::Session.temp(domain: "testshop.myshopify.com", token: "any-token", api_version: :unstable) do
       @assigned_site = ShopifyAPI::Base.site
       @assigned_version = ShopifyAPI::Base.api_version
+      @assigned_user = ShopifyAPI::Base.user
+      @assigned_password = ShopifyAPI::Base.password
     end
 
     assert_equal('https://testshop.myshopify.com', @assigned_site.to_s)
@@ -92,6 +96,31 @@ class SessionTest < Test::Unit::TestCase
 
     assert_equal(ShopifyAPI::ApiVersion.new(handle: :unstable), @assigned_version)
     assert_equal(ShopifyAPI::ApiVersion.new(handle: '2019-01'), ShopifyAPI::Base.api_version)
+
+    assert_nil(@assigned_user)
+    assert_equal('foo', ShopifyAPI::Base.user)
+
+    assert_nil(@assigned_password)
+    assert_equal('bar', ShopifyAPI::Base.password)
+  end
+
+  test "#temp does not use basic auth values from Base.site" do
+    ShopifyAPI::Base.site = 'https://user:pass@fakeshop.myshopify.com'
+
+    ShopifyAPI::Session.temp(domain: "testshop.myshopify.com", token: "any-token", api_version: :unstable) do
+      @assigned_site = ShopifyAPI::Base.site
+      @assigned_user = ShopifyAPI::Base.user
+      @assigned_password = ShopifyAPI::Base.password
+    end
+
+    assert_equal('https://testshop.myshopify.com', @assigned_site.to_s)
+    assert_equal('https://fakeshop.myshopify.com', ShopifyAPI::Base.site.to_s)
+
+    assert_nil(@assigned_user)
+    assert_equal('user', ShopifyAPI::Base.user)
+
+    assert_nil(@assigned_password)
+    assert_equal('pass', ShopifyAPI::Base.password)
   end
 
   test "#with_session activates the session for the duration of the block" do


### PR DESCRIPTION
Fixes #744.
 
If an app was set up using `ShopifyAPI::Base.user/password`, temp sessions wouldn't work properly because those values would be set for them as well, which might not be desirable.

This change essentially ensures that we clear those values on `ShopifyAPI::Base` before running the block and restore them before exiting. That way, the temp session is indeed fresh.

**Concern**: while starting a fully fresh session makes sense and the suggested fix works, I wonder if it can be considered backward compatible. There could be a scenario where someone relies on the Basic auth settings being used for temp sessions, and those apps would be broken if they bumped their API version.