### PR TITLE
Fix a typo in the GraphQL Docs

### DIFF
--- a/docs/graphql.md
+++ b/docs/graphql.md
@@ -32,7 +32,7 @@ result.data.shop.name
 ## Getting started
 
 1. [Dump the schema](#dump-the-schema)
-2. [Configure session/authencation](#sessions-and-authentication)
+2. [Configure session/authentication](#sessions-and-authentication)
 3. [Make queries](#make-queries)
 
 ### Dump the schema


### PR DESCRIPTION
This simply fixes a typo in the GraphQL documentation.