### PR TITLE
Validating .spin.dev domains in JWT check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### Fixed
 - [#935](https://github.com/Shopify/shopify_api/pull/935) Fix issue [#931](https://github.com/Shopify/shopify_api/pull/931), weight of variant should be float
+- [#939](https://github.com/Shopify/shopify_api/pull/939) Hotfix for `.spin.dev` JWT validation.
 
 ## Version 10.0.2
 

--- a/Rakefile
+++ b/Rakefile
@@ -11,7 +11,7 @@ namespace :test do
 
   Rake::TestTask.new(:rest_wrappers) do |t|
     pattern = if ENV.key?("API_VERSION")
-      "test/rest/**/#{ENV["API_VERSION"]}/*.rb"
+      "test/rest/**/#{ENV.fetch("API_VERSION")}/*.rb"
     else
       "test/rest/**/*.rb"
     end

--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -46,7 +46,7 @@ module ShopifyAPI
 
       sig { params(shop: String).returns(T::Boolean) }
       def validate_shop(shop)
-        /\A[a-z0-9]+[a-z0-9\-]*[a-z0-9]+\.myshopify\.(io|com)\z/.match?(shop)
+        /\A[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\.(myshopify\.(io|com)|spin\.dev)\z/.match?(shop)
       end
 
       alias_method :eql?, :==

--- a/test/auth/jwt_payload_test.rb
+++ b/test/auth/jwt_payload_test.rb
@@ -38,6 +38,26 @@ module ShopifyAPITest
           })
       end
 
+      def test_decode_jwt_payload_succeeds_with_spin_domain
+        payload = @jwt_payload.dup
+        payload[:iss] = "https://test-shop.other.spin.dev/admin"
+        payload[:dest] = "https://test-shop.other.spin.dev"
+        jwt_token = JWT.encode(payload, ShopifyAPI::Context.api_secret_key, "HS256")
+        decoded = ShopifyAPI::Auth::JwtPayload.new(jwt_token)
+        assert_equal(payload,
+          {
+            iss: decoded.iss,
+            dest: decoded.dest,
+            aud: decoded.aud,
+            sub: decoded.sub,
+            exp: decoded.exp,
+            nbf: decoded.nbf,
+            iat: decoded.iat,
+            jti: decoded.jti,
+            sid: decoded.sid,
+          })
+      end
+
       def test_decode_jwt_payload_fails_with_wrong_key
         jwt_token = JWT.encode(@jwt_payload, "Wrong", "HS256")
         assert_raises(ShopifyAPI::Errors::InvalidJwtTokenError) do


### PR DESCRIPTION
## Description

Contributes to https://github.com/Shopify/first-party-library-planning/issues/203

This PR fixes JWT validation for services running under the `.spin.dev` domain, namely our first party apps.

## How has this been tested?

I have manually hotfixed a spin deployment with this change and validated that the JWT check works as expected. I've also added a unit test to cover this case for future regressions. 

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
