### PR TITLE
Deprecate unnecessary validate_shop call from JWT class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,9 @@
 ## Unreleased
 
 ### Fixed
+
 - [#935](https://github.com/Shopify/shopify_api/pull/935) Fix issue [#931](https://github.com/Shopify/shopify_api/pull/931), weight of variant should be float
-- [#939](https://github.com/Shopify/shopify_api/pull/939) Hotfix for `.spin.dev` JWT validation.
+- [#944](https://github.com/Shopify/shopify_api/pull/944) Deprecated the `validate_shop` method from the JWT class since we can trust the token payload, since it comes from Shopify.
 
 ## Version 10.0.2
 

--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -35,8 +35,6 @@ module ShopifyAPI
 
         raise ShopifyAPI::Errors::InvalidJwtTokenError,
           "Session token had invalid API key" unless @aud == Context.api_key
-        raise ShopifyAPI::Errors::InvalidJwtTokenError,
-          "Session token had invalid shop" unless validate_shop(shop)
       end
 
       sig { returns(String) }
@@ -44,9 +42,14 @@ module ShopifyAPI
         @dest.gsub("https://", "")
       end
 
+      # TODO: Remove before releasing v11
       sig { params(shop: String).returns(T::Boolean) }
       def validate_shop(shop)
-        /\A[a-z0-9]+[a-z0-9\-\.]*[a-z0-9]+\.(myshopify\.(io|com)|spin\.dev)\z/.match?(shop)
+        Context.logger.warn(
+          "Deprecation notice: ShopifyAPI::Auth::JwtPayload.validate_shop no longer checks the given shop and always " \
+            "returns true. It will be removed in v11."
+        )
+        true
       end
 
       alias_method :eql?, :==

--- a/test/auth/jwt_payload_test.rb
+++ b/test/auth/jwt_payload_test.rb
@@ -83,15 +83,6 @@ module ShopifyAPITest
         end
       end
 
-      def test_decode_jwt_payload_fails_if_domain_is_invalid
-        payload = @jwt_payload.dup
-        payload[:dest] = "https://notadomain"
-        jwt_token = JWT.encode(payload, ShopifyAPI::Context.api_secret_key, "HS256")
-        assert_raises(ShopifyAPI::Errors::InvalidJwtTokenError) do
-          ShopifyAPI::Auth::JwtPayload.new(jwt_token)
-        end
-      end
-
       def test_decode_jwt_payload_fails_with_invalid_api_key
         jwt_token = JWT.encode(@jwt_payload, ShopifyAPI::Context.api_secret_key, "HS256")
 


### PR DESCRIPTION
## Description

The `validate_shop` from the JWT class is not really necessary, because this information is coming from Shopify, and it is signed, so we can trust that, if the data itself is valid, the shop name will be correct.

## How has this been tested?

Via tests.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
