### PR TITLE
Hashes aren't automatically named arguments

### DIFF
--- a/docs/usage/oauth.md
+++ b/docs/usage/oauth.md
@@ -51,7 +51,7 @@ def callback
   begin
     auth_result = ShopifyAPI::Auth::Oauth.validate_auth_callback(
       cookies: cookies.to_h,
-      auth_query: ShopifyAPI::Auth::Oauth::AuthQuery.new(request.parameters.symbolize_keys.except(:controller, :action))
+      auth_query: ShopifyAPI::Auth::Oauth::AuthQuery.new(**request.parameters.symbolize_keys.except(:controller, :action))
     )
     
     cookies[auth_result[:cookie].name] = {


### PR DESCRIPTION
Passing `request.parameters.symbolize_keys.except(:controller, :action)` without the double-splat operator (**) results in the following error `wrong number of arguments (given 1, expected 0; required keywords: code, shop, timestamp, state, host, hmac)`

## Description

Fixes #<issue-number>

Please, include a summary of what the PR is for:
- What is the problem it is solving?
- What is the context of these changes?
- What is the impact of this PR?

## How has this been tested?

Please, describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
