### PR TITLE
Add debug option to GraphQL requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 
 ## Unreleased
 
+- [#1327](https://github.com/Shopify/shopify-api-ruby/pull/1327) Support `?debug=true` parameter in GraphQL client requests
+
 ## 14.4.0
 
 - [#1325](https://github.com/Shopify/shopify-api-ruby/pull/1325) Add support for 2024-07 API version

--- a/lib/shopify_api/clients/graphql/client.rb
+++ b/lib/shopify_api/clients/graphql/client.rb
@@ -29,14 +29,24 @@ module ShopifyAPI
             headers: T.nilable(T::Hash[T.any(Symbol, String), T.untyped]),
             tries: Integer,
             response_as_struct: T.nilable(T::Boolean),
+            debug: T::Boolean,
           ).returns(HttpResponse)
         end
-        def query(query:, variables: nil, headers: nil, tries: 1, response_as_struct: Context.response_as_struct)
+        def query(
+          query:,
+          variables: nil,
+          headers: nil,
+          tries: 1,
+          response_as_struct: Context.response_as_struct,
+          debug: false
+        )
           body = { query: query, variables: variables }
+          search_params = debug ? "?debug=true" : ""
+
           @http_client.request(
             HttpRequest.new(
               http_method: :post,
-              path: "#{@api_version}/graphql.json",
+              path: "#{@api_version}/graphql.json#{search_params}",
               body: body,
               query: nil,
               extra_headers: headers,

--- a/lib/shopify_api/clients/graphql/storefront.rb
+++ b/lib/shopify_api/clients/graphql/storefront.rb
@@ -46,12 +46,20 @@ module ShopifyAPI
             headers: T.nilable(T::Hash[T.any(Symbol, String), T.untyped]),
             tries: Integer,
             response_as_struct: T.nilable(T::Boolean),
+            debug: T::Boolean,
           ).returns(HttpResponse)
         end
-        def query(query:, variables: nil, headers: {}, tries: 1, response_as_struct: Context.response_as_struct)
+        def query(
+          query:,
+          variables: nil,
+          headers: {},
+          tries: 1,
+          response_as_struct: Context.response_as_struct,
+          debug: false
+        )
           T.must(headers).merge!({ @storefront_auth_header => @storefront_access_token })
           super(query: query, variables: variables, headers: headers, tries: tries,
-                    response_as_struct: response_as_struct)
+                    response_as_struct: response_as_struct, debug: debug)
         end
       end
     end

--- a/test/test_helpers/graphql_client.rb
+++ b/test/test_helpers/graphql_client.rb
@@ -83,5 +83,25 @@ module TestHelpers
 
       @client.query(query: query, variables: variables)
     end
+
+    def test_can_make_debug_requests
+      query = <<~QUERY
+        {
+          shop {
+            name
+          }
+        }
+      QUERY
+      body = { query: query, variables: nil }
+      success_body = { "success" => true }
+      response_headers = { "content-type" => "application/json" }
+
+      stub_request(:post, "https://test-shop.myshopify.com/#{@path}/#{ShopifyAPI::Context.api_version}/graphql.json?debug=true")
+        .with(body: body, headers: @expected_headers)
+        .to_return(body: success_body.to_json, headers: response_headers)
+
+      response = @client.query(query: query, debug: true)
+      assert_equal(success_body, response.body)
+    end
   end
 end


### PR DESCRIPTION
## Description

Currently, the GraphQL client doesn't allow adding the `?debug=true` search parameter when making requests, which enables Shopify to better debug those requests.

This PR adds support for that parameter to the `query` method in the GraphQL clients.

## How has this been tested?

Unit tests locally, and investigating logs in an actual app to ensure the parameter was there.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
