### PR TITLE
Packaging for release 9.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## Version 9.4.0
+
+* [#843](https://github.com/Shopify/shopify_api/pull/843) Introduce a new `access_scopes` attribute on the Session class.
+  * Specifying this in the Session constructor is optional. By default, this attribute returns `nil`.
+
 ## Version 9.3.0
 
 * [#797](https://github.com/Shopify/shopify_api/pull/797) Release new Endpoint `fulfillment_order.open` and `fulfillment_order.reschedule`.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (9.3.0)
+    shopify_api (9.4.0)
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
@@ -41,7 +41,7 @@ GEM
     eventmachine (1.2.7)
     ffi (1.12.2)
     forwardable-extended (2.6.0)
-    graphql (1.12.3)
+    graphql (1.12.5)
     graphql-client (0.16.0)
       activesupport (>= 3.0)
       graphql (~> 1.8)

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module ShopifyAPI
-  VERSION = "9.3.0"
+  VERSION = "9.4.0"
 end


### PR DESCRIPTION
## Version 9.4.0

* [#843](https://github.com/Shopify/shopify_api/pull/843) Introduce a new `access_scopes` attribute on the Session class.
  * Specifying this in the Session constructor is optional. By default, this attribute returns `nil`.