### PR TITLE
Remove access tokens in log headers

### DIFF
--- a/lib/active_resource/detailed_log_subscriber.rb
+++ b/lib/active_resource/detailed_log_subscriber.rb
@@ -3,6 +3,9 @@ module ActiveResource
   class DetailedLogSubscriber < ActiveSupport::LogSubscriber
     VERSION_EOL_WARNING_HEADER = 'x-shopify-api-version-warning'
     VERSION_DEPRECATION_HEADER = 'x-shopify-api-deprecated-reason'
+    SHOPIFY_ACCESS_TOKEN = 'X-Shopify-Access-Token'
+    FILTERED = '[FILTERED]'
+
     def request(event)
       log_request_response_details(event)
       warn_on_deprecated_header_or_version_eol_header(event)
@@ -17,10 +20,11 @@ module ActiveResource
     def log_request_response_details(event)
       data = event.payload[:data]
       headers = data.extract_options!
+      headers[SHOPIFY_ACCESS_TOKEN] = FILTERED
       request_body = data.first
 
       info("Request:\n#{request_body}") if request_body
-      info("Headers: #{headers.except("X-Shopify-Access-Token").inspect}")
+      info("Headers: #{headers.inspect}")
       info("Response:\n#{event.payload[:response].body}")
     end
 

--- a/lib/active_resource/detailed_log_subscriber.rb
+++ b/lib/active_resource/detailed_log_subscriber.rb
@@ -20,7 +20,7 @@ module ActiveResource
       request_body = data.first
 
       info("Request:\n#{request_body}") if request_body
-      info("Headers: #{headers.inspect}")
+      info("Headers: #{headers.except("X-Shopify-Access-Token").inspect}")
       info("Response:\n#{event.payload[:response].body}")
     end
 

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -14,7 +14,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     @ua_header = "\"User-Agent\"=>\"ShopifyAPI/#{ShopifyAPI::VERSION} " \
       "ActiveResource/#{ActiveResource::VERSION::STRING} Ruby/#{RUBY_VERSION}\""
     @request_headers = "Headers: {\"Accept\"=>\"application/json\", " \
-      "#{@ua_header}, \"X-Shopify-Access-Token\"=>\"access_token\"}"
+      "#{@ua_header}}"
 
     ShopifyAPI::Base.clear_session
     fake(

--- a/test/detailed_log_subscriber_test.rb
+++ b/test/detailed_log_subscriber_test.rb
@@ -14,7 +14,7 @@ class LogSubscriberTest < Test::Unit::TestCase
     @ua_header = "\"User-Agent\"=>\"ShopifyAPI/#{ShopifyAPI::VERSION} " \
       "ActiveResource/#{ActiveResource::VERSION::STRING} Ruby/#{RUBY_VERSION}\""
     @request_headers = "Headers: {\"Accept\"=>\"application/json\", " \
-      "#{@ua_header}}"
+      "#{@ua_header}, \"X-Shopify-Access-Token\"=>\"[FILTERED]\"}"
 
     ShopifyAPI::Base.clear_session
     fake(


### PR DESCRIPTION
Removing sensitive information from the log
`INFO -- : Headers: {"Accept"=>"application/json", "User-Agent"=>"ShopifyAPI/9.3.0 ActiveResource/5.1.1 Ruby/2.7.1", "X-Shopify-Access-Token"=>"..."}`

becomes

`INFO -- : Headers: {"Accept"=>"application/json", "User-Agent"=>"ShopifyAPI/9.3.0 ActiveResource/5.1.1 Ruby/2.7.1"}`