### PR TITLE
Release v16.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
-- Add support for 2026-04 API version
+
+## 16.2.0 (2026-04-13)
+- [#1442](https://github.com/Shopify/shopify-api-ruby/pull/1442) Add support for 2026-04 API version
+- [#1437](https://github.com/Shopify/shopify-api-ruby/pull/1437) Support new `shopify-*` webhook header format
 
 ## 16.1.0 (2026-01-15)
 - Add support for 2026-01 API version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (16.1.0)
+    shopify_api (16.2.0)
       activesupport
       concurrent-ruby
       hash_diff
@@ -60,8 +60,9 @@ GEM
     logger (1.6.1)
     method_source (1.0.0)
     mini_mime (1.1.5)
-    minitest (5.15.0)
-    mocha (1.13.0)
+    minitest (5.27.0)
+    mocha (3.0.1)
+      ruby2_keywords (>= 0.0.5)
     multi_xml (0.6.0)
     mutex_m (0.3.0)
     netrc (0.11.0)
@@ -109,6 +110,7 @@ GEM
     rubocop-sorbet (0.6.11)
       rubocop (>= 0.90.0)
     ruby-progressbar (1.13.0)
+    ruby2_keywords (0.0.5)
     securerandom (0.3.2)
     sorbet (0.5.11230)
       sorbet-static (= 0.5.11230)
@@ -151,6 +153,8 @@ GEM
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-23
+  arm64-darwin-24
+  arm64-darwin-25
   universal-darwin-22
   x86_64-linux
 

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module ShopifyAPI
-  VERSION = "16.1.0"
+  VERSION = "16.2.0"
 end


### PR DESCRIPTION
## Summary
- Bump version to 16.2.0
- Update CHANGELOG with entries for #1442 and #1437

### Changes included in this release
- [#1442](https://github.com/Shopify/shopify-api-ruby/pull/1442) Add support for 2026-04 API version
- [#1437](https://github.com/Shopify/shopify-api-ruby/pull/1437) Support new `shopify-*` webhook header format

## Post-merge steps
1. `git tag -f v16.2.0 && git push origin v16.2.0`
2. Publish via Shipit
3. Verify on [rubygems.org](https://rubygems.org/gems/shopify_api/versions/)
4. Update `shopify_app` gemspec