### PR TITLE
Fix edge cases for internal hosts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
+- [#1374](https://github.com/Shopify/shopify-api-ruby/pull/1374) Fix edge cases for Shopify internal hosts
 
 ## 14.9.0
 

--- a/lib/shopify_api/auth/oauth.rb
+++ b/lib/shopify_api/auth/oauth.rb
@@ -111,7 +111,7 @@ module ShopifyAPI
 
         sig { params(shop: String).returns(String) }
         def auth_base_uri(shop)
-          return "https://#{shop}/admin" unless defined?(DevServer)
+          return "https://#{shop}/admin" unless defined?(DevServer) && shop.include?(".my.shop.dev")
 
           # For first-party apps in development only, we leverage DevServer to build the admin base URI
           admin_web = T.unsafe(Object.const_get("DevServer")).new("web") # rubocop:disable Sorbet/ConstantsFromStrings

--- a/lib/shopify_api/clients/http_client.rb
+++ b/lib/shopify_api/clients/http_client.rb
@@ -131,6 +131,7 @@ module ShopifyAPI
       def append_first_party_development_headers(headers, parsed_uri)
         return headers unless defined?(DevServer)
         return headers unless headers["Host"]&.include?(".my.shop.dev") || parsed_uri.host&.include?(".my.shop.dev")
+        return headers if headers["x-forwarded-host"]&.include?(".my.shop.dev")
 
         # These headers are only used for first party applications in development mode
         headers["x-forwarded-host"] = headers["Host"] || parsed_uri.host


### PR DESCRIPTION
Follow up to https://github.com/Shopify/shopify-api-ruby/pull/1370

## Description

This fixes 2 issues when targeting internal hosts

### Several requests with same HTTP client

The HTTP client can be reused for several HTTP calls. The current logic is flawed because it will update the headers for every request, ending with an invalid configuration:

1. first request is done to URI `https://shop1.my.shop.dev/admin/api/unstable/graphql.json`
 -> Host header is set to `app.shop.dev`and X-Forwarded-Host is set to `shop1.my.shop.dev`
2. second request is done, using the same client, and same URI
 -> X-Forwarded-Host is set to the value of the Host header, so `app.shop.dev` from previous request
 -> we end up with the Host and X-Forwarded-Host headers set to `app.shop.dev`, which fails

### Oauth with local DevServer and production host

Apps (like the POS channel or Flows afaik) can run locally but target production APIs, inside the production admin . The Oauth flow when installing them currently targets the internal Admin Web, whereas we should still target Production web when the shop does not have an internal host.

## How has this been tested?

This has been tested locally with POS channel

## Checklist:

- [X] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [X] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [x] I have added a changelog line.
