### PR TITLE
Avoid depending on ActiveSupport

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -7,6 +7,8 @@ module ShopifyAPI
   end
 
   class Session
+    SECONDS_IN_A_DAY = 24 * 60 * 60
+
     cattr_accessor :api_key, :secret, :myshopify_domain
     self.myshopify_domain = 'myshopify.com'
 
@@ -106,7 +108,8 @@ module ShopifyAPI
     def request_token(params)
       return token if token
 
-      unless self.class.validate_signature(params) && params[:timestamp].to_i > 24.hours.ago.utc.to_i
+      twenty_four_hours_ago = Time.now.utc.to_i - SECONDS_IN_A_DAY
+      unless self.class.validate_signature(params) && params[:timestamp].to_i > twenty_four_hours_ago
         raise ShopifyAPI::ValidationException, "Invalid Signature: Possible malicious login"
       end
 

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -3,6 +3,8 @@ require 'test_helper'
 require 'timecop'
 
 class SessionTest < Test::Unit::TestCase
+  SECONDS_IN_A_DAY = 24 * 60 * 60
+
   def setup
     super
     ShopifyAPI::Session.secret = 'secret'
@@ -373,7 +375,7 @@ class SessionTest < Test::Unit::TestCase
   end
 
   test "raise error if timestamp is too old" do
-    params = { code: "any-code", timestamp: Time.now - 2.days }
+    params = { code: "any-code", timestamp: Time.now - 2 * SECONDS_IN_A_DAY }
     signature = generate_signature(params)
     params[:foo] = 'world'
     assert_raises(ShopifyAPI::ValidationException) do


### PR DESCRIPTION
In #817 we ran into an issue relating to ActiveSupport not being loaded when updating to Rails 6.1.0. We only use it for some trivial time-related helpers – I think we can drop it completely.