### PR TITLE
Fix Eager Load: uninitialized constant ShopifyAPI::AdminVersions (Nam…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - [#919](https://github.com/Shopify/shopify_api/pull/919) Allow REST resources to configure a deny list of attributes to be excluded when saving
+- [#921](https://github.com/Shopify/shopify_api/pull/921) Fix the Zeitwerk issue [#913](https://github.com/Shopify/shopify_api/issues/913) and allow the applications start successfully with `config.eager_load = true`
 
 ## Version 10.0.0
 

--- a/lib/shopify_api/admin_versions.rb
+++ b/lib/shopify_api/admin_versions.rb
@@ -12,4 +12,7 @@ module ShopifyAPI
   ], T::Array[String])
 
   LATEST_SUPPORTED_ADMIN_VERSION = T.let("2022-01", String)
+  
+  class AdminVersions
+  end
 end

--- a/lib/shopify_api/admin_versions.rb
+++ b/lib/shopify_api/admin_versions.rb
@@ -12,7 +12,7 @@ module ShopifyAPI
   ], T::Array[String])
 
   LATEST_SUPPORTED_ADMIN_VERSION = T.let("2022-01", String)
-  
+
   class AdminVersions
   end
 end

--- a/test/admin_versions_test.rb
+++ b/test/admin_versions_test.rb
@@ -12,7 +12,7 @@ module ShopifyAPITest
     def test_supported_latest_supported_admin_version
       assert_instance_of(String, ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION)
     end
-    
+
     def test_loading_of_shopify_admin_versions
       assert_instance_of(Class, ShopifyAPI::AdminVersions)
     end

--- a/test/admin_versions_test.rb
+++ b/test/admin_versions_test.rb
@@ -12,5 +12,9 @@ module ShopifyAPITest
     def test_supported_latest_supported_admin_version
       assert_instance_of(String, ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION)
     end
+    
+    def test_loading_of_shopify_admin_versions
+      assert_instance_of(Class, ShopifyAPI::AdminVersions)
+    end
   end
 end


### PR DESCRIPTION
## Description
Application fails to start with `config.eager_load = true` which is by default in production.
This commit fixes the error thrown by zeitwerk: `const_get’: uninitialized constant ShopifyAPI::AdminVersions (NameError)

Fixes https://github.com/Shopify/shopify_api/issues/913

## How has this been tested?

The change was tested manually in the local environment, after the change, the application `shopify_app` started successfully + a new unit test.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.