### PR TITLE
Add logging based on env var

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,7 +25,7 @@ Tip: include an error message (in a `<details></details>` tag) if your issue is 
 1.
 
 ## Logs
-Enable logs with `export SHOPIFY_LOG=1` and paste them here
+Enable logs with `export SHOPIFY_LOG=1` and paste them here from "shopify_api.log"
 
 
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,36 @@
+# Issue summary
+
+Write a short description of the issue here ↓
+
+
+
+## Expected behavior
+
+What do you think should happen?
+
+
+
+## Actual behavior
+
+What actually happens?
+
+Tip: include an error message (in a `<details></details>` tag) if your issue is related to an error
+
+
+
+## Steps to reproduce the problem
+
+1.
+1.
+1.
+
+## Logs
+Enable logs with `export SHOPIFY_LOG=1` and paste them here
+
+
+
+## Specifications
+
+- `shopify_python_api` version:
+- `pyactiveresource` version:
+- Shopify API version used (e.g. `'2020-07'`):

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -25,12 +25,12 @@ Tip: include an error message (in a `<details></details>` tag) if your issue is 
 1.
 
 ## Logs
-Enable logs with `export SHOPIFY_LOG=1` and paste them here from "shopify_api.log"
+If applicable, enable the logs as described in the README, and paste the relevant portion here.
 
 
 
 ## Specifications
 
