### PR TITLE
Use `request.remote_ip` instead of `request.ip` to obtain buyer IP

### DIFF
--- a/docs/usage/graphql_storefront.md
+++ b/docs/usage/graphql_storefront.md
@@ -39,7 +39,7 @@ QUERY
 
 # You may not need the "Shopify-Storefront-Buyer-IP" header, see its documentation: 
 # https://shopify.dev/docs/api/usage/authentication#making-server-side-requests
-response = client.query(query: query, headers: { "Shopify-Storefront-Buyer-IP": request.ip })
+response = client.query(query: query, headers: { "Shopify-Storefront-Buyer-IP": request.remote_ip })
 # do something with the returned data
 ```
 


### PR DESCRIPTION
## Description

This is a usage doc update to guide devs to accurately obtain the buyer IP using rail's `request.remote_ip` rather than `request.ip`. This is because the buyer can be behind a proxy server. The proxies usually set HTTP_CLIENT_IP and/or HTTP_X_FORWARDED_FOR headers to track the originating client IP. These headers are properly handled by `request.remote_ip` ([doc](https://apidock.com/rails/ActionController/Request/remote_ip)). The developer can optionally introduce a set of known proxy servers to further control this behaviour by setting `Rails.application.config.action_dispatch.trusted_proxies`.

## Checklist:

- [x] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [x] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
