### PR TITLE
Drop the dependency on webrick

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,6 @@ PATH
       activeresource (>= 4.1.0, < 6.0.0)
       graphql-client
       rack
-      webrick
 
 GEM
   remote: https://rubygems.org/
@@ -130,7 +129,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.7.0)
     zeitwerk (2.3.0)
 
 PLATFORMS

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("activeresource", ">= 4.1.0", "< 6.0.0")
   s.add_runtime_dependency("rack")
   s.add_runtime_dependency("graphql-client")
-  s.add_runtime_dependency("webrick")
 
   s.add_development_dependency("mocha", ">= 1.4.0")
   s.add_development_dependency("webmock")


### PR DESCRIPTION
It made sense to use these utils when they were part of the stdlib but now it's a bit silly to pull a whole webserver for 5 lines of code.