### PR TITLE
Hide bundler post-install messages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           rm -f ${GITHUB_WORKSPACE}/Gemfile.lock
       - name: Run Tests
         run: |
-          bundle config set with ignore_messages docs
+          bundle config set --with docs
+          bundle config set ignore_messages
           bundle
           bundle exec rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,6 @@ jobs:
           rm -f ${GITHUB_WORKSPACE}/Gemfile.lock
       - name: Run Tests
         run: |
-          bundle config set with ignore_messages
-          bundle config set with docs
+          bundle config set with ignore_messages docs
           bundle
           bundle exec rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           rm -f ${GITHUB_WORKSPACE}/Gemfile.lock
       - name: Run Tests
         run: |
+          bundle config set with ignore_messages
           bundle config set with docs
           bundle
           bundle exec rake test

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,6 +28,6 @@ jobs:
       - name: Run Tests
         run: |
           bundle config set --with docs
-          bundle config set ignore_messages
+          bundle config set ignore_messages true
           bundle
           bundle exec rake test


### PR DESCRIPTION
These may be useful in dev but in CI they're noisy.

Example:

```
Post-install message from i18n:

HEADS UP! i18n 1.1 changed fallbacks to exclude default locale.
But that may break your application.

If you are upgrading your Rails application from an older version of Rails:

Please check your Rails app for 'config.i18n.fallbacks = true'.
If you're using I18n (>= 1.1.0) and Rails (< 5.2.2), this should be
'config.i18n.fallbacks = [I18n.default_locale]'.
If not, fallbacks will be broken in your app by I18n 1.1.x.

If you are starting a NEW Rails application, you can ignore this notice.

For more info see:
https://github.com/svenfuchs/i18n/releases/tag/v1.1.0
```