### PR TITLE
Add `current` methods for shop and recurring application charges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 - [#1327](https://github.com/Shopify/shopify-api-ruby/pull/1327) Support `?debug=true` parameter in GraphQL client requests
 - [#1308](https://github.com/Shopify/shopify-api-ruby/pull/1308) Support hash_with_indifferent_access when creating REST objects from Shopify responses. Closes #1296
 - [#1332](https://github.com/Shopify/shopify-api-ruby/pull/1332) Fixed an issue where `Customer` REST API PUT requests didn't send all of the fields in the `email_marketing_consent` attribute
+- [#1335](https://github.com/Shopify/shopify-api-ruby/pull/1335) Add back the `current` methods for `Shop` and `RecurringApplicationCharge` resources
 
 ## 14.4.0
 

--- a/lib/shopify_api/rest/resources/2022_04/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2022_04/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2022_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_04/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2022_07/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2022_07/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2022_07/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_07/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2022_10/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2022_10/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2022_10/shop.rb
+++ b/lib/shopify_api/rest/resources/2022_10/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2023_01/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2023_01/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_01/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_01/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2023_04/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2023_04/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_04/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2023_07/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2023_07/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_07/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_07/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2023_10/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2023_10/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2023_10/shop.rb
+++ b/lib/shopify_api/rest/resources/2023_10/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2024_01/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2024_01/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2024_01/shop.rb
+++ b/lib/shopify_api/rest/resources/2024_01/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2024_04/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2024_04/recurring_application_charge.rb
@@ -149,6 +149,15 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
+
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2024_04/shop.rb
+++ b/lib/shopify_api/rest/resources/2024_04/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/lib/shopify_api/rest/resources/2024_07/recurring_application_charge.rb
+++ b/lib/shopify_api/rest/resources/2024_07/recurring_application_charge.rb
@@ -149,6 +149,14 @@ module ShopifyAPI
         T.cast(response, T::Array[RecurringApplicationCharge])
       end
 
+      sig do
+        params(session: Auth::Session)
+          .returns(T.nilable(RecurringApplicationCharge))
+      end
+      def current(session: ShopifyAPI::Context.active_session)
+        charges = all(session: session)
+        charges.select { |charge| charge.status == "active" }.first
+      end
     end
 
     sig do

--- a/lib/shopify_api/rest/resources/2024_07/shop.rb
+++ b/lib/shopify_api/rest/resources/2024_07/shop.rb
@@ -216,6 +216,16 @@ module ShopifyAPI
         T.cast(response, T::Array[Shop])
       end
 
+      sig do
+        params(
+          fields: T.untyped,
+          session: Auth::Session,
+        ).returns(T.nilable(Shop))
+      end
+      def current(fields: nil, session: ShopifyAPI::Context.active_session)
+        all(session: session, fields: fields).first
+      end
+
     end
 
   end

--- a/test/rest/2022_04/recurring_application_charge_test.rb
+++ b/test/rest/2022_04/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202204Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2022-04/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2022-04-02", "status" => "accepted", "created_at" => "2022-04-02T08:59:11-05:00", "updated_at" => "2022-04-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2022-04-10", "status" => "active", "created_at" => "2022-04-10T08:59:11-05:00", "updated_at" => "2022-04-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-04/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2022_04/shop_test.rb
+++ b/test/rest/2022_04/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202204Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2022-04/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-04/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2022_07/recurring_application_charge_test.rb
+++ b/test/rest/2022_07/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202207Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2022-07/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2022-07-02", "status" => "accepted", "created_at" => "2022-07-02T08:59:11-05:00", "updated_at" => "2022-07-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2022-07-10", "status" => "active", "created_at" => "2022-07-10T08:59:11-05:00", "updated_at" => "2022-07-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-07/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2022_07/shop_test.rb
+++ b/test/rest/2022_07/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202207Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2022-07/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-07/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2022_10/recurring_application_charge_test.rb
+++ b/test/rest/2022_10/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202210Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2022-10/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2022-10-02", "status" => "accepted", "created_at" => "2022-10-02T08:59:11-05:00", "updated_at" => "2022-10-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2022-10-10", "status" => "active", "created_at" => "2022-10-10T08:59:11-05:00", "updated_at" => "2022-10-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-10/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2022_10/shop_test.rb
+++ b/test/rest/2022_10/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202210Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2022-10/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2022-10/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2023_01/recurring_application_charge_test.rb
+++ b/test/rest/2023_01/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202301Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-01/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-01-02", "status" => "accepted", "created_at" => "2023-01-02T08:59:11-05:00", "updated_at" => "2023-01-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-01-10", "status" => "active", "created_at" => "2023-01-10T08:59:11-05:00", "updated_at" => "2023-01-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-01/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2023_01/shop_test.rb
+++ b/test/rest/2023_01/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202301Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-01/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-01/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2023_04/recurring_application_charge_test.rb
+++ b/test/rest/2023_04/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202304Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-04/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-04-02", "status" => "accepted", "created_at" => "2023-04-02T08:59:11-05:00", "updated_at" => "2023-04-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-04-10", "status" => "active", "created_at" => "2023-04-10T08:59:11-05:00", "updated_at" => "2023-04-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-04/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2023_04/shop_test.rb
+++ b/test/rest/2023_04/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202304Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-04/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-04/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2023_07/recurring_application_charge_test.rb
+++ b/test/rest/2023_07/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202307Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-07/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-07-02", "status" => "accepted", "created_at" => "2023-07-02T08:59:11-05:00", "updated_at" => "2023-07-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-07-10", "status" => "active", "created_at" => "2023-07-10T08:59:11-05:00", "updated_at" => "2023-07-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2023_07/shop_test.rb
+++ b/test/rest/2023_07/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202307Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-07/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-07/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2023_10/recurring_application_charge_test.rb
+++ b/test/rest/2023_10/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202310Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-10/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-10-02", "status" => "accepted", "created_at" => "2023-10-02T08:59:11-05:00", "updated_at" => "2023-10-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2023-10-10", "status" => "active", "created_at" => "2023-10-10T08:59:11-05:00", "updated_at" => "2023-10-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-10/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2023_10/shop_test.rb
+++ b/test/rest/2023_10/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202310Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2023-10/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2023-10/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2024_01/recurring_application_charge_test.rb
+++ b/test/rest/2024_01/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202401Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2024-01/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2024-01-02", "status" => "accepted", "created_at" => "2024-01-02T08:59:11-05:00", "updated_at" => "2024-01-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2024-01-10", "status" => "active", "created_at" => "2024-01-10T08:59:11-05:00", "updated_at" => "2024-01-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2024-01/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2024_01/shop_test.rb
+++ b/test/rest/2024_01/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202401Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2024-01/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2024-01/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2024_04/recurring_application_charge_test.rb
+++ b/test/rest/2024_04/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202404Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2024-04/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2024-04-02", "status" => "accepted", "created_at" => "2024-04-02T08:59:11-05:00", "updated_at" => "2024-04-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2024-04-10", "status" => "active", "created_at" => "2024-04-10T08:59:11-05:00", "updated_at" => "2024-04-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2024-04/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2024_04/shop_test.rb
+++ b/test/rest/2024_04/shop_test.rb
@@ -91,4 +91,22 @@ class Shop202404Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2024-04/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2024-04/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
+
 end

--- a/test/rest/2024_07/recurring_application_charge_test.rb
+++ b/test/rest/2024_07/recurring_application_charge_test.rb
@@ -329,4 +329,26 @@ class RecurringApplicationCharge202404Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current()
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2024-07/recurring_application_charges.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"recurring_application_charges" => [
+        {"id" => 455696195, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2024-07-02", "status" => "accepted", "created_at" => "2024-07-02T08:59:11-05:00", "updated_at" => "2024-07-02T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357713, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696195", "currency" => "USD"},
+        {"id" => 455696196, "name" => "Super Mega Plan", "price" => "15.00", "billing_on" => "2024-07-10", "status" => "active", "created_at" => "2024-07-10T08:59:11-05:00", "updated_at" => "2024-07-10T09:03:16-05:00", "activated_on" => nil, "return_url" => "http://yourapp.example.org", "test" => nil, "cancelled_on" => nil, "trial_days" => 0, "trial_ends_on" => nil, "api_client_id" => 755357714, "decorated_return_url" => "http://yourapp.example.org?charge_id=455696196", "currency" => "USD"},
+      ]}), headers: {})
+
+    charge = ShopifyAPI::RecurringApplicationCharge.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2024-07/recurring_application_charges.json")
+
+    assert_equal(455696196, charge.id)
+    assert_equal("active", charge.status)
+  end
+
 end

--- a/test/rest/2024_07/shop_test.rb
+++ b/test/rest/2024_07/shop_test.rb
@@ -91,4 +91,21 @@ class Shop202404Test < Test::Unit::TestCase
     end
   end
 
+  sig do
+    void
+  end
+  def test_current
+    stub_request(:get, "https://test-shop.myshopify.io/admin/api/2024-07/shop.json")
+      .with(
+        headers: {"X-Shopify-Access-Token"=>"this_is_a_test_token", "Accept"=>"application/json"},
+        body: {}
+      )
+      .to_return(status: 200, body: JSON.generate({"shop" => {"province" => "California", "country" => "US", "address1" => "1 Infinite Loop", "city" => "Cupertino", "address2" => "Suite 100"}}), headers: {})
+
+    shop = ShopifyAPI::Shop.current
+
+    assert_requested(:get, "https://test-shop.myshopify.io/admin/api/2024-07/shop.json")
+
+    assert_equal(shop.province, "California")
+  end
 end


### PR DESCRIPTION
## Description

Fixes #923

As pointed out, we'd removed some utility methods from the `Shop` and `RecurringApplicationCharge` resources, which created problems for apps that relied on those methods.

This PR adds back those methods.

## How has this been tested?

With unit tests, and by calling the methods in an app using the library.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] I have added a changelog line.
