### PR TITLE
Filter unwanted product / variant attributes on creation

### DIFF
--- a/lib/shopify_api/resources/product.rb
+++ b/lib/shopify_api/resources/product.rb
@@ -5,6 +5,11 @@ module ShopifyAPI
 
     early_july_pagination_release!
 
+    def initialize(*)
+      super
+      self.attributes.except!('total_inventory') unless allow_inventory_params?
+    end
+
     # compute the price range
     def price_range
       prices = variants.collect(&:price).collect(&:to_f)
@@ -19,10 +24,6 @@ module ShopifyAPI
     def total_inventory=(new_value)
       raise_deprecated_inventory_call('total_inventory') unless allow_inventory_params?
       super
-    end
-
-    def serializable_hash(options = {})
-      allow_inventory_params? ? super(options) : super(options).except('total_inventory')
     end
 
     def collections

--- a/lib/shopify_api/resources/variant.rb
+++ b/lib/shopify_api/resources/variant.rb
@@ -4,7 +4,14 @@ module ShopifyAPI
     include DisablePrefixCheck
 
     conditional_prefix :product
-    
+
+    def initialize(*)
+      super
+      unless allow_inventory_params?
+        attributes.except!('inventory_quantity_adjustment', 'inventory_quantity', 'old_inventory_quantity')
+      end
+    end
+
     def inventory_quantity_adjustment=(new_value)
       raise_deprecated_inventory_call('inventory_quantity_adjustment') unless allow_inventory_params?
       super
@@ -18,16 +25,6 @@ module ShopifyAPI
     def old_inventory_quantity=(new_value)
       raise_deprecated_inventory_call('old_inventory_quantity') unless allow_inventory_params?
       super
-    end
-
-    def serializable_hash(options = {})
-      if allow_inventory_params?
-        super(options)
-      else
-        super(options).tap do |resource|
-          (resource['variant'] || resource).except!('inventory_quantity', 'old_inventory_quantity')
-        end
-      end
     end
 
     private


### PR DESCRIPTION
Fixes #775 

## Why am I making these changes?

We had reports that the changes made in #731 were causing the JSON serialization of API objects to break when `Base.api_version` wasn't set, for instance outside the scope of a temp session.

The issue here was that we were filtering the fields out only when serializing the Product / Variant objects, rather than removing them altogether (even though they were no longer allowed in the API after version `2019-10`).

## What is this PR doing?

This PR changes those objects so that we remove the fields when the object is first created, so that we don't need to check later on.