### PR TITLE
Fix webhook requests for headers with a symbol key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
 
 - [#979](https://github.com/Shopify/shopify_api/pull/979) Update `ShopifyAPI::Context.setup` to take `old_api_secret_key` to support API credentials rotation
+- [#977](https://github.com/Shopify/shopify_api/pull/977) Fix webhook requests when a header is present having a symbol key (e.g. `:clearance`)
 
 ## Version 10.1.0
 

--- a/lib/shopify_api/webhooks/request.rb
+++ b/lib/shopify_api/webhooks/request.rb
@@ -35,7 +35,7 @@ module ShopifyAPI
       sig { params(raw_body: String, headers: T::Hash[String, T.untyped]).void }
       def initialize(raw_body:, headers:)
         # normalize the headers by forcing lowercase, removing any prepended "http"s, and changing underscores to dashes
-        headers = headers.to_h { |k, v| [k.downcase.sub("http_", "").gsub("_", "-"), v] }
+        headers = headers.to_h { |k, v| [k.to_s.downcase.sub("http_", "").gsub("_", "-"), v] }
 
         missing_headers = []
         [

--- a/test/webhooks/request_test.rb
+++ b/test/webhooks/request_test.rb
@@ -27,7 +27,7 @@ module ShopifyAPITest
           "HTTP_X_SHOPIFY_TOPIC" => "some/topic",
           "HTTP_X_SHOPIFY_HMAC_SHA256" => "some_hmac",
           "HTTP_X_SHOPIFY_SHOP_DOMAIN" => "shop.myshopify.com",
-          :clearance => "session"
+          :clearance => "session",
         }
 
         assert(ShopifyAPI::Webhooks::Request.new(raw_body: "{}", headers: headers))

--- a/test/webhooks/request_test.rb
+++ b/test/webhooks/request_test.rb
@@ -21,6 +21,17 @@ module ShopifyAPITest
           ShopifyAPI::Webhooks::Request.new(raw_body: "{}", headers: {})
         end
       end
+
+      def test_with_symbol_headers
+        headers = {
+          "HTTP_X_SHOPIFY_TOPIC" => "some/topic",
+          "HTTP_X_SHOPIFY_HMAC_SHA256" => "some_hmac",
+          "HTTP_X_SHOPIFY_SHOP_DOMAIN" => "shop.myshopify.com",
+          :clearance => "session"
+        }
+
+        assert(ShopifyAPI::Webhooks::Request.new(raw_body: "{}", headers: headers))
+      end
     end
   end
 end


### PR DESCRIPTION
## Description

Webhooks fail when there is a header with a symbol as a key:

```
ShopifyAPITest::Webhooks::WebhookRequestTest#test_with_symbol_headers:
NoMethodError: undefined method `sub' for :clearance:Symbol
Did you mean?  stub
```

This happens e.g. when using Clearance, which adds `:clearance` as a header, containing the Clearance session. This means that webhooks will always fail as soon as you include Clearance into the project. Its middleware always adds that header, even if there is no authenticated request.

## How has this been tested?

Test case within this PR.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
