### PR TITLE
Stop using the deprecated URI.parser

### DIFF
--- a/lib/shopify_api/resources/base.rb
+++ b/lib/shopify_api/resources/base.rb
@@ -87,7 +87,7 @@ module ShopifyAPI
       def resource_prefix=(value)
         @prefix_parameters = nil
 
-        resource_prefix_call = value.gsub(/:\w+/) { |key| "\#{URI.parser.escape options[#{key}].to_s}" }
+        resource_prefix_call = value.gsub(/:\w+/) { |key| "\#{URI::DEFAULT_PARSER.escape options[#{key}].to_s}" }
 
         silence_warnings do
           # Redefine the new methods.


### PR DESCRIPTION
It's deprecated since https://github.com/rails/rails/pull/39733, but very easy to replace.