### PR TITLE
Add workflows to create api update reminders

### DIFF
--- a/.github/api_update_reminder.md
+++ b/.github/api_update_reminder.md
@@ -1,0 +1,25 @@
+---
+title: A new release of the Shopify API is due soon
+labels: automated
+---
+
+This is an automated reminder for the maintainers that a new Stable release of the Shopify API is due soon, so the library needs to be updated.
+
+A new library release should be prepared to:
+* add the upcoming Stable release
+* remove the oldest Stable release which will no longer be supported.
+
+The PR should be created as a **draft** but not yet be merged.
+
+The release schedule can be found at https://shopify.dev/concepts/about-apis/versioning
+
+Review the changelog and consider if anything in the library needs to change:
+
+https://shopify.dev/changelog
+
+Test against the upcoming release by using the Release Candidate.
+
+Another reminder issue will be created on the date of the next release.
+When that happens, test again using the now Stable API version, and aim to release an update of the library within one week.
+
+Thank you!

--- a/.github/api_update_reminder_on_release.md
+++ b/.github/api_update_reminder_on_release.md
@@ -1,0 +1,19 @@
+---
+title: A new release of the Shopify API occurred
+labels: automated
+---
+
+This is an automated reminder for the maintainers that a new Stable release of the Shopify API is scheduled for today
+at 12pm Eastern Time, so a new release of the library is now due.
+
+A draft PR should already exist for this.
+
+Review the changelog again and consider if anything in the library needs to change:
+
+https://shopify.dev/changelog
+
+Test against the new release by using the Stable version just released.
+
+Aim to release an update of the library within one week.
+
+Thank you!

--- a/.github/workflows/api_update_reminder.yml
+++ b/.github/workflows/api_update_reminder.yml
@@ -1,0 +1,16 @@
+on:
+  workflow_dispatch: ~
+  schedule:
+    - cron: "0 0 1 3,6,9,12 *" # At 00:00 on 1st of March, June, September, and December
+
+name: API update reminder
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/api_update_reminder.md

--- a/.github/workflows/api_update_reminder_on_release.yml
+++ b/.github/workflows/api_update_reminder_on_release.yml
@@ -1,0 +1,16 @@
+on:
+  workflow_dispatch: ~
+  schedule:
+    - cron: "0 0 1 1,4,7,10 *" # At 00:00 on 1st of January, April, July, and October
+
+name: API update reminder on release
+jobs:
+  reminder:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: JasonEtco/create-an-issue@v2.4.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          filename: .github/api_update_reminder_on_release.md


### PR DESCRIPTION
## Description

Add workflows to create a GitHub issues as a reminders to update the API library version as a result of a new release of the Shopify API.

One reminder issue will be created one month before the release date; the second reminder will be on the day of release.