### PR TITLE
Fixes `to_hash` to include readonly attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 - [#935](https://github.com/Shopify/shopify_api/pull/935) Fix issue [#931](https://github.com/Shopify/shopify_api/pull/931), weight of variant should be float
 - [#944](https://github.com/Shopify/shopify_api/pull/944) Deprecated the `validate_shop` method from the JWT class since we can trust the token payload, since it comes from Shopify.
+- [#941](https://github.com/Shopify/shopify_api/pull/941) Fix `to_hash` to return readonly attributes, unless being used for serialize the object for saving - fix issue [#930](https://github.com/Shopify/shopify_api/issues/930)
 
 ## Version 10.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,14 @@
 
 ## Unreleased
 
+- [#941](https://github.com/Shopify/shopify_api/pull/941) Fix `to_hash` to return readonly attributes, unless being used for serialize the object for saving - fix issue [#930](https://github.com/Shopify/shopify_api/issues/930)
+
 ## Version 10.0.3
 
 ### Fixed
 
 - [#935](https://github.com/Shopify/shopify_api/pull/935) Fix issue [#931](https://github.com/Shopify/shopify_api/pull/931), weight of variant should be float
 - [#944](https://github.com/Shopify/shopify_api/pull/944) Deprecated the `validate_shop` method from the JWT class since we can trust the token payload, since it comes from Shopify.
-- [#941](https://github.com/Shopify/shopify_api/pull/941) Fix `to_hash` to return readonly attributes, unless being used for serialize the object for saving - fix issue [#930](https://github.com/Shopify/shopify_api/issues/930)
 
 ## Version 10.0.2
 

--- a/lib/shopify_api/rest/base.rb
+++ b/lib/shopify_api/rest/base.rb
@@ -116,10 +116,16 @@ module ShopifyAPI
           @has_many.include?(attribute)
         end
 
+        sig { returns(T::Hash[Symbol, Class]) }
+        attr_reader :has_many
+
         sig { params(attribute: Symbol).returns(T::Boolean) }
         def has_one?(attribute)
           @has_one.include?(attribute)
         end
+
+        sig { returns(T::Hash[Symbol, Class]) }
+        attr_reader :has_one
 
         sig { returns(T.nilable(T::Array[Symbol])) }
         def read_only_attributes
@@ -261,8 +267,8 @@ module ShopifyAPI
         match.nil? ? true : super
       end
 
-      sig { returns(T::Hash[String, T.untyped]) }
-      def to_hash
+      sig { params(saving: T::Boolean).returns(T::Hash[String, T.untyped]) }
+      def to_hash(saving = false)
         hash = {}
         instance_variables.each do |var|
           next if [
@@ -273,7 +279,7 @@ module ShopifyAPI
             :"@errors",
             :"@aliased_properties",
           ].include?(var)
-          next if self.class.read_only_attributes&.include?(var)
+          next if saving && self.class.read_only_attributes&.include?(var)
 
           var = var.to_s.delete("@")
           attribute = if @aliased_properties.value?(var)
@@ -283,10 +289,16 @@ module ShopifyAPI
           end.to_sym
 
           if self.class.has_many?(attribute)
-            hash[attribute.to_s] = get_property(attribute).map(&:to_hash).to_a if get_property(attribute)
+            hash[attribute.to_s] = get_property(attribute).map do |element|
+              data = element
+              data = self.class.has_many[attribute].create_instance(session: session, data: element) if data.is_a?(Hash)
+              data.to_hash(saving) unless data.nil?
+            end.to_a if get_property(attribute)
           elsif self.class.has_one?(attribute)
-            element_hash = get_property(attribute)&.to_hash
-            hash[attribute.to_s] = element_hash if element_hash || @forced_nils[attribute.to_s]
+            data = get_property(attribute)
+            data = self.class.has_one[attribute].create_instance(session: session, data: data) if data.is_a?(Hash)
+            data = data.to_hash(saving) if data
+            hash[attribute.to_s] = data if data || @forced_nils[attribute.to_s]
           elsif !get_property(attribute).nil? || @forced_nils[attribute.to_s]
             hash[attribute.to_s] =
               get_property(attribute)
@@ -313,7 +325,7 @@ module ShopifyAPI
 
       sig { params(update_object: T::Boolean).void }
       def save(update_object: false)
-        hash = HashDiff::Comparison.new(original_state, to_hash).left_diff
+        hash = HashDiff::Comparison.new(original_state, to_hash(true)).left_diff
         method = hash[self.class.primary_key] ? :put : :post
 
         path = self.class.get_path(http_method: method, operation: method, entity: self)

--- a/test/clients/base_rest_resource_test.rb
+++ b/test/clients/base_rest_resource_test.rb
@@ -163,6 +163,24 @@ module ShopifyAPITest
         assert_nil(resource.id)
       end
 
+      def test_to_hash_includes_unsaveable_attributes
+        resource = TestHelpers::FakeResource.new(session: @session)
+        resource.attribute = "attribute"
+        resource.unsaveable_attribute = "this is an attribute"
+
+        assert_includes(resource.to_hash, "attribute")
+        assert_includes(resource.to_hash, "unsaveable_attribute")
+      end
+
+      def test_to_hash_for_saving_excludes_unsaveable_attributes
+        resource = TestHelpers::FakeResource.new(session: @session)
+        resource.attribute = "attribute"
+        resource.unsaveable_attribute = "this is an attribute"
+
+        assert_includes(resource.to_hash(true), "attribute")
+        refute_includes(resource.to_hash(true), "unsaveable_attribute")
+      end
+
       def test_deletes_existing_resource_and_fails_on_deleting_nonexistent_resource
         resource = TestHelpers::FakeResource.new(session: @session)
         resource.id = 1


### PR DESCRIPTION
## Description

Fixes issue #930

Adds parameter to `to_hash` so that default behaviour includes readonly attributes; setting the parameter to `true` indicates that `to_hash` is being used to serialize the object for saving (and thus excludes readonly attributes).

## How has this been tested?

Added tests to verify that readonly attributes are included when using the default `to_hash` and excluded when using `to_hash(true)` (i.e, `saving = true`).

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