-- `shopify_python_api` version:
-- `pyactiveresource` version:
-- Shopify API version used (e.g. `'2020-07'`):
+- `shopify_api` version:
+- `activeresource` version:
+- Shopify API version used (example: `2020-07`):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 * [#802](https://github.com/Shopify/shopify_api/pull/802) Made `inventory_quantity` a read-only field in Variant
 
+* [#821](https://github.com/Shopify/shopify_api/pull/821) Add logging based on environment variable, move log subscriber out of `detailed_log_subscriber`.
+  The `ActiveResource::DetailedLogSubscriber` no longer automatically attaches when the class is loaded. If you were previously relying on that behaviour, you'll now need to call `ActiveResource::DetailedLogSubscriber.attach_to(:active_resource_detailed)`. (If using the new `SHOPIFY_LOG_PATH` environment setting then this is handled for you).
+
 ## Version 9.2.0
 
 * Removes the `shopify` binary which will be used by the Shopify CLI

--- a/README.md
+++ b/README.md
@@ -634,6 +634,8 @@ Enable ActiveResource's logger with
 
 `export SHOPIFY_LOG=1`
 
+This will create "shopify_api.log" in the current project directory.
+
 # Additional Resources
 
 * [GraphQL API Reference](https://shopify.dev/docs/admin-api/graphql/reference)

--- a/README.md
+++ b/README.md
@@ -632,9 +632,9 @@ bundle exec rake docker
 
 Enable ActiveResource's logger with 
 
-`export SHOPIFY_LOG=1`
+`export SHOPIFY_LOG_PATH={your_log_path}`
 
-This will create "shopify_api.log" in the current project directory.
+This will create file `your_log_path` in the current project directory.
 
 # Additional Resources
 

--- a/README.md
+++ b/README.md
@@ -13,34 +13,36 @@ The REST API is implemented as JSON over HTTP using all four verbs (GET/POST/PUT
 
 - [Shopify API](#shopify-api)
 - [Usage](#usage)
-  * [Requirements](#requirements)
-    + [Ruby version](#ruby-version)
-  * [Installation](#installation)
-  * [Getting Started](#getting-started)
-    + [1) Create an app](#1-create-an-app)
-    + [2A) Private Apps](#2a-private-apps)
-    + [2B) Public and Custom Apps](#2b-public-and-custom-apps)
-    + [3) Requesting access from a shop](#3-requesting-access-from-a-shop)
-    + [4) Trading your `code` for an access token.](#4-trading-your--code--for-an-access-token)
-    + [5) Activating the session](#5-activating-the-session)
-    + [6A) Making requests to the GraphQL API](#6a-making-requests-to-the-graphql-api)
-    + [6B) Making requests to the REST API](#6b-making-requests-to-the-rest-api)
-  * [Console](#console)
-  * [Thread safety](#thread-safety)
-  * [Bulk Operations](#bulk-operations)
-    + [Example](#example)
+  - [Requirements](#requirements)
+    - [Ruby version](#ruby-version)
+  - [Installation](#installation)
+  - [Getting Started](#getting-started)
+    - [1) Create an app](#1-create-an-app)
+    - [2A) Private Apps](#2a-private-apps)
+    - [2B) Public and Custom Apps](#2b-public-and-custom-apps)
+    - [3) Requesting access from a shop](#3-requesting-access-from-a-shop)
+    - [4) Trading your `code` for an access token.](#4-trading-your-code-for-an-access-token)
+    - [5) Activating the session](#5-activating-the-session)
+    - [6A) Making requests to the GraphQL API](#6a-making-requests-to-the-graphql-api)
+          - [Note: the GraphQL client has improved and changed in version 9.0. See the client documentation for full usage details and a [migration guide](docs/graphql.md#migration-guide).](#note-the-graphql-client-has-improved-and-changed-in-version-90-see-the-client-documentation-for-full-usage-details-and-a-migration-guide)
+    - [6B) Making requests to the REST API](#6b-making-requests-to-the-rest-api)
+  - [Console](#console)
+  - [Thread safety](#thread-safety)
+  - [Bulk Operations](#bulk-operations)
+    - [Example](#example)
       - [1) Start the bulk operation](#1-start-the-bulk-operation)
-      - [2) Poll the status of the bulk operation](#2-poll-the-status-of-the-bulk-operation)
-      - [3) Retrieve your data](#3-retrieve-your-data)
-  * [Pagination](#pagination)
+      - [Step 2) Poll the status of the bulk operation](#step-2-poll-the-status-of-the-bulk-operation)
+      - [Step 3) Retrieve your data](#step-3-retrieve-your-data)
+  - [Pagination](#pagination)
 - [Breaking Change Notices](#breaking-change-notices)
-  * [Breaking change notice for version 8.0.0](#breaking-change-notice-for-version-800)
-  * [Breaking change notice for version 7.0.0](#breaking-change-notice-for-version-700)
-    + [Changes to ShopifyAPI::Session](#changes-to-shopifyapi--session)
-    + [Changes to how to define resources](#changes-to-how-to-define-resources)
-    + [URL construction](#url-construction)
-    + [URLs that have not changed](#urls-that-have-not-changed)
+  - [Breaking change notice for version 8.0.0](#breaking-change-notice-for-version-800)
+  - [Breaking change notice for version 7.0.0](#breaking-change-notice-for-version-700)
+    - [Changes to ShopifyAPI::Session](#changes-to-shopifyapisession)
+    - [Changes to how to define resources](#changes-to-how-to-define-resources)
+    - [URL construction](#url-construction)
+    - [URLs that have not changed](#urls-that-have-not-changed)
 - [Using Development Version](#using-development-version)
+- [Logging](#logging)
 - [Additional Resources](#additional-resources)
 - [Copyright](#copyright)
 
@@ -625,6 +627,12 @@ or you can even use our automated rake task for docker:
 ```bash
 bundle exec rake docker
 ```
+
+# Logging 
+
+Enable ActiveResource's logger with 
+
+`export SHOPIFY_LOG=1`
 
 # Additional Resources
 

--- a/lib/active_resource/detailed_log_subscriber.rb
+++ b/lib/active_resource/detailed_log_subscriber.rb
@@ -49,5 +49,3 @@ module ActiveResource
     end
   end
 end
-
-ActiveResource::DetailedLogSubscriber.attach_to(:active_resource_detailed)

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -33,7 +33,7 @@ else
   require 'active_resource/connection_ext'
 end
 
-if ENV["SHOPIFY_LOG"] == '1'
-  ActiveResource::Base.logger = Logger.new("shopify_api.log")
+if ENV["SHOPIFY_LOG_PATH"]
+  ActiveResource::Base.logger = Logger.new(ENV["SHOPIFY_LOG_PATH"])
   ActiveResource::DetailedLogSubscriber
 end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -32,3 +32,8 @@ if ShopifyAPI::Base.respond_to?(:connection_class)
 else
   require 'active_resource/connection_ext'
 end
+
+if ENV["SHOPIFY_LOG"] == '1'
+  ActiveResource::Base.logger = Logger.new("shopify_api.log")
+  ActiveResource::DetailedLogSubscriber
+end

--- a/lib/shopify_api.rb
+++ b/lib/shopify_api.rb
@@ -35,5 +35,5 @@ end
 
 if ENV["SHOPIFY_LOG_PATH"]
   ActiveResource::Base.logger = Logger.new(ENV["SHOPIFY_LOG_PATH"])
-  ActiveResource::DetailedLogSubscriber
+  ActiveResource::DetailedLogSubscriber.attach_to(:active_resource_detailed)
 end


### PR DESCRIPTION
Logging is enabled through `export SHOPIFY_LOG_PATH={path}`

Is this the right way to go about logging? Current solution is to have users set an env variable SHOPIFY_LOG_PATH.
Should I also include some method inside the API to enable logging such as `ShopifyAPI::Logging=true`?