### PR TITLE
Fix AdminVersions module name

### DIFF
--- a/lib/shopify_api/admin_versions.rb
+++ b/lib/shopify_api/admin_versions.rb
@@ -2,14 +2,19 @@
 # frozen_string_literal: true
 
 module ShopifyAPI
-  SUPPORTED_ADMIN_VERSIONS = T.let([
-    "unstable",
-    "2022-04",
-    "2022-01",
-    "2021-10",
-    "2021-07",
-    "2021-04",
-  ], T::Array[String])
+  module AdminVersions
+    SUPPORTED_ADMIN_VERSIONS = T.let([
+      "unstable",
+      "2022-04",
+      "2022-01",
+      "2021-10",
+      "2021-07",
+      "2021-04",
+    ], T::Array[String])
 
-  LATEST_SUPPORTED_ADMIN_VERSION = T.let("2022-01", String)
+    LATEST_SUPPORTED_ADMIN_VERSION = T.let("2022-01", String)
+  end
+
+  SUPPORTED_ADMIN_VERSIONS = ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS
+  LATEST_SUPPORTED_ADMIN_VERSION = ShopifyAPI::AdminVersions::LATEST_SUPPORTED_ADMIN_VERSION
 end

--- a/lib/shopify_api/context.rb
+++ b/lib/shopify_api/context.rb
@@ -52,9 +52,9 @@ module ShopifyAPI
         private_shop: nil,
         user_agent_prefix: nil
       )
-        unless SUPPORTED_ADMIN_VERSIONS.include?(api_version)
+        unless ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS.include?(api_version)
           raise Errors::UnsupportedVersionError,
-            "Invalid vession #{api_version}, supported versions: #{SUPPORTED_ADMIN_VERSIONS}"
+            "Invalid vession #{api_version}, supported versions: #{ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS}"
         end
 
         @api_key = api_key

--- a/test/admin_versions_test.rb
+++ b/test/admin_versions_test.rb
@@ -6,11 +6,11 @@ require_relative "./test_helper"
 module ShopifyAPITest
   class AdminVersionsTest < Minitest::Test
     def test_supported_admin_versions
-      assert_instance_of(Array, ShopifyAPI::SUPPORTED_ADMIN_VERSIONS)
+      assert_instance_of(Array, ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS)
     end
 
     def test_supported_latest_supported_admin_version
-      assert_instance_of(String, ShopifyAPI::LATEST_SUPPORTED_ADMIN_VERSION)
+      assert_instance_of(String, ShopifyAPI::AdminVersions::LATEST_SUPPORTED_ADMIN_VERSION)
     end
   end
 end


### PR DESCRIPTION
## Description

Fixes #913

The `admin_versions` file was incorrectly set up, and ended up breaking backward compatibility by dropping the module name.

To make sure this doesn't break any existing apps, as well as to continue providing a shorthand, I aliased the values in the module to the global one as well.

Props to @scart88 for picking this up!

## How has this been tested?

Via the unit tests.

## Checklist:

- [X] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [X] I have performed a self-review of my own code.
- [X] I have added tests that prove my fix is effective or that my feature works.
- [X] I have added a changelog line.
