### PR TITLE
Update latest API version to 2022-04

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Changelog
 
 ## Unreleased
-- [#933](https://github.com/Shopify/shopify_api/pull/933) Fix syntax of GraphQL query in `Webhooks.get_webhook_id` method by removing extra curly brace
 
+- [#933](https://github.com/Shopify/shopify_api/pull/933) Fix syntax of GraphQL query in `Webhooks.get_webhook_id` method by removing extra curly brace
 - [#941](https://github.com/Shopify/shopify_api/pull/941) Fix `to_hash` to return readonly attributes, unless being used for serialize the object for saving - fix issue [#930](https://github.com/Shopify/shopify_api/issues/930)
+- [#959](https://github.com/Shopify/shopify_api/pull/959) Update `LATEST_SUPPORTED_ADMIN_VERSION` to `2022-04` to align it with the current value
 
 ## Version 10.0.3
 

--- a/lib/shopify_api/admin_versions.rb
+++ b/lib/shopify_api/admin_versions.rb
@@ -12,7 +12,7 @@ module ShopifyAPI
       "2021-04",
     ], T::Array[String])
 
-    LATEST_SUPPORTED_ADMIN_VERSION = T.let("2022-01", String)
+    LATEST_SUPPORTED_ADMIN_VERSION = T.let("2022-04", String)
   end
 
   SUPPORTED_ADMIN_VERSIONS = ShopifyAPI::AdminVersions::SUPPORTED_ADMIN_VERSIONS


### PR DESCRIPTION
We didn't update the latest supported version to 2022-04 when it was released, this PR fixes that.