### PR TITLE
Add API support for scheduled fulfillment orders

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [#797](https://github.com/Shopify/shopify_api/pull/797) Release new Endpoint `fulfillment_order.open` and `fulfillment_order.reschedule`.
+
 * [#818](https://github.com/Shopify/shopify_api/pull/818) Avoid depending on ActiveSupport in Sesssion class.
 
 * Freeze all string literals. This should have no impact unless your application is modifying ('monkeypatching') the internals of the library in an unusual way.

--- a/lib/shopify_api/resources/fulfillment_order.rb
+++ b/lib/shopify_api/resources/fulfillment_order.rb
@@ -52,6 +52,19 @@ module ShopifyAPI
       keyed_fulfillment_orders
     end
 
+    def open
+      load_attributes_from_response(post(:open, {}, only_id))
+    end
+
+    def reschedule(new_fulfill_at:)
+      body = {
+        fulfillment_order: {
+          new_fulfill_at: new_fulfill_at,
+        },
+      }
+      load_attributes_from_response(post(:reschedule, {}, body.to_json))
+    end
+
     def close(message: nil)
       body = {
         fulfillment_order: {

--- a/test/fixtures/assigned_fulfillment_orders.json
+++ b/test/fixtures/assigned_fulfillment_orders.json
@@ -13,6 +13,7 @@
       "assigned_location_id": 905684977,
       "request_status": "cancellation_accepted",
       "delivery_category": null,
+      "fulfill_at": null,
       "fulfillment_order_line_items": [
          {
             "id": 519788021,
@@ -51,6 +52,7 @@
       "assigned_location_id": 905684977,
       "request_status": "cancellation_accepted",
       "delivery_category": null,
+      "fulfill_at": null,
       "fulfillment_order_line_items": [
          {
             "id": 519788021,

--- a/test/fixtures/fulfillment_order.json
+++ b/test/fixtures/fulfillment_order.json
@@ -12,6 +12,7 @@
    "assigned_location_id": 905684977,
    "request_status": "unsubmitted",
    "delivery_category": null,
+   "fulfill_at": null,
    "fulfillment_order_line_items": [
       {
          "id": 519788021,

--- a/test/fixtures/fulfillment_orders.json
+++ b/test/fixtures/fulfillment_orders.json
@@ -13,6 +13,7 @@
       "assigned_location_id": 905684977,
       "request_status": "unsubmitted",
       "delivery_category": null,
+      "fulfill_at": null,
       "fulfillment_order_line_items": [
          {
             "id": 519788021,
@@ -51,6 +52,7 @@
       "assigned_location_id": 905684977,
       "request_status": "unsubmitted",
       "delivery_category": null,
+      "fulfill_at": null,
       "fulfillment_order_line_items": [
          {
             "id": 519788021,


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shopify/issues/255067

Add `open` and `reschedule` APIs support for `scheduled` fulfillment orders.

- [x] POST /admin/api/2021-01/fulfillment_orders/{fulfillment_order_id}/open.json

- [x] POST /admin/api/2021-01/fulfillment_orders/{fulfillment_order_id}/reschedule.json