### PR TITLE
Gift card floating point values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Changelog
 
 ## Unreleased
+- [#957](https://github.com/Shopify/shopify_api/pull/957) Allow GiftCard to have String `balance` and `initial_value` (because API response is String)
+
 - [#933](https://github.com/Shopify/shopify_api/pull/933) Fix syntax of GraphQL query in `Webhooks.get_webhook_id` method by removing extra curly brace
 
 - [#941](https://github.com/Shopify/shopify_api/pull/941) Fix `to_hash` to return readonly attributes, unless being used for serialize the object for saving - fix issue [#930](https://github.com/Shopify/shopify_api/issues/930)

--- a/lib/shopify_api/rest/resources/2021_07/gift_card.rb
+++ b/lib/shopify_api/rest/resources/2021_07/gift_card.rb
@@ -45,7 +45,7 @@ module ShopifyAPI
 
     sig { returns(T.nilable(Integer)) }
     attr_reader :api_client_id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :balance
     sig { returns(T.nilable(String)) }
     attr_reader :code
@@ -61,7 +61,7 @@ module ShopifyAPI
     attr_reader :expires_on
     sig { returns(T.nilable(Integer)) }
     attr_reader :id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :initial_value
     sig { returns(T.nilable(String)) }
     attr_reader :last_characters

--- a/lib/shopify_api/rest/resources/2021_10/gift_card.rb
+++ b/lib/shopify_api/rest/resources/2021_10/gift_card.rb
@@ -45,7 +45,7 @@ module ShopifyAPI
 
     sig { returns(T.nilable(Integer)) }
     attr_reader :api_client_id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :balance
     sig { returns(T.nilable(String)) }
     attr_reader :code
@@ -61,7 +61,7 @@ module ShopifyAPI
     attr_reader :expires_on
     sig { returns(T.nilable(Integer)) }
     attr_reader :id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :initial_value
     sig { returns(T.nilable(String)) }
     attr_reader :last_characters

--- a/lib/shopify_api/rest/resources/2022_01/gift_card.rb
+++ b/lib/shopify_api/rest/resources/2022_01/gift_card.rb
@@ -45,7 +45,7 @@ module ShopifyAPI
 
     sig { returns(T.nilable(Integer)) }
     attr_reader :api_client_id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :balance
     sig { returns(T.nilable(String)) }
     attr_reader :code
@@ -61,7 +61,7 @@ module ShopifyAPI
     attr_reader :expires_on
     sig { returns(T.nilable(Integer)) }
     attr_reader :id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :initial_value
     sig { returns(T.nilable(String)) }
     attr_reader :last_characters

--- a/lib/shopify_api/rest/resources/2022_04/gift_card.rb
+++ b/lib/shopify_api/rest/resources/2022_04/gift_card.rb
@@ -45,7 +45,7 @@ module ShopifyAPI
 
     sig { returns(T.nilable(Integer)) }
     attr_reader :api_client_id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :balance
     sig { returns(T.nilable(String)) }
     attr_reader :code
@@ -61,7 +61,7 @@ module ShopifyAPI
     attr_reader :expires_on
     sig { returns(T.nilable(Integer)) }
     attr_reader :id
-    sig { returns(T.nilable(Float)) }
+    sig { returns(T.any(T.nilable(Float), T.nilable(String))) }
     attr_reader :initial_value
     sig { returns(T.nilable(String)) }
     attr_reader :last_characters

--- a/test/rest/2021_07/gift_card_test.rb
+++ b/test/rest/2021_07/gift_card_test.rb
@@ -93,8 +93,9 @@ class GiftCard202107Test < Test::Unit::TestCase
 
     gift_card = ShopifyAPI::GiftCard.new
     gift_card.initial_value = 25.0
-    gift_card.save()
+    gift_card.save(update_object: true)
 
+    assert(gift_card.initial_value == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-07/gift_cards.json")
   end
 

--- a/test/rest/2021_07/gift_card_test.rb
+++ b/test/rest/2021_07/gift_card_test.rb
@@ -96,6 +96,7 @@ class GiftCard202107Test < Test::Unit::TestCase
     gift_card.save(update_object: true)
 
     assert(gift_card.initial_value == "25.00")
+    assert(gift_card.balance == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-07/gift_cards.json")
   end
 

--- a/test/rest/2021_10/gift_card_test.rb
+++ b/test/rest/2021_10/gift_card_test.rb
@@ -93,8 +93,9 @@ class GiftCard202110Test < Test::Unit::TestCase
 
     gift_card = ShopifyAPI::GiftCard.new
     gift_card.initial_value = 25.0
-    gift_card.save()
+    gift_card.save(update_object: true)
 
+    assert(gift_card.initial_value == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-10/gift_cards.json")
   end
 

--- a/test/rest/2021_10/gift_card_test.rb
+++ b/test/rest/2021_10/gift_card_test.rb
@@ -96,6 +96,7 @@ class GiftCard202110Test < Test::Unit::TestCase
     gift_card.save(update_object: true)
 
     assert(gift_card.initial_value == "25.00")
+    assert(gift_card.balance == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2021-10/gift_cards.json")
   end
 

--- a/test/rest/2022_01/gift_card_test.rb
+++ b/test/rest/2022_01/gift_card_test.rb
@@ -93,8 +93,9 @@ class GiftCard202201Test < Test::Unit::TestCase
 
     gift_card = ShopifyAPI::GiftCard.new
     gift_card.initial_value = 25.0
-    gift_card.save()
+    gift_card.save(update_object: true)
 
+    assert(gift_card.initial_value == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/gift_cards.json")
   end
 

--- a/test/rest/2022_01/gift_card_test.rb
+++ b/test/rest/2022_01/gift_card_test.rb
@@ -96,6 +96,7 @@ class GiftCard202201Test < Test::Unit::TestCase
     gift_card.save(update_object: true)
 
     assert(gift_card.initial_value == "25.00")
+    assert(gift_card.balance == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-01/gift_cards.json")
   end
 

--- a/test/rest/2022_04/gift_card_test.rb
+++ b/test/rest/2022_04/gift_card_test.rb
@@ -96,6 +96,7 @@ class GiftCard202204Test < Test::Unit::TestCase
     gift_card.save(update_object: true)
 
     assert(gift_card.initial_value == "25.00")
+    assert(gift_card.balance == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-04/gift_cards.json")
   end
 

--- a/test/rest/2022_04/gift_card_test.rb
+++ b/test/rest/2022_04/gift_card_test.rb
@@ -93,8 +93,9 @@ class GiftCard202204Test < Test::Unit::TestCase
 
     gift_card = ShopifyAPI::GiftCard.new
     gift_card.initial_value = 25.0
-    gift_card.save()
+    gift_card.save(update_object: true)
 
+    assert(gift_card.initial_value == "25.00")
     assert_requested(:post, "https://test-shop.myshopify.io/admin/api/2022-04/gift_cards.json")
   end
 


### PR DESCRIPTION
## Description

Fixes #955 

The gift card API returns string values for `balance` and `initial_value` (e.g. "25.00"). However, the `ShopifyAPI::GiftCard` class specifies `returns(T.nilable(Float))`. When an instance of `ShopifyAPI::GiftCard` is created using the response from the API, calling `gift_card.balance` or `gift_card.initial_value` results in an error like so:

`TypeError: Return value: Expected type T.nilable(Float), got type String with value "120.00"`


## How has this been tested?

Enhanced test suite to assert that `balance` and `initial_value` methods can returns the expected values.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
