### PR TITLE
Create clients.rb

### DIFF
--- a/lib/shopify_api/clients.rb
+++ b/lib/shopify_api/clients.rb
@@ -1,0 +1,4 @@
+module ShopifyAPI
+  module Clients
+  end
+end


### PR DESCRIPTION
We're running an older version of Rails and were having LoadErrors when using required:false in the gemfile.  Adding this file fixed the load error for ShopifyAPI::Clients

## Description

Fixes #<issue-number>

Please, include a summary of what the PR is for:
- What is the problem it is solving?
- What is the context of these changes?
- What is the impact of this PR?

## How has this been tested?

Please, describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My commit message follow the pattern described in [here](https://chris.beams.io/posts/git-commit/)
- [ ] I have performed a self-review of my own code.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] I have updated the project documentation.
- [ ] I have added a changelog line.
