### PR TITLE
Add helper method alias to JwtPayload similar to ShopifyApp::JWT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 - [#1314](https://github.com/Shopify/shopify-api-ruby/pull/1314)
   - Add new session util method `SessionUtils::session_id_from_shopify_id_token`
   - `SessionUtils::current_session_id` now accepts shopify Id token in the format of `Bearer this_token` or just `this_token`
+- [#1315](https://github.com/Shopify/shopify-api-ruby/pull/1315) Add helper/alias methods to `ShopifyAPI::Auth::JwtPayload`:
+  - `shopify_domain` alias for `shop` - returns the sanitized shop domain
+  - `shopify_user_id` - returns the user Id (`sub`) as an Integer value
+  - `expires_at` alias for `exp` - returns the expiration time
 
 ## 14.2.0
 - [#1309](https://github.com/Shopify/shopify-api-ruby/pull/1309) Add `Session#copy_attributes_from` method

--- a/lib/shopify_api/auth/jwt_payload.rb
+++ b/lib/shopify_api/auth/jwt_payload.rb
@@ -15,6 +15,8 @@ module ShopifyAPI
       sig { returns(Integer) }
       attr_reader :exp, :nbf, :iat
 
+      alias_method :expire_at, :exp
+
       sig { params(token: String).void }
       def initialize(token)
         payload_hash = begin
@@ -42,6 +44,12 @@ module ShopifyAPI
       sig { returns(String) }
       def shop
         @dest.gsub("https://", "")
+      end
+      alias_method :shopify_domain, :shop
+
+      sig { returns(Integer) }
+      def shopify_user_id
+        @sub.to_i
       end
 
       # TODO: Remove before releasing v11

--- a/test/auth/jwt_payload_test.rb
+++ b/test/auth/jwt_payload_test.rb
@@ -36,6 +36,12 @@ module ShopifyAPITest
             jti: decoded.jti,
             sid: decoded.sid,
           })
+
+        # Helper methods
+        assert_equal(decoded.expire_at, @jwt_payload[:exp])
+        assert_equal("test-shop.myshopify.io", decoded.shopify_domain)
+        assert_equal("test-shop.myshopify.io", decoded.shop)
+        assert_equal(1, decoded.shopify_user_id)
       end
 
       def test_decode_jwt_payload_succeeds_with_spin_domain
@@ -56,6 +62,9 @@ module ShopifyAPITest
             jti: decoded.jti,
             sid: decoded.sid,
           })
+
+        assert_equal("test-shop.other.spin.dev", decoded.shopify_domain)
+        assert_equal("test-shop.other.spin.dev", decoded.shop)
       end
 
       def test_decode_jwt_payload_fails_with_wrong_key


### PR DESCRIPTION
## Description
- Partially for:  https://github.com/Shopify/temp-project-mover-Archetypically-20250319145332/issues/257

Add helper methods to JwtPayload with names similar to[ ShopifyApp JWT](https://github.com/Shopify/shopify_app/blob/main/lib/shopify_app/session/jwt.rb#L20-L30) to make deprecation migration easier.
```ruby
  def shopify_domain
    @payload && ShopifyApp::Utils.sanitize_shop_domain(@payload["dest"])
  end

  def shopify_user_id
    @payload["sub"].to_i if @payload && @payload["sub"]
  end

  def expire_at
    @payload["exp"].to_i if @payload && @payload["exp"]
  end
```

## How has this been tested?
Unit tested the methods to return expected values

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have updated the project documentation.
- [x] I have added a changelog line.
