### PR TITLE
add path to create fulfillments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- [#956](https://github.com/Shopify/shopify_api/pull/956) Add path to create Fulfillment from ShopifyAPI::Fulfillment
+
 - [#933](https://github.com/Shopify/shopify_api/pull/933) Fix syntax of GraphQL query in `Webhooks.get_webhook_id` method by removing extra curly brace
 
 - [#941](https://github.com/Shopify/shopify_api/pull/941) Fix `to_hash` to return readonly attributes, unless being used for serialize the object for saving - fix issue [#930](https://github.com/Shopify/shopify_api/issues/930)

--- a/lib/shopify_api/rest/resources/2021_07/fulfillment.rb
+++ b/lib/shopify_api/rest/resources/2021_07/fulfillment.rb
@@ -37,6 +37,7 @@ module ShopifyAPI
       {http_method: :get, operation: :get, ids: [:fulfillment_order_id], path: "fulfillment_orders/<fulfillment_order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id, :id], path: "orders/<order_id>/fulfillments/<id>.json"},
+      {http_method: :post, operation: :post, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :post, operation: :update_tracking, ids: [:id], path: "fulfillments/<id>/update_tracking.json"}
     ], T::Array[T::Hash[String, T.any(T::Array[Symbol], String, Symbol)]])
 

--- a/lib/shopify_api/rest/resources/2021_10/fulfillment.rb
+++ b/lib/shopify_api/rest/resources/2021_10/fulfillment.rb
@@ -38,6 +38,7 @@ module ShopifyAPI
       {http_method: :get, operation: :get, ids: [:fulfillment_order_id], path: "fulfillment_orders/<fulfillment_order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id, :id], path: "orders/<order_id>/fulfillments/<id>.json"},
+      {http_method: :post, operation: :post, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :post, operation: :update_tracking, ids: [:id], path: "fulfillments/<id>/update_tracking.json"}
     ], T::Array[T::Hash[String, T.any(T::Array[Symbol], String, Symbol)]])
 

--- a/lib/shopify_api/rest/resources/2022_01/fulfillment.rb
+++ b/lib/shopify_api/rest/resources/2022_01/fulfillment.rb
@@ -38,6 +38,7 @@ module ShopifyAPI
       {http_method: :get, operation: :get, ids: [:fulfillment_order_id], path: "fulfillment_orders/<fulfillment_order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id, :id], path: "orders/<order_id>/fulfillments/<id>.json"},
+      {http_method: :post, operation: :post, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :post, operation: :update_tracking, ids: [:id], path: "fulfillments/<id>/update_tracking.json"}
     ], T::Array[T::Hash[String, T.any(T::Array[Symbol], String, Symbol)]])
 

--- a/lib/shopify_api/rest/resources/2022_04/fulfillment.rb
+++ b/lib/shopify_api/rest/resources/2022_04/fulfillment.rb
@@ -38,6 +38,7 @@ module ShopifyAPI
       {http_method: :get, operation: :get, ids: [:fulfillment_order_id], path: "fulfillment_orders/<fulfillment_order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :get, operation: :get, ids: [:order_id, :id], path: "orders/<order_id>/fulfillments/<id>.json"},
+      {http_method: :post, operation: :post, ids: [:order_id], path: "orders/<order_id>/fulfillments.json"},
       {http_method: :post, operation: :update_tracking, ids: [:id], path: "fulfillments/<id>/update_tracking.json"}
     ], T::Array[T::Hash[String, T.any(T::Array[Symbol], String, Symbol)]])
 

--- a/test/rest/2021_07/fulfillment_test.rb
+++ b/test/rest/2021_07/fulfillment_test.rb
@@ -137,4 +137,20 @@ class Fulfillment202107Test < Test::Unit::TestCase
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-07/fulfillments/1069019865/update_tracking.json")
   end
 
+  sig do
+    void
+  end
+  def test_7()
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
+        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+      )
+      .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
+
+    fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.save
+
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+  end
 end

--- a/test/rest/2021_07/fulfillment_test.rb
+++ b/test/rest/2021_07/fulfillment_test.rb
@@ -141,16 +141,17 @@ class Fulfillment202107Test < Test::Unit::TestCase
     void
   end
   def test_7()
-    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2021-07/orders/450789469/fulfillments.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
-        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+        body: { "fulfillment" => hash_including("order_id") }
       )
       .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
 
     fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.order_id = 450789469
     fulfillment.save
 
-    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-07/orders/450789469/fulfillments.json")
   end
 end

--- a/test/rest/2021_10/fulfillment_test.rb
+++ b/test/rest/2021_10/fulfillment_test.rb
@@ -137,4 +137,20 @@ class Fulfillment202110Test < Test::Unit::TestCase
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-10/fulfillments/1069019865/update_tracking.json")
   end
 
