### PR TITLE
Clarify CHANGELOG entry for ActiveSupport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## Unreleased
 
-* [#818](https://github.com/Shopify/shopify_api/pull/818) Avoid depending on ActiveSupport
+* [#818](https://github.com/Shopify/shopify_api/pull/818) Avoid depending on ActiveSupport in Sesssion class.
 
 * Freeze all string literals. This should have no impact unless your application is modifying ('monkeypatching') the internals of the library in an unusual way.
 


### PR DESCRIPTION
I realised we still have a bunch of other places that depend on ActiveSupport.