### PR TITLE
Revert "Prepare for api-patterns-team channel rename"

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -5,4 +5,4 @@ owners:
   - Shopify/app-partner-dev-tools-education
 slack_channels:
   - dev-tools-education
-  - help-api-patterns
+  - api-patterns-team


### PR DESCRIPTION
Reverts Shopify/shopify_api#776

Core shopify is locked until tomorrow due to a Datadog outage. I'm going to revert these changes and postpone our Slack channel rename until tomorrow.