### PR TITLE
Release v16.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
+
+## 16.3.0 (2026-07-29)
 - [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Add `ShopifyAPI::Utils::ShopValidator` (module) with `sanitize_shop_domain` and `sanitize!`.
 - [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) `ShopifyAPI::Auth::TokenExchange.exchange_token` always uses the session token's `dest` claim, instead of the `shop` parameter, that is now deprecated. It will show a deprecation warning and the argument will be removed in the next major version.
 - [#1454](https://github.com/Shopify/shopify-api-ruby/pull/1454) Add support for 2026-07 API version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 Note: For changes to the API, see https://shopify.dev/changelog?filter=api
 ## Unreleased
 
-## 16.3.0 (2026-07-29)
-- [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Add `ShopifyAPI::Utils::ShopValidator` (module) with `sanitize_shop_domain` and `sanitize!`.
-- [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) `ShopifyAPI::Auth::TokenExchange.exchange_token` always uses the session token's `dest` claim, instead of the `shop` parameter, that is now deprecated. It will show a deprecation warning and the argument will be removed in the next major version.
-- [#1454](https://github.com/Shopify/shopify-api-ruby/pull/1454) Add support for 2026-07 API version
-- [#1457](https://github.com/Shopify/shopify-api-ruby/pull/1457) Add support for the 2026-10 API version. REST resources for 2026-10 are not bundled yet; the GraphQL Admin API and the REST client are unaffected.
-- [#1457](https://github.com/Shopify/shopify-api-ruby/pull/1457) Referencing a REST resource for an API version whose resources aren't bundled now raises `ShopifyAPI::Errors::RestResourceNotLoadedError` (a `NameError` subclass) explaining the version gap, instead of a bare `uninitialized constant`.
+## 16.3.0 (2026-08-04)
+- [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Add `ShopifyAPI::Utils::ShopValidator` with `sanitize_shop_domain` and `sanitize!`.
+- [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Derive the target shop for `ShopifyAPI::Auth::TokenExchange.exchange_token` from the session token's `dest` claim. The `shop` argument is now deprecated and will be removed in the next major version.
+- [#1454](https://github.com/Shopify/shopify-api-ruby/pull/1454) Add generated REST resource classes for the 2026-07 API version.
+- [#1457](https://github.com/Shopify/shopify-api-ruby/pull/1457) Allow GraphQL Admin API and direct REST clients to target the 2026-10 API version. Generated REST resource classes for 2026-10 are not bundled yet.
+- [#1457](https://github.com/Shopify/shopify-api-ruby/pull/1457) Raise `ShopifyAPI::Errors::RestResourceNotLoadedError` (a `NameError` subclass) with version-specific guidance when generated REST resources aren't bundled, instead of a bare `uninitialized constant` error.
 
 ## 16.2.0 (2026-04-13)
 - [#1442](https://github.com/Shopify/shopify-api-ruby/pull/1442) Add support for 2026-04 API version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shopify_api (16.2.0)
+    shopify_api (16.3.0)
       activesupport
       addressable (~> 2.7)
       concurrent-ruby

--- a/lib/shopify_api/version.rb
+++ b/lib/shopify_api/version.rb
@@ -2,5 +2,5 @@
 # frozen_string_literal: true
 
 module ShopifyAPI
-  VERSION = "16.2.0"
+  VERSION = "16.3.0"
 end


### PR DESCRIPTION
## Release v16.3.0

Minor release adding generated REST resource classes for API version 2026-07, client support for API version 2026-10, clearer errors for API versions without bundled REST resources, and shop-domain and token-exchange improvements. All changes are backward compatible.

### Changes

- [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Add `ShopifyAPI::Utils::ShopValidator` with `sanitize_shop_domain` and `sanitize!`.
- [#1443](https://github.com/Shopify/shopify-api-ruby/pull/1443) Derive the target shop for `ShopifyAPI::Auth::TokenExchange.exchange_token` from the session token's `dest` claim. The `shop` argument is now deprecated and will be removed in the next major version.
- [#1454](https://github.com/Shopify/shopify-api-ruby/pull/1454) Add generated REST resource classes for the 2026-07 API version.
- [#1457](https://github.com/Shopify/shopify-api-ruby/pull/1457) Allow GraphQL Admin API and direct REST clients to target the 2026-10 API version. Generated REST resource classes for 2026-10 are not bundled yet.
- [#1457](https://github.com/Shopify/shopify-api-ruby/pull/1457) Raise `ShopifyAPI::Errors::RestResourceNotLoadedError` (a `NameError` subclass) with version-specific guidance when generated REST resources aren't bundled, instead of a bare `uninitialized constant` error.

### Verification

- The release branch includes the current `main` branch, including #1443, #1454, and #1457.
- CI passes on Ruby 3.2, 3.3, and 3.4.
- A locally built 16.3.0 gem contains all 72 generated REST resource files for API version 2026-07.

### Release checklist

- [x] Bumped `lib/shopify_api/version.rb` to `16.3.0`.
- [x] Updated `Gemfile.lock`.
- [x] Moved unreleased changes under `## 16.3.0` in `CHANGELOG.md`.
- [ ] After merge, tag the merge commit as `v16.3.0`.
- [ ] Publish the `rubygems` stack through Shipit.
- [ ] Verify 16.3.0 on [RubyGems](https://rubygems.org/gems/shopify_api/versions).
<!-- github-gate:idempotency=github-gate:publish_pr_body:a356726e635145d51233f6ce -->