+  sig do
+    void
+  end
+  def test_7()
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
+        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+      )
+      .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
+
+    fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.save
+
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+  end
 end

--- a/test/rest/2021_10/fulfillment_test.rb
+++ b/test/rest/2021_10/fulfillment_test.rb
@@ -141,16 +141,17 @@ class Fulfillment202110Test < Test::Unit::TestCase
     void
   end
   def test_7()
-    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2021-10/orders/450789469/fulfillments.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
-        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+        body: { "fulfillment" => hash_including("order_id") }
       )
       .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
 
     fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.order_id = 450789469
     fulfillment.save
 
-    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-10/orders/450789469/fulfillments.json")
   end
 end

--- a/test/rest/2022_01/fulfillment_test.rb
+++ b/test/rest/2022_01/fulfillment_test.rb
@@ -144,11 +144,12 @@ class Fulfillment202201Test < Test::Unit::TestCase
     stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
-        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+        body: { "fulfillment" => hash_including("order_id") }
       )
       .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
 
     fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.order_id = 450789469
     fulfillment.save
 
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")

--- a/test/rest/2022_01/fulfillment_test.rb
+++ b/test/rest/2022_01/fulfillment_test.rb
@@ -137,4 +137,20 @@ class Fulfillment202201Test < Test::Unit::TestCase
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/fulfillments/1069019865/update_tracking.json")
   end
 
+  sig do
+    void
+  end
+  def test_7()
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
+        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+      )
+      .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
+
+    fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.save
+
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+  end
 end

--- a/test/rest/2022_04/fulfillment_test.rb
+++ b/test/rest/2022_04/fulfillment_test.rb
@@ -141,16 +141,17 @@ class Fulfillment202204Test < Test::Unit::TestCase
     void
   end
   def test_7()
-    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-04/orders/450789469/fulfillments.json")
       .with(
         headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
-        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+        body: { "fulfillment" => hash_including("order_id") }
       )
       .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
 
     fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.order_id = 450789469
     fulfillment.save
 
-    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-04/orders/450789469/fulfillments.json")
   end
 end

--- a/test/rest/2022_04/fulfillment_test.rb
+++ b/test/rest/2022_04/fulfillment_test.rb
@@ -137,4 +137,20 @@ class Fulfillment202204Test < Test::Unit::TestCase
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-04/fulfillments/1069019865/update_tracking.json")
   end
 
+  sig do
+    void
+  end
+  def test_7()
+    stub_request(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json", "Content-Type"=>"application/json"},
+        body: { "fulfillment" => hash_including({"notify_customer" => true, "tracking_info" => {"number" => "1111", "url" => "http://www.my-url.com", "company" => "my-company"}}) }
+      )
+      .to_return(status: 200, body: JSON.generate({"fulfillment" => {"tracking_company" => "my-company", "location_id" => 24826418, "id" => 1069019865, "order_id" => 1073459963, "status" => "success", "created_at" => "2022-04-07T11:55:27-04:00", "service" => "manual", "updated_at" => "2022-04-07T11:56:13-04:00", "shipment_status" => nil, "line_items" => [{"id" => 1071823174, "variant_id" => 43729076, "title" => "Draft", "quantity" => 1, "sku" => "draft-151", "variant_title" => "151cm", "vendor" => nil, "fulfillment_service" => "manual", "product_id" => 108828309, "requires_shipping" => true, "taxable" => true, "gift_card" => false, "name" => "Draft - 151cm", "variant_inventory_management" => nil, "properties" => [], "product_exists" => true, "fulfillable_quantity" => 1, "grams" => 10, "price" => "10.00", "total_discount" => "0.00", "fulfillment_status" => nil, "price_set" => {"shop_money" => {"amount" => "10.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "10.00", "currency_code" => "USD"}}, "total_discount_set" => {"shop_money" => {"amount" => "0.00", "currency_code" => "USD"}, "presentment_money" => {"amount" => "0.00", "currency_code" => "USD"}}, "discount_allocations" => [], "admin_graphql_api_id" => "gid://shopify/LineItem/1071823174", "tax_lines" => []}], "tracking_number" => "1111", "tracking_numbers" => ["1111"], "tracking_url" => "http://www.my-url.com", "tracking_urls" => ["http://www.my-url.com"], "receipt" => {}, "name" => "#1033.1", "admin_graphql_api_id" => "gid://shopify/Fulfillment/1069019865"}}), headers: {})
+
+    fulfillment = ShopifyAPI::Fulfillment.new
+    fulfillment.save
+
+    assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/orders/450789469/fulfillments.json")
+  end
 end


### PR DESCRIPTION
## Description

Fixes #954 

Adds path to create a new fulfillment: `POST orders/<order_id>/fulfillments.json`. Previously it was not possible to create a new fulfillment using the `ShopifyAPI::Fulfillment` class.

## How has this been tested?

Added tests to the test suite. 

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
