### PR TITLE
Run CI on pull requests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,6 +2,7 @@ name: CI
 
 on:
   - push
+  - pull_request
 
 jobs:
   build:


### PR DESCRIPTION
It seems we're only running CI on `push` requests, which means it doesn't get run for 3rd-party contributions.