### PR TITLE
Allow using latest activeresource(6.0.0)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 
 gemspec
 
-gem "activeresource", "~> 5.1"
+gem "activeresource", "~> 6.0"
 
 group :docs, optional: true do
   gem "jekyll"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,29 +2,29 @@ PATH
   remote: .
   specs:
     shopify_api (9.5)
-      activeresource (>= 4.1.0, < 6.0.0)
+      activeresource (>= 4.1.0, < 7.0.0)
       graphql-client
       rack
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (6.0.3.1)
-      activesupport (= 6.0.3.1)
+    activemodel (6.1.4.4)
+      activesupport (= 6.1.4.4)
     activemodel-serializers-xml (1.0.2)
       activemodel (> 5.x)
       activesupport (> 5.x)
       builder (~> 3.1)
-    activeresource (5.1.1)
-      activemodel (>= 5.0, < 7)
+    activeresource (6.0.0)
+      activemodel (>= 6.0)
       activemodel-serializers-xml (~> 1.0)
-      activesupport (>= 5.0, < 7)
-    activesupport (6.0.3.1)
+      activesupport (>= 6.0)
+    activesupport (6.1.4.4)
       concurrent-ruby (~> 1.0, >= 1.0.2)
-      i18n (>= 0.7, < 2)
-      minitest (~> 5.1)
-      tzinfo (~> 1.1)
-      zeitwerk (~> 2.2, >= 2.2.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+      zeitwerk (~> 2.3)
     addressable (2.8.0)
       public_suffix (>= 2.0.2, < 5.0)
     ast (2.4.1)
@@ -32,7 +32,7 @@ GEM
     byebug (11.1.3)
     coderay (1.1.2)
     colorator (1.1.0)
-    concurrent-ruby (1.1.6)
+    concurrent-ruby (1.1.9)
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     em-websocket (0.5.1)
@@ -47,7 +47,7 @@ GEM
       graphql (~> 1.10)
     hashdiff (1.0.1)
     http_parser.rb (0.6.0)
-    i18n (1.8.2)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
     jekyll (4.1.0)
       addressable (~> 2.4)
@@ -78,7 +78,7 @@ GEM
       rb-inotify (~> 0.9, >= 0.9.10)
     mercenary (0.4.0)
     method_source (1.0.0)
-    minitest (5.14.4)
+    minitest (5.15.0)
     mocha (1.11.2)
     parallel (1.19.2)
     parser (2.7.2.0)
@@ -120,22 +120,21 @@ GEM
       ffi (~> 1.9)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
-    thread_safe (0.3.6)
     timecop (0.9.1)
-    tzinfo (1.2.7)
-      thread_safe (~> 0.1)
+    tzinfo (2.0.4)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (1.7.0)
     webmock (3.8.3)
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    zeitwerk (2.3.0)
+    zeitwerk (2.5.3)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
-  activeresource (~> 5.1)
+  activeresource (~> 6.0)
   jekyll
   minitest (>= 5.14)
   mocha (>= 1.4.0)

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = ">= 2.4"
 
-  s.add_runtime_dependency("activeresource", ">= 4.1.0", "< 6.0.0")
+  s.add_runtime_dependency("activeresource", ">= 4.1.0", "< 7.0.0")
   s.add_runtime_dependency("rack")
   s.add_runtime_dependency("graphql-client")
 


### PR DESCRIPTION
Activeresource 6.0.0 has been released and supports rails 7.  This is a simple PR to switch this gem to allow using the latests activeresource(6.0.0)