### PR TITLE
Add dev.yml (for Shopify employees)

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,11 @@
+name: shopify-api
+
+type: ruby
+
+up:
+  - ruby: 2.7.1
+  - bundler
+
+commands:
+  test:
+    run: bundle exec rake test


### PR DESCRIPTION
This adds a basic configuration for `dev`, the tooling used internally at Shopify.