### PR TITLE
Address gardener workflow review comments

### DIFF
--- a/.claude/skills/investigating-github-issues/SKILL.md
+++ b/.claude/skills/investigating-github-issues/SKILL.md
@@ -94,7 +94,7 @@ Determine the current latest major version:
 
 ```bash
 gh release list --limit 10
-git tag -l 'v*'
+git tag -l 'v*' --sort=-v:refname
 ```
 
 Also consult:

--- a/.github/workflows/gardener-investigate-issue.yml
+++ b/.github/workflows/gardener-investigate-issue.yml
@@ -16,6 +16,7 @@ permissions:
   contents: read
   issues: read
   pull-requests: read
+  checks: read
 
 jobs:
   investigate:


### PR DESCRIPTION
## Summary

Addresses the valid Copilot review comments from #1449:

- Add `checks: read` because the read-only tool allowlist still permits `gh pr checks *`.
- Use git's built-in version sorting for tag inspection with `git tag -l 'v*' --sort=-v:refname`.

## Test plan

- `git diff --check`
- Parsed `.github/workflows/gardener-investigate-issue.yml` with `yq`

Follow-up to https://github.com/Shopify/shopify-api-ruby/pull/1449.