### PR TITLE
Constrain Zeitwerk to 2.6.5

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       openssl
       securerandom
       sorbet-runtime
-      zeitwerk (~> 2.5)
+      zeitwerk (~> 2.5, < 2.6.5)
 
 GEM
   remote: https://rubygems.org/

--- a/shopify_api.gemspec
+++ b/shopify_api.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency("openssl")
   s.add_runtime_dependency("securerandom")
   s.add_runtime_dependency("sorbet-runtime")
-  s.add_runtime_dependency("zeitwerk", "~> 2.5")
+  s.add_runtime_dependency("zeitwerk", "~> 2.5", "< 2.6.5") # https://github.com/Shopify/shopify-api-ruby/issues/1058
 
   s.add_development_dependency("activesupport")
   s.add_development_dependency("pry-byebug")


### PR DESCRIPTION
I tried to resolve https://github.com/Shopify/shopify-api-ruby/issues/1058 but couldn't figure out what's causing it, so for now I think it's better to set this constraint.