### PR TITLE
Use new Metafield types API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Unreleased
 
+* [#916](https://github.com/Shopify/shopify_api/pull/916) Use new Metafield types API
+
 ## Version 9.5.1
 
 - [#891](https://github.com/Shopify/shopify_api/pull/891) Removed the upper bound on the `activeresource` dependency to allow apps to use the latest version

--- a/lib/shopify_api/resources/metafield.rb
+++ b/lib/shopify_api/resources/metafield.rb
@@ -3,12 +3,19 @@ module ShopifyAPI
   class Metafield < Base
     include DisablePrefixCheck
 
+    NEW_TYPES_IN_VERSION = ShopifyAPI::ApiVersion.find_version("2021-07")
+
     conditional_prefix :resource, true
     early_july_pagination_release!
 
     def value
       return if attributes["value"].nil?
-      attributes["value_type"] == "integer" ? attributes["value"].to_i : attributes["value"]
+
+      if ShopifyAPI::Base.api_version >= NEW_TYPES_IN_VERSION
+        %w[integer number_integer].include?(attributes["type"]) ? attributes["value"].to_i : attributes["value"]
+      else
+        attributes["value_type"] == "integer" ? attributes["value"].to_i : attributes["value"]
+      end
     end
   end
 end

--- a/test/metafield_test.rb
+++ b/test/metafield_test.rb
@@ -53,4 +53,21 @@ class MetafieldTest < Test::Unit::TestCase
     metafield = ShopifyAPI::Metafield.find(721389482)
     assert(metafield.destroy)
   end
+
+  def test_coerce_metafield_value
+    metafield = ShopifyAPI::Metafield.new(value: "999", value_type: "integer")
+    assert_equal(999, metafield.value)
+  end
+
+  def test_coerce_metafield_value_2021_07
+    ShopifyAPI::ApiVersion.version_lookup_mode = :define_on_unknown
+    version = ShopifyAPI::ApiVersion.find_version('2021-07')
+    ShopifyAPI::Base.api_version = version.to_s
+
+    metafield1 = ShopifyAPI::Metafield.new(value: "999", type: "integer")
+    assert_equal(999, metafield1.value)
+
+    metafield2 = ShopifyAPI::Metafield.new(value: "999", type: "number_integer")
+    assert_equal(999, metafield2.value)
+  end
 end


### PR DESCRIPTION
Conditionally replaces usage of the `Metafield.valueType` field, which was deprecated in API version `2021-07`[^1] and is scheduled to be removed completely on the October 1st 2022.

Based on the migration docs we assume integer Metafields can have the type `integer` if they were created under the new type regime or `number_integer` if they were created under the new regime[^2].

FIXES: #902

[^1]: https://shopify.dev/changelog/online-store-2-0-new-metafields-type-system-and-dynamic-sources
[^2]: https://shopify.dev/apps/metafields/types#migrate-your-metafields-in-the-rest-api

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] ~~I have updated the project documentation.~~ n/a
- [x] I have added a changelog line.