### PR TITLE
Add T::Array[String] support for webhook fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1183](https://github.com/Shopify/shopify-api-ruby/pull/1189) Added string array support for fields parameter in Webhook::Registry
+
 ## 13.1.0
 
 - [#1183](https://github.com/Shopify/shopify-api-ruby/pull/1183) Added support for API version 2023-07

--- a/lib/shopify_api/webhooks/registry.rb
+++ b/lib/shopify_api/webhooks/registry.rb
@@ -13,7 +13,7 @@ module ShopifyAPI
             delivery_method: Symbol,
             path: String,
             handler: T.nilable(Handler),
-            fields: T.nilable(String)).void
+            fields: T.nilable(T.any(String, T::Array[String]))).void
         end
         def add_registration(topic:, delivery_method:, path:, handler: nil, fields: nil)
           @registry[topic] = case delivery_method

--- a/test/webhooks/registry_test.rb
+++ b/test/webhooks/registry_test.rb
@@ -94,6 +94,10 @@ module ShopifyAPITest
         do_registration_test(:http, "test-webhooks", fields: "field1, field2")
       end
 
+      def test_http_registration_with_fields_array_add_and_update
+        do_registration_test(:http, "test-webhooks", fields: ["field1", "field2"])
+      end
+
       def test_raises_on_http_registration_check_error
         do_registration_check_error_test(:http, "test-webhooks")
       end
@@ -106,6 +110,10 @@ module ShopifyAPITest
         do_registration_test(:pub_sub, "pubsub://my-project-id:my-topic-id", fields: "field1, field2")
       end
 
+      def test_pubsub_registration_with_fields_array_add_and_update
+        do_registration_test(:pub_sub, "pubsub://my-project-id:my-topic-id", fields: ["field1", "field2"])
+      end
+
       def test_raises_on_pubsub_registration_check_error
         do_registration_check_error_test(:pub_sub, "pubsub://my-project-id:my-topic-id")
       end
@@ -116,6 +124,10 @@ module ShopifyAPITest
 
       def test_eventbridge_registration_with_fields_add_and_update
         do_registration_test(:event_bridge, "test-webhooks", fields: "field1, field2")
+      end
+
+      def test_eventbridge_registration_with_fields_array_add_and_update
+        do_registration_test(:event_bridge, "test-webhooks", fields: ["field1", "field2"])
       end
 
       def test_raises_on_eventbridge_registration_check_error


### PR DESCRIPTION
## Description

This PR updates the sorbet signature for the `Webhooks::Registry` to support `T::Array[String]`.

```
ShopifyApp.configure do |config|
  config.webhooks = [
    {topic: 'products/update', path: 'webhooks/products_update', fields: ['title', 'vendor']}
  ]
end
```

The [examples currently described in ShopifyApp above](https://github.com/Shopify/shopify_app/blob/main/docs/shopify_app/webhooks.md) do not work as the following error is encountered:

`Parameter 'fields': Expected type T.nilable(String), got type Array with value ["title", "vendor"] (TypeError)`

This PR updates the signature to match the underlying registration code which accepts both String and T::Array[String]

https://github.com/Shopify/shopify-api-ruby/blob/77ab36ca816516a677b736a46eec59aeed36a055/lib/shopify_api/webhooks/registration.rb#L24C19-L24C61

## How has this been tested?

Added additional tests asserting the behaviour remains unchanged when passing in array.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
