### PR TITLE
Add access_scopes attribute to session object

### DIFF
--- a/lib/shopify_api/session.rb
+++ b/lib/shopify_api/session.rb
@@ -13,7 +13,7 @@ module ShopifyAPI
     self.myshopify_domain = 'myshopify.com'
 
     attr_accessor :domain, :token, :name, :extra
-    attr_reader :api_version
+    attr_reader :api_version, :access_scopes
     alias_method :url, :domain
 
     class << self
@@ -92,10 +92,11 @@ module ShopifyAPI
       end
     end
 
-    def initialize(domain:, token:, api_version: ShopifyAPI::Base.api_version, extra: {})
+    def initialize(domain:, token:, access_scopes: nil, api_version: ShopifyAPI::Base.api_version, extra: {})
       self.domain = self.class.prepare_domain(domain)
       self.api_version = api_version
       self.token = token
+      self.access_scopes = access_scopes
       self.extra = extra
     end
 
@@ -179,6 +180,11 @@ module ShopifyAPI
     end
 
     private
+
+    def access_scopes=(access_scopes)
+      return unless access_scopes
+      @access_scopes = ShopifyAPI::ApiAccess.new(access_scopes)
+    end
 
     def parameterize(params)
       URI.escape(params.collect { |k, v| "#{k}=#{v}" }.join('&'))

--- a/test/session_test.rb
+++ b/test/session_test.rb
@@ -54,6 +54,39 @@ class SessionTest < Test::Unit::TestCase
     assert(session.valid?)
   end
 
+  test "be valid with nil access_scopes" do
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version,
+      access_scopes: nil
+    )
+
+    assert(session.valid?)
+  end
+
+  test "be valid with string of access_scopes" do
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version,
+      access_scopes: "read_products, write_orders"
+    )
+
+    assert(session.valid?)
+  end
+
+  test "be valid with a collection of access_scopes" do
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version,
+      access_scopes: %w(read_products write_orders)
+    )
+
+    assert(session.valid?)
+  end
+
   test "not raise error without params" do
     assert_nothing_raised do
       ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: any_api_version)
@@ -81,6 +114,36 @@ class SessionTest < Test::Unit::TestCase
   test "not raise error without params" do
     assert_nothing_raised do
       ShopifyAPI::Session.new(domain: "testshop.myshopify.com", token: "any-token", api_version: any_api_version)
+    end
+  end
+
+  test "provides default nil access_scopes attribute" do
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      api_version: any_api_version
+    )
+    assert_nil session.access_scopes
+  end
+
+  test "provides specified nil access_scopes attribute" do
+    session = ShopifyAPI::Session.new(
+      domain: "testshop.myshopify.com",
+      token: "any-token",
+      access_scopes: "read_products",
+      api_version: any_api_version
+    )
+    assert_equal "read_products", session.access_scopes.to_s
+  end
+
+  test "session instantiation raises error if bad access scopes are provided" do
+    assert_raises NoMethodError do
+      ShopifyAPI::Session.new(
+        domain: "testshop.myshopify.com",
+        token: "any-token",
+        access_scopes: { bad_input: "bad_input" },
+        api_version: any_api_version
+      )
     end
   end
 


### PR DESCRIPTION
> Related: https://github.com/Shopify/shopify_app/pull/1192

This PR introduces an `access_scopes` attribute to the Session object. 

## Things to focus on

1. Do we determine the validity of a session through this attribute?
2. Is there immediate benefit in returning a `ShopifyAPI::ApiAccess` object? Will a string suffice?
3. ~~Is this level of error handling needed?~